### PR TITLE
Apply SCORE round1 reliability/security hardening and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .env
 .DS_Store
 packages/*/dist/
+.data/

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Reliable, secure multi-agent messaging core for OpenClaw-style agent systems.
 
 ## What is implemented (prod-first + hardening)
 
-- ACK correlation path in broker (`startAckCorrelation`) to mark outbox rows `acked` by `msgId`.
+- ACK correlation path in broker (`startAckCorrelation`) to mark outbox rows `acked` by `msgId` and requeue `nack` responses as failed.
 - Persistent optimistic-locking store (`SQLiteDedupeOutboxStore`) for dedupe + outbox state.
+- JSON file stores now emit a startup warning when no external locking is configured (`MURMUR_JSON_STORE_LOCKING=1`), because they are single-process safe by default.
 - Delivery hardening in outbox flush:
   - exponential backoff with jitter
   - ack-timeout requeue support (`requeueStaleSent`)
   - poison-message handling threshold on consumer side
+  - broker connect retry/backoff and optional token auth in `BrokerConfig`
 - Security policy gate before publish:
   - allowed sender→recipient map
   - max payload size checks
@@ -22,7 +24,7 @@ Reliable, secure multi-agent messaging core for OpenClaw-style agent systems.
   - `MURMUR_ENABLE_MLS=1` feature flag
   - adapter placeholder that keeps build stable
 - Postgres SQL executor abstraction (`PgSqlExecutor`) for environments that need PG-backed implementations.
-- Minimal functional Telegram bridge (`@murmurv2/bridge-telegram`) for inbound/outbound with env config.
+- Minimal functional Telegram bridge (`@murmurv2/bridge-telegram`) for inbound/outbound with strict env/config validation.
 - Local persistent message store (`SQLiteMessageStore`) for conversation history/search.
 - Basic MCP server (`@murmurv2/mcp-server`) exposing:
   - `send_message`
@@ -174,7 +176,8 @@ This only enables scaffolded interfaces right now. See `docs/MLS-SCAFFOLD.md`.
 ## Tests
 
 ```bash
-npm test
+npm test                # build + unit tests
+npm run test:integration
 ```
 
 ## Secure local demo (default)

--- a/deploy/docker-compose.messaging.yml
+++ b/deploy/docker-compose.messaging.yml
@@ -3,8 +3,8 @@ services:
   nats:
     image: nats:2.10-alpine
     container_name: murmurv2-nats
-    command: ["-js", "-m", "8222"]
+    command: ["-js", "-m", "8222", "--auth", "${NATS_TOKEN}"]
     ports:
-      - "4222:4222"
-      - "8222:8222"
+      - "127.0.0.1:4222:4222"
+      - "127.0.0.1:8222:8222"
     restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "demo:producer": "node scripts/demo-producer.mjs",
     "demo:secure": "node scripts/demo-secure-smoke.mjs",
     "mcp:server": "node packages/mcp-server/dist/index.js",
-    "test": "npm run build && node --test tests/*.test.mjs"
+    "test:unit": "node --test tests/*.test.mjs",
+    "test:integration": "node scripts/run-integration.mjs",
+    "test": "npm run build && npm run test:unit"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/bridge-telegram/package.json
+++ b/packages/bridge-telegram/package.json
@@ -9,6 +9,7 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@murmurv2/core": "0.1.0"
+    "@murmurv2/core": "0.1.0",
+    "@murmurv2/security": "0.1.0"
   }
 }

--- a/packages/bridge-telegram/src/index.ts
+++ b/packages/bridge-telegram/src/index.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { SQLiteMessageStore, type EnvelopeV1 } from "@murmurv2/core";
+import type { CryptoProvider } from "@murmurv2/security";
+
+const UNSIGNED_MARKER = "unsigned";
 
 export interface TelegramBridgeConfig {
   botToken: string;
@@ -9,6 +12,12 @@ export interface TelegramBridgeConfig {
   recipientAgentId?: string;
   apiBase?: string;
   messageStorePath?: string;
+  /**
+   * Optional crypto provider used for envelope signing.
+   * Consumers should treat envelopes as unsigned when payloadNonce/signature are both "unsigned".
+   */
+  cryptoProvider?: CryptoProvider;
+  signingPrivateKey?: string;
 }
 
 interface TelegramUpdate {
@@ -33,6 +42,10 @@ const validateTelegramBridgeConfig = (cfg: TelegramBridgeConfig): void => {
   if (errs.length > 0) throw new Error(`invalid-telegram-bridge-config: ${errs.join("; ")}`);
 };
 
+export const isEnvelopeSigned = (env: EnvelopeV1): boolean => {
+  return env.payloadNonce !== UNSIGNED_MARKER && env.signature !== UNSIGNED_MARKER;
+};
+
 export class TelegramBridge {
   private readonly cfg: TelegramBridgeConfig;
   private readonly store: SQLiteMessageStore;
@@ -46,6 +59,8 @@ export class TelegramBridge {
       recipientAgentId: config?.recipientAgentId ?? process.env.MURMUR_TELEGRAM_RECIPIENT_AGENT_ID ?? "human",
       apiBase: config?.apiBase ?? "https://api.telegram.org",
       messageStorePath: config?.messageStorePath ?? process.env.MURMUR_STORE_PATH ?? ".data/murmur.db",
+      cryptoProvider: config?.cryptoProvider,
+      signingPrivateKey: config?.signingPrivateKey ?? process.env.MURMUR_TELEGRAM_SIGNING_PRIVATE_KEY,
     };
     validateTelegramBridgeConfig(this.cfg);
     this.store = new SQLiteMessageStore(this.cfg.messageStorePath);
@@ -54,6 +69,34 @@ export class TelegramBridge {
   private endpoint(method: string): string {
     if (!this.cfg.botToken) throw new Error("missing MURMUR_TELEGRAM_BOT_TOKEN");
     return `${this.cfg.apiBase}/bot${this.cfg.botToken}/${method}`;
+  }
+
+  private async signEnvelopePayload(payloadCiphertext: string): Promise<{ payloadNonce: string; signature: string }> {
+    if (this.cfg.cryptoProvider && this.cfg.signingPrivateKey) {
+      const signature = await this.cfg.cryptoProvider.sign(payloadCiphertext, this.cfg.signingPrivateKey);
+      return { payloadNonce: "signed", signature };
+    }
+    return { payloadNonce: UNSIGNED_MARKER, signature: UNSIGNED_MARKER };
+  }
+
+  private async toInboundEnvelope(msg: TelegramUpdate["message"]): Promise<EnvelopeV1> {
+    const text = msg?.text ?? "";
+    const payloadCiphertext = Buffer.from(text, "utf8").toString("base64");
+    const sender = msg?.from?.username ?? `telegram:${msg?.from?.id ?? "unknown"}`;
+    const conversationId = `telegram:${msg?.chat.id}:${msg?.message_thread_id ?? "main"}`;
+    const signatureFields = await this.signEnvelopePayload(payloadCiphertext);
+
+    return {
+      schemaVersion: "1.0",
+      msgId: `telegram-${msg?.message_id}`,
+      conversationId,
+      senderAgentId: sender,
+      recipients: [this.cfg.recipientAgentId ?? "human"],
+      createdAt: new Date((msg?.date ?? 0) * 1000).toISOString(),
+      payloadCiphertext,
+      payloadNonce: signatureFields.payloadNonce,
+      signature: signatureFields.signature,
+    };
   }
 
   private async callTelegram<T>(method: string, payload: Record<string, unknown>): Promise<T> {
@@ -117,25 +160,13 @@ export class TelegramBridge {
       if (String(msg.chat.id) !== this.cfg.defaultChatId) continue;
       if (this.cfg.defaultTopicId && String(msg.message_thread_id ?? "") !== this.cfg.defaultTopicId) continue;
 
-      const sender = msg.from?.username ?? `telegram:${msg.from?.id ?? "unknown"}`;
-      const conversationId = `telegram:${msg.chat.id}:${msg.message_thread_id ?? "main"}`;
-      const envelope: EnvelopeV1 = {
-        schemaVersion: "1.0",
-        msgId: `telegram-${msg.message_id}`,
-        conversationId,
-        senderAgentId: sender,
-        recipients: [this.cfg.recipientAgentId ?? "human"],
-        createdAt: new Date(msg.date * 1000).toISOString(),
-        payloadCiphertext: Buffer.from(msg.text, "utf8").toString("base64"),
-        payloadNonce: "plain",
-        signature: "telegram-bridge",
-      };
+      const envelope = await this.toInboundEnvelope(msg);
 
       await this.store.append({
-        conversationId,
+        conversationId: envelope.conversationId,
         msgId: envelope.msgId,
         direction: "inbound",
-        sender,
+        sender: envelope.senderAgentId,
         text: msg.text,
         createdAt: envelope.createdAt,
         transport: "telegram",
@@ -148,6 +179,8 @@ export class TelegramBridge {
   }
 
   toOutboundEnvelope(input: { text: string; conversationId?: string; recipients?: string[] }): EnvelopeV1 {
+    const payloadCiphertext = Buffer.from(input.text, "utf8").toString("base64");
+
     return {
       schemaVersion: "1.0",
       msgId: randomUUID(),
@@ -155,9 +188,26 @@ export class TelegramBridge {
       senderAgentId: this.cfg.senderAgentId ?? "telegram-bridge",
       recipients: input.recipients ?? [this.cfg.recipientAgentId ?? "human"],
       createdAt: new Date().toISOString(),
-      payloadCiphertext: Buffer.from(input.text, "utf8").toString("base64"),
-      payloadNonce: "plain",
-      signature: "telegram-bridge",
+      payloadCiphertext,
+      payloadNonce: UNSIGNED_MARKER,
+      signature: UNSIGNED_MARKER,
+    };
+  }
+
+  async toOutboundEnvelopeSigned(input: { text: string; conversationId?: string; recipients?: string[] }): Promise<EnvelopeV1> {
+    const payloadCiphertext = Buffer.from(input.text, "utf8").toString("base64");
+    const signatureFields = await this.signEnvelopePayload(payloadCiphertext);
+
+    return {
+      schemaVersion: "1.0",
+      msgId: randomUUID(),
+      conversationId: input.conversationId ?? `telegram:${this.cfg.defaultChatId}:${this.cfg.defaultTopicId ?? "main"}`,
+      senderAgentId: this.cfg.senderAgentId ?? "telegram-bridge",
+      recipients: input.recipients ?? [this.cfg.recipientAgentId ?? "human"],
+      createdAt: new Date().toISOString(),
+      payloadCiphertext,
+      payloadNonce: signatureFields.payloadNonce,
+      signature: signatureFields.signature,
     };
   }
 }

--- a/packages/bridge-telegram/src/index.ts
+++ b/packages/bridge-telegram/src/index.ts
@@ -23,6 +23,16 @@ interface TelegramUpdate {
   };
 }
 
+const validateTelegramBridgeConfig = (cfg: TelegramBridgeConfig): void => {
+  const errs: string[] = [];
+  if (!cfg.botToken || !cfg.botToken.trim()) errs.push("MURMUR_TELEGRAM_BOT_TOKEN is required");
+  if (!cfg.defaultChatId || !cfg.defaultChatId.trim()) errs.push("MURMUR_TELEGRAM_CHAT_ID is required");
+  if (!cfg.apiBase || !/^https?:\/\//.test(cfg.apiBase)) errs.push("apiBase must be an absolute http(s) URL");
+  if (!cfg.senderAgentId || !cfg.senderAgentId.trim()) errs.push("senderAgentId must be non-empty");
+  if (!cfg.recipientAgentId || !cfg.recipientAgentId.trim()) errs.push("recipientAgentId must be non-empty");
+  if (errs.length > 0) throw new Error(`invalid-telegram-bridge-config: ${errs.join("; ")}`);
+};
+
 export class TelegramBridge {
   private readonly cfg: TelegramBridgeConfig;
   private readonly store: SQLiteMessageStore;
@@ -37,6 +47,7 @@ export class TelegramBridge {
       apiBase: config?.apiBase ?? "https://api.telegram.org",
       messageStorePath: config?.messageStorePath ?? process.env.MURMUR_STORE_PATH ?? ".data/murmur.db",
     };
+    validateTelegramBridgeConfig(this.cfg);
     this.store = new SQLiteMessageStore(this.cfg.messageStorePath);
   }
 

--- a/packages/bridge-telegram/tsconfig.json
+++ b/packages/bridge-telegram/tsconfig.json
@@ -12,9 +12,10 @@
     "types": ["node"],
     "baseUrl": ".",
     "paths": {
-      "@murmurv2/core": ["../core/src/index.ts"]
+      "@murmurv2/core": ["../core/src/index.ts"],
+      "@murmurv2/security": ["../security/src/index.ts"]
     }
   },
   "include": ["src"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../security" }]
 }

--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -124,7 +124,10 @@ export class NatsBroker {
           await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", reason));
         }
       }
-    })().catch(() => undefined);
+    })().catch((err) => {
+      const e = err instanceof Error ? err : new Error(String(err));
+      console.error("[NatsBroker.subscribeWithAck] loop crashed", { message: e.message, stack: e.stack });
+    });
 
     return sub;
   }
@@ -154,11 +157,19 @@ export class NatsBroker {
               new Date().toISOString(),
             );
           }
-        } catch {
-          // ignore malformed ack frames
+        } catch (err) {
+          const e = err instanceof Error ? err : new Error(String(err));
+          console.error("[NatsBroker.startAckCorrelation] malformed ack frame", {
+            message: e.message,
+            stack: e.stack,
+            raw: this.sc.decode(m.data),
+          });
         }
       }
-    })().catch(() => undefined);
+    })().catch((err) => {
+      const e = err instanceof Error ? err : new Error(String(err));
+      console.error("[NatsBroker.startAckCorrelation] loop crashed", { message: e.message, stack: e.stack });
+    });
 
     return sub;
   }

--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -15,6 +15,10 @@ import {
 export interface BrokerConfig {
   url: string;
   stream?: string;
+  token?: string;
+  connectMaxAttempts?: number;
+  connectBaseBackoffMs?: number;
+  connectJitterRatio?: number;
 }
 
 export type MessageHandler = (envelope: EnvelopeV1) => Promise<void>;
@@ -28,7 +32,28 @@ export class NatsBroker {
 
   async connect(): Promise<void> {
     if (this.nc) return;
-    this.nc = await connect({ servers: this.config.url });
+
+    const maxAttempts = this.config.connectMaxAttempts ?? 5;
+    const baseBackoffMs = this.config.connectBaseBackoffMs ?? 250;
+    const jitterRatio = this.config.connectJitterRatio ?? 0.2;
+    let lastErr: unknown;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        this.nc = await connect({
+          servers: this.config.url,
+          token: this.config.token,
+        });
+        return;
+      } catch (err) {
+        lastErr = err;
+        if (attempt >= maxAttempts) break;
+        const sleepMs = applyJitter(computeBackoffMs(attempt, baseBackoffMs), jitterRatio);
+        await new Promise((resolve) => setTimeout(resolve, sleepMs));
+      }
+    }
+
+    throw lastErr instanceof Error ? lastErr : new Error("nats-connect-failed");
   }
 
   async close(): Promise<void> {
@@ -115,8 +140,19 @@ export class NatsBroker {
       for await (const m of sub) {
         try {
           const decoded = JSON.parse(this.sc.decode(m.data)) as AckV1;
-          if (decoded.status === "ack" && typeof decoded.msgId === "string") {
+          if (typeof decoded.msgId !== "string" || decoded.msgId.length === 0) continue;
+
+          if (decoded.status === "ack") {
             await params.outbox.markAcked(decoded.msgId);
+            continue;
+          }
+
+          if (decoded.status === "nack") {
+            await params.outbox.markFailed(
+              decoded.msgId,
+              decoded.reason ?? "nack",
+              new Date().toISOString(),
+            );
           }
         } catch {
           // ignore malformed ack frames

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,14 +35,32 @@ export interface DedupeStore {
 }
 
 export class InMemoryDedupeStore implements DedupeStore {
-  private readonly keys = new Set<string>();
+  private readonly keys: Map<string, true>;
+  private readonly maxSize: number;
+
+  constructor(maxSize = 10_000) {
+    this.keys = new Map<string, true>();
+    this.maxSize = Math.max(1, Math.floor(maxSize));
+  }
 
   async seen(msgId: string, consumerId: string): Promise<boolean> {
     return this.keys.has(`${consumerId}:${msgId}`);
   }
 
   async markSeen(msgId: string, consumerId: string): Promise<void> {
-    this.keys.add(`${consumerId}:${msgId}`);
+    this.keys.set(`${consumerId}:${msgId}`, true);
+    this.evictIfNeeded();
+  }
+
+  private evictIfNeeded(): void {
+    if (this.keys.size <= this.maxSize) return;
+    const evictCount = Math.max(1, Math.ceil(this.maxSize * 0.1));
+    const oldest = this.keys.keys();
+    for (let i = 0; i < evictCount; i += 1) {
+      const next = oldest.next();
+      if (next.done) break;
+      this.keys.delete(next.value);
+    }
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,11 +50,22 @@ interface JsonDedupeState {
   seen: string[];
 }
 
+const warnedJsonPaths = new Set<string>();
+const warnIfJsonStoreMayRace = (filePath: string): void => {
+  if (process.env.MURMUR_JSON_STORE_LOCKING === "1") return;
+  if (warnedJsonPaths.has(filePath)) return;
+  warnedJsonPaths.add(filePath);
+  console.warn(
+    `[murmur/core] JSON store at ${filePath} has no inter-process locking. Use single-process mode or set MURMUR_JSON_STORE_LOCKING=1 once external locking is guaranteed.`,
+  );
+};
+
 export class JsonFileDedupeStore implements DedupeStore {
   private readonly filePath: string;
 
   constructor(filePath = ".data/dedupe.json") {
     this.filePath = filePath;
+    warnIfJsonStoreMayRace(this.filePath);
   }
 
   private async load(): Promise<Set<string>> {
@@ -116,7 +127,9 @@ interface JsonOutboxState {
 }
 
 export class JsonFileOutboxStore implements OutboxStore {
-  constructor(private readonly filePath = ".data/outbox.json") {}
+  constructor(private readonly filePath = ".data/outbox.json") {
+    warnIfJsonStoreMayRace(this.filePath);
+  }
 
   private async load(): Promise<JsonOutboxState> {
     try {
@@ -409,18 +422,21 @@ export interface SqlExecutor {
 }
 
 export class PgSqlExecutor implements SqlExecutor {
-  constructor(private readonly connectionString: string) {}
+  private readonly poolPromise: Promise<import("pg").Pool>;
+
+  constructor(private readonly connectionString: string) {
+    this.poolPromise = import("pg").then(({ Pool }) => new Pool({ connectionString: this.connectionString }));
+  }
 
   async query<T = Record<string, unknown>>(sql: string, params: unknown[] = []): Promise<{ rows: T[]; rowCount: number }> {
-    const { Client } = await import("pg");
-    const client = new Client({ connectionString: this.connectionString });
-    await client.connect();
-    try {
-      const res = await client.query(sql, params);
-      return { rows: res.rows as T[], rowCount: res.rowCount ?? 0 };
-    } finally {
-      await client.end();
-    }
+    const pool = await this.poolPromise;
+    const res = await pool.query(sql, params);
+    return { rows: res.rows as T[], rowCount: res.rowCount ?? 0 };
+  }
+
+  async close(): Promise<void> {
+    const pool = await this.poolPromise;
+    await pool.end();
   }
 }
 
@@ -517,13 +533,25 @@ export class SQLiteMessageStore {
 export const isEnvelopeV1 = (v: unknown): v is EnvelopeV1 => {
   if (!v || typeof v !== "object") return false;
   const o = v as Record<string, unknown>;
+  const hasOptional = (key: keyof EnvelopeV1, type: "string" | "number"): boolean => {
+    const value = o[key as string];
+    return value === undefined || typeof value === type;
+  };
+
   return (
     o.schemaVersion === "1.0" &&
-    typeof o.msgId === "string" &&
-    typeof o.conversationId === "string" &&
-    typeof o.senderAgentId === "string" &&
-    Array.isArray(o.recipients) &&
-    typeof o.payloadCiphertext === "string"
+    typeof o.msgId === "string" && o.msgId.length > 0 &&
+    typeof o.conversationId === "string" && o.conversationId.length > 0 &&
+    typeof o.senderAgentId === "string" && o.senderAgentId.length > 0 &&
+    Array.isArray(o.recipients) && o.recipients.length > 0 && o.recipients.every((r) => typeof r === "string" && r.length > 0) &&
+    typeof o.createdAt === "string" && !Number.isNaN(Date.parse(o.createdAt)) &&
+    typeof o.payloadCiphertext === "string" && o.payloadCiphertext.length > 0 &&
+    typeof o.payloadNonce === "string" && o.payloadNonce.length > 0 &&
+    typeof o.signature === "string" && o.signature.length > 0 &&
+    hasOptional("ttlSeconds", "number") &&
+    hasOptional("traceId", "string") &&
+    hasOptional("sequence", "number") &&
+    hasOptional("parentMsgId", "string")
   );
 };
 

--- a/scripts/run-integration.mjs
+++ b/scripts/run-integration.mjs
@@ -1,0 +1,22 @@
+import { spawnSync } from "node:child_process";
+
+const run = (cmd, args, { allowFail = false } = {}) => {
+  const res = spawnSync(cmd, args, { stdio: "inherit", env: process.env });
+  if (res.status !== 0 && !allowFail) {
+    throw new Error(`${cmd} ${args.join(" ")} failed with status ${res.status}`);
+  }
+  return res.status ?? 1;
+};
+
+const hasDocker = spawnSync("docker", ["--version"], { stdio: "ignore" }).status === 0;
+if (!hasDocker) {
+  console.log("[integration] docker unavailable; skipping integration tests");
+  process.exit(0);
+}
+
+run("npm", ["run", "demo:up"]);
+try {
+  run("node", ["--test", "tests/*.integration.mjs"]);
+} finally {
+  run("npm", ["run", "demo:down"], { allowFail: true });
+}

--- a/tests/broker-ack-correlation.integration.mjs
+++ b/tests/broker-ack-correlation.integration.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NatsBroker } from "../packages/broker-nats/dist/src/index.js";
+import { SQLiteDedupeOutboxStore, createAck } from "../packages/core/dist/src/index.js";
+
+const envelope = {
+  schemaVersion: "1.0",
+  msgId: "msg-int-1",
+  conversationId: "conv-1",
+  senderAgentId: "agent.a",
+  recipients: ["agent.b"],
+  createdAt: new Date().toISOString(),
+  payloadCiphertext: Buffer.from("x").toString("base64"),
+  payloadNonce: "nonce",
+  signature: "sig",
+};
+
+test("ack correlation handles nack as immediate failed requeue", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "murmur-int-"));
+  const dbPath = join(dir, "murmur.db");
+  const store = new SQLiteDedupeOutboxStore(dbPath);
+  const broker = new NatsBroker({ url: process.env.NATS_URL ?? "nats://127.0.0.1:4222" });
+
+  await store.enqueue("msg.demo.secure", envelope);
+  await store.markSent(envelope.msgId);
+
+  const sub = await broker.startAckCorrelation({
+    outbox: store,
+    ackSubject: "ack.integration-test",
+  });
+
+  await broker.publishAck("ack.integration-test", createAck(envelope.msgId, "integration", "nack", "forced-nack"));
+
+  await new Promise((r) => setTimeout(r, 150));
+  const due = await store.claimDue(10);
+  assert.equal(due.length, 1);
+  assert.equal(due[0].status, "failed");
+  assert.equal(due[0].lastError, "forced-nack");
+
+  sub.unsubscribe();
+  await broker.close();
+});

--- a/tests/broker-flush.test.mjs
+++ b/tests/broker-flush.test.mjs
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { NatsBroker } from "../packages/broker-nats/dist/src/index.js";
+
+const envelope = {
+  schemaVersion: "1.0",
+  msgId: "msg-1",
+  conversationId: "conv-1",
+  senderAgentId: "agent.a",
+  recipients: ["agent.b"],
+  createdAt: new Date().toISOString(),
+  payloadCiphertext: Buffer.from("x").toString("base64"),
+  payloadNonce: "nonce",
+  signature: "sig",
+};
+
+const makeOutbox = (records) => {
+  const state = new Map(records.map((r) => [r.msgId, { ...r }]));
+  return {
+    async claimDue() {
+      return [...state.values()];
+    },
+    async markSent(msgId) {
+      state.get(msgId).status = "sent";
+    },
+    async markFailed(msgId, err, nextAttemptAt) {
+      const row = state.get(msgId);
+      row.status = "failed";
+      row.lastError = err;
+      row.nextAttemptAt = nextAttemptAt;
+    },
+    async markDlq(msgId, err) {
+      const row = state.get(msgId);
+      row.status = "dlq";
+      row.lastError = err;
+    },
+    async markAcked() {},
+    async enqueue() {},
+    __state: state,
+  };
+};
+
+test("flushOutbox marks policy failures as DLQ", async () => {
+  const outbox = makeOutbox([
+    { msgId: envelope.msgId, subject: "s", envelope, attempts: 0, status: "pending", nextAttemptAt: new Date().toISOString() },
+  ]);
+  const broker = new NatsBroker({ url: "nats://invalid:4222" });
+  broker.publish = async () => {
+    throw new Error("policy-rejected:recipient-not-allowed:agent.b");
+  };
+
+  await broker.flushOutbox({ outbox, maxAttempts: 3 });
+  assert.equal(outbox.__state.get(envelope.msgId).status, "dlq");
+});
+
+test("flushOutbox retries transient failures with failed status", async () => {
+  const outbox = makeOutbox([
+    { msgId: envelope.msgId, subject: "s", envelope, attempts: 0, status: "pending", nextAttemptAt: new Date().toISOString() },
+  ]);
+  const broker = new NatsBroker({ url: "nats://invalid:4222" });
+  broker.publish = async () => {
+    throw new Error("network-timeout");
+  };
+
+  await broker.flushOutbox({ outbox, maxAttempts: 3, baseBackoffMs: 10, jitterRatio: 0 });
+  const row = outbox.__state.get(envelope.msgId);
+  assert.equal(row.status, "failed");
+  assert.equal(row.lastError, "network-timeout");
+  assert.ok(new Date(row.nextAttemptAt).getTime() >= Date.now());
+});

--- a/tests/core-dedupe-store.test.mjs
+++ b/tests/core-dedupe-store.test.mjs
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { InMemoryDedupeStore, SQLiteDedupeOutboxStore } from "../packages/core/dist/src/index.js";
+
+test("InMemoryDedupeStore seen/markSeen roundtrip", async () => {
+  const store = new InMemoryDedupeStore();
+  assert.equal(await store.seen("m1", "c1"), false);
+  await store.markSeen("m1", "c1");
+  assert.equal(await store.seen("m1", "c1"), true);
+  assert.equal(await store.seen("m1", "c2"), false);
+});
+
+test("InMemoryDedupeStore evicts oldest entries when maxSize exceeded", async () => {
+  const store = new InMemoryDedupeStore(5);
+  await store.markSeen("m1", "c");
+  await store.markSeen("m2", "c");
+  await store.markSeen("m3", "c");
+  await store.markSeen("m4", "c");
+  await store.markSeen("m5", "c");
+  await store.markSeen("m6", "c");
+
+  assert.equal(await store.seen("m1", "c"), false);
+  assert.equal(await store.seen("m2", "c"), true);
+  assert.equal(await store.seen("m6", "c"), true);
+});
+
+test("SQLiteDedupeOutboxStore markSeen/seen roundtrip", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "murmur-dedupe-"));
+  const dbPath = join(dir, "murmur.db");
+
+  try {
+    const store = new SQLiteDedupeOutboxStore(dbPath);
+    assert.equal(await store.seen("m1", "consumer-1"), false);
+    await store.markSeen("m1", "consumer-1");
+    assert.equal(await store.seen("m1", "consumer-1"), true);
+    assert.equal(await store.seen("m1", "consumer-2"), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/core-envelope-validation.test.mjs
+++ b/tests/core-envelope-validation.test.mjs
@@ -18,13 +18,23 @@ test("isEnvelopeV1 accepts valid envelope", () => {
   assert.equal(isEnvelopeV1(baseEnvelope), true);
 });
 
-test("isEnvelopeV1 rejects malformed recipients and timestamps", () => {
-  assert.equal(isEnvelopeV1({ ...baseEnvelope, recipients: [] }), false);
-  assert.equal(isEnvelopeV1({ ...baseEnvelope, recipients: ["", "agent.b"] }), false);
-  assert.equal(isEnvelopeV1({ ...baseEnvelope, createdAt: "not-a-date" }), false);
+test("isEnvelopeV1 rejects null/undefined/string payloads", () => {
+  assert.equal(isEnvelopeV1(null), false);
+  assert.equal(isEnvelopeV1(undefined), false);
+  assert.equal(isEnvelopeV1("envelope"), false);
 });
 
-test("isEnvelopeV1 rejects missing required security fields", () => {
-  assert.equal(isEnvelopeV1({ ...baseEnvelope, payloadNonce: "" }), false);
-  assert.equal(isEnvelopeV1({ ...baseEnvelope, signature: "" }), false);
+test("isEnvelopeV1 rejects malformed msgId", () => {
+  const { msgId: _drop, ...withoutMsgId } = baseEnvelope;
+  assert.equal(isEnvelopeV1(withoutMsgId), false);
+  assert.equal(isEnvelopeV1({ ...baseEnvelope, msgId: "" }), false);
+});
+
+test("isEnvelopeV1 rejects missing payloadCiphertext", () => {
+  const { payloadCiphertext: _drop, ...withoutCiphertext } = baseEnvelope;
+  assert.equal(isEnvelopeV1(withoutCiphertext), false);
+});
+
+test("isEnvelopeV1 accepts optional ttlSeconds and traceId", () => {
+  assert.equal(isEnvelopeV1({ ...baseEnvelope, ttlSeconds: 60, traceId: "trace-1" }), true);
 });

--- a/tests/core-envelope-validation.test.mjs
+++ b/tests/core-envelope-validation.test.mjs
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isEnvelopeV1 } from "../packages/core/dist/src/index.js";
+
+const baseEnvelope = {
+  schemaVersion: "1.0",
+  msgId: "msg-1",
+  conversationId: "conv-1",
+  senderAgentId: "agent.a",
+  recipients: ["agent.b"],
+  createdAt: new Date().toISOString(),
+  payloadCiphertext: Buffer.from("hello").toString("base64"),
+  payloadNonce: "nonce",
+  signature: "sig",
+};
+
+test("isEnvelopeV1 accepts valid envelope", () => {
+  assert.equal(isEnvelopeV1(baseEnvelope), true);
+});
+
+test("isEnvelopeV1 rejects malformed recipients and timestamps", () => {
+  assert.equal(isEnvelopeV1({ ...baseEnvelope, recipients: [] }), false);
+  assert.equal(isEnvelopeV1({ ...baseEnvelope, recipients: ["", "agent.b"] }), false);
+  assert.equal(isEnvelopeV1({ ...baseEnvelope, createdAt: "not-a-date" }), false);
+});
+
+test("isEnvelopeV1 rejects missing required security fields", () => {
+  assert.equal(isEnvelopeV1({ ...baseEnvelope, payloadNonce: "" }), false);
+  assert.equal(isEnvelopeV1({ ...baseEnvelope, signature: "" }), false);
+});

--- a/tests/security-crypto-roundtrip.test.mjs
+++ b/tests/security-crypto-roundtrip.test.mjs
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createKeyPair,
+  createSigningKeyPair,
+  decryptPayload,
+  encryptPayload,
+  signEnvelope,
+  verifyEnvelopeSignature,
+} from "../packages/security/dist/src/index.js";
+
+test("encrypt/decrypt roundtrip", async () => {
+  const sender = await createKeyPair();
+  const recipient = await createKeyPair();
+  const payload = await encryptPayload("hello", recipient.publicKey, sender.privateKey);
+  const plaintext = await decryptPayload(payload, recipient.privateKey);
+  assert.equal(plaintext, "hello");
+});
+
+test("decrypt with wrong key fails", async () => {
+  const sender = await createKeyPair();
+  const recipient = await createKeyPair();
+  const wrongRecipient = await createKeyPair();
+  const payload = await encryptPayload("hello", recipient.publicKey, sender.privateKey);
+  await assert.rejects(() => decryptPayload(payload, wrongRecipient.privateKey));
+});
+
+test("sign/verify roundtrip", async () => {
+  const signing = await createSigningKeyPair();
+  const body = "payload";
+  const signature = await signEnvelope(body, signing.privateKey);
+  const valid = await verifyEnvelopeSignature(body, signature, signing.publicKey);
+  assert.equal(valid, true);
+});
+
+test("tampered payload fails signature verification", async () => {
+  const signing = await createSigningKeyPair();
+  const signature = await signEnvelope("payload", signing.privateKey);
+  const valid = await verifyEnvelopeSignature("payload-modified", signature, signing.publicKey);
+  assert.equal(valid, false);
+});

--- a/tests/security-mls-flag.test.mjs
+++ b/tests/security-mls-flag.test.mjs
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isMlsEnabled } from "../packages/security/dist/src/index.js";
+
+test("isMlsEnabled reflects env flag", () => {
+  const prev = process.env.MURMUR_ENABLE_MLS;
+  process.env.MURMUR_ENABLE_MLS = "1";
+  assert.equal(isMlsEnabled(), true);
+
+  process.env.MURMUR_ENABLE_MLS = "0";
+  assert.equal(isMlsEnabled(), false);
+
+  if (prev === undefined) delete process.env.MURMUR_ENABLE_MLS;
+  else process.env.MURMUR_ENABLE_MLS = prev;
+});

--- a/tests/telegram-config-validation.test.mjs
+++ b/tests/telegram-config-validation.test.mjs
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { TelegramBridge } from "../packages/bridge-telegram/dist/src/index.js";
+
+test("TelegramBridge validates required config", () => {
+  assert.throws(
+    () =>
+      new TelegramBridge({
+        botToken: "",
+        defaultChatId: "",
+      }),
+    /invalid-telegram-bridge-config/,
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core message transport/validation paths (NATS connect/ACK correlation and stricter `isEnvelopeV1` checks), which could change runtime behavior and reject previously-accepted envelopes. Added tests reduce risk but failures could impact delivery/retry semantics.
> 
> **Overview**
> **Hardens delivery + ACK handling in `NatsBroker`.** Adds connect retry/backoff with optional NATS token auth, treats `nack` frames as immediate outbox `failed` with reason, and improves error logging for crashed subscribe/correlation loops.
> 
> **Tightens core validation and store safety.** `isEnvelopeV1` now enforces non-empty fields and valid `createdAt`, `InMemoryDedupeStore` becomes size-bounded with eviction, JSON file stores warn when no inter-process locking is configured, and `PgSqlExecutor` switches to a pooled connection with `close()`.
> 
> **Improves demo/bridge/test ergonomics.** Telegram bridge now validates required config and can optionally sign envelopes via `@murmurv2/security` (with explicit unsigned markers), docker-compose locks NATS ports to localhost and enables token auth, and new unit + docker-backed integration tests are added with a `test:integration` runner.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f881c16dd1c55cab90db262fa20a6df7b615e8cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->