### PR TITLE
feat: add Prometheus metrics exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ node scripts/murmur-add-peer.mjs 'MURMUR-REPLY:eyJ...'
 node scripts/murmur-daemon.mjs
 ```
 
+### Optional: expose Prometheus metrics
+
+```bash
+npm run build
+METRICS_PORT=9464 node scripts/prometheus-exporter.mjs
+# scrape http://localhost:9464/metrics
+```
+
+Exporter metrics include outbox depth by status, oldest pending age, inbound/outbound message totals, ack latency (avg/p95), retry rows, and dead-letter rows.
+
 ### Send your first message
 
 Add Murmur as an MCP server in your AI client (e.g., Claude Code):
@@ -418,7 +428,7 @@ See [protocol-v1.md](docs/protocol-v1.md) for the full specification.
 - [x] Systemd + Docker deployment
 
 ### In Progress
-- [ ] Prometheus metrics exporter — outbox depth, delivery latency, error rates
+- [x] Prometheus metrics exporter — outbox depth, delivery latency, error rates
 - [ ] npm package publishing — `@murmurv2/*` on npm registry
 - [ ] NATS native request-reply — replace polling with ephemeral inbox subjects
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "ws": "^8.19.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.10.2",
         "@types/pg": "^8.16.0",
         "typescript": "^5.9.3"
@@ -93,6 +94,16 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "demo:producer": "node scripts/demo-producer.mjs",
     "demo:secure": "node scripts/demo-secure-smoke.mjs",
     "mcp:server": "node packages/mcp-server/dist/index.js",
+    "metrics:exporter": "node scripts/prometheus-exporter.mjs",
     "test:unit": "node --test tests/*.test.mjs",
     "test:integration": "node scripts/run-integration.mjs",
     "test:notify-smoke": "node scripts/notify-smoke.mjs",
@@ -23,6 +24,7 @@
     "test": "npm run build && npm run test:unit && npm run test:notify-smoke && npm run test:openclaw-bridge-smoke"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.10.2",
     "@types/pg": "^8.16.0",
     "typescript": "^5.9.3"

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,15 +1,208 @@
-export interface MessagingMetrics {
-  published: number;
-  acked: number;
-  nacked: number;
-  retried: number;
-  dlq: number;
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import path from "node:path";
+import Database from "better-sqlite3";
+
+export interface PrometheusExporterOptions {
+  dbPath?: string;
+  host?: string;
+  port?: number;
+  now?: () => number;
 }
 
-export const newMetrics = (): MessagingMetrics => ({
-  published: 0,
-  acked: 0,
-  nacked: 0,
-  retried: 0,
-  dlq: 0
-});
+export interface PrometheusSnapshot {
+  generatedAt: string;
+  outboxDepth: Record<string, number>;
+  outboxOldestPendingAgeSeconds: number;
+  localMessagesTotal: Record<string, number>;
+  localMessagesLastHour: Record<string, number>;
+  ackLatencyAvgSeconds: number;
+  ackLatencyP95Seconds: number;
+  errorRowsLastHour: number;
+  retryRows: number;
+  deadLetterRows: number;
+}
+
+const escapeLabel = (value: string): string => value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("\n", "\\n");
+
+const metricLine = (name: string, value: number, labels?: Record<string, string>): string => {
+  if (!labels || Object.keys(labels).length === 0) return `${name} ${Number.isFinite(value) ? value : 0}`;
+  const encoded = Object.entries(labels)
+    .map(([key, label]) => `${key}="${escapeLabel(label)}"`)
+    .join(",");
+  return `${name}{${encoded}} ${Number.isFinite(value) ? value : 0}`;
+};
+
+const rowCount = (db: Database.Database, sql: string, params: unknown[] = []): number => {
+  const row = db.prepare(sql).get(...params) as { count?: number } | undefined;
+  return Number(row?.count ?? 0);
+};
+
+const percentile = (sortedValues: number[], p: number): number => {
+  if (sortedValues.length === 0) return 0;
+  const index = Math.min(sortedValues.length - 1, Math.max(0, Math.ceil(sortedValues.length * p) - 1));
+  return sortedValues[index] ?? 0;
+};
+
+export const collectPrometheusSnapshot = (dbPath = ".data/murmur.db", now = () => Date.now()): PrometheusSnapshot => {
+  const resolvedDbPath = path.resolve(dbPath);
+  const db = new Database(resolvedDbPath, { readonly: true });
+  try {
+    const outboxRows = db.prepare(`SELECT status, COUNT(*) as count FROM outbox GROUP BY status`).all() as Array<{ status: string; count: number }>;
+    const outboxDepth = Object.fromEntries(outboxRows.map((row) => [row.status, Number(row.count)]));
+
+    const oldestPending = db.prepare(`
+      SELECT MIN(created_at) AS created_at
+      FROM outbox
+      WHERE status IN ('pending', 'failed', 'sent')
+    `).get() as { created_at?: string | null } | undefined;
+    const oldestPendingAgeSeconds = oldestPending?.created_at
+      ? Math.max(0, Math.round((now() - Date.parse(oldestPending.created_at)) / 1000))
+      : 0;
+
+    const messageTotals = db.prepare(`SELECT direction, COUNT(*) as count FROM local_messages GROUP BY direction`).all() as Array<{ direction: string; count: number }>;
+    const localMessagesTotal = Object.fromEntries(messageTotals.map((row) => [row.direction, Number(row.count)]));
+
+    const hourAgoIso = new Date(now() - 60 * 60 * 1000).toISOString();
+    const messagesLastHour = db.prepare(`
+      SELECT direction, COUNT(*) as count
+      FROM local_messages
+      WHERE created_at >= ?
+      GROUP BY direction
+    `).all(hourAgoIso) as Array<{ direction: string; count: number }>;
+    const localMessagesLastHour = Object.fromEntries(messagesLastHour.map((row) => [row.direction, Number(row.count)]));
+
+    const ackLatencyRows = db.prepare(`
+      SELECT (julianday(updated_at) - julianday(created_at)) * 86400.0 AS latency_seconds
+      FROM outbox
+      WHERE status = 'acked'
+        AND created_at IS NOT NULL
+        AND updated_at IS NOT NULL
+      ORDER BY latency_seconds ASC
+    `).all() as Array<{ latency_seconds: number | null }>;
+    const ackLatencies = ackLatencyRows
+      .map((row) => Number(row.latency_seconds ?? 0))
+      .filter((value) => Number.isFinite(value) && value >= 0)
+      .sort((a, b) => a - b);
+    const ackLatencyAvgSeconds = ackLatencies.length > 0
+      ? ackLatencies.reduce((sum, value) => sum + value, 0) / ackLatencies.length
+      : 0;
+    const ackLatencyP95Seconds = percentile(ackLatencies, 0.95);
+
+    const errorRowsLastHour = rowCount(
+      db,
+      `SELECT COUNT(*) as count FROM outbox WHERE status IN ('failed', 'dlq') AND updated_at >= ?`,
+      [hourAgoIso],
+    );
+    const retryRows = rowCount(db, `SELECT COUNT(*) as count FROM outbox WHERE status = 'failed'`);
+    const deadLetterRows = rowCount(db, `SELECT COUNT(*) as count FROM outbox WHERE status = 'dlq'`);
+
+    return {
+      generatedAt: new Date(now()).toISOString(),
+      outboxDepth,
+      outboxOldestPendingAgeSeconds: oldestPendingAgeSeconds,
+      localMessagesTotal,
+      localMessagesLastHour,
+      ackLatencyAvgSeconds,
+      ackLatencyP95Seconds,
+      errorRowsLastHour,
+      retryRows,
+      deadLetterRows,
+    };
+  } finally {
+    db.close();
+  }
+};
+
+export const renderPrometheusMetrics = (snapshot: PrometheusSnapshot): string => {
+  const lines: string[] = [
+    "# HELP murmur_exporter_up Murmur Prometheus exporter health status.",
+    "# TYPE murmur_exporter_up gauge",
+    "murmur_exporter_up 1",
+    "# HELP murmur_outbox_depth Current outbox rows by status.",
+    "# TYPE murmur_outbox_depth gauge",
+  ];
+
+  for (const status of ["pending", "failed", "sent", "acked", "dlq"]) {
+    lines.push(metricLine("murmur_outbox_depth", snapshot.outboxDepth[status] ?? 0, { status }));
+  }
+
+  lines.push(
+    "# HELP murmur_outbox_oldest_pending_age_seconds Age of the oldest not-yet-acked outbox row.",
+    "# TYPE murmur_outbox_oldest_pending_age_seconds gauge",
+    metricLine("murmur_outbox_oldest_pending_age_seconds", snapshot.outboxOldestPendingAgeSeconds),
+    "# HELP murmur_local_messages_total Stored local messages by direction.",
+    "# TYPE murmur_local_messages_total gauge",
+  );
+
+  for (const direction of ["inbound", "outbound"]) {
+    lines.push(metricLine("murmur_local_messages_total", snapshot.localMessagesTotal[direction] ?? 0, { direction }));
+  }
+
+  lines.push(
+    "# HELP murmur_local_messages_last_hour Stored local messages in the last hour by direction.",
+    "# TYPE murmur_local_messages_last_hour gauge",
+  );
+
+  for (const direction of ["inbound", "outbound"]) {
+    lines.push(metricLine("murmur_local_messages_last_hour", snapshot.localMessagesLastHour[direction] ?? 0, { direction }));
+  }
+
+  lines.push(
+    "# HELP murmur_ack_latency_avg_seconds Average time from enqueue to ack for acked messages.",
+    "# TYPE murmur_ack_latency_avg_seconds gauge",
+    metricLine("murmur_ack_latency_avg_seconds", snapshot.ackLatencyAvgSeconds),
+    "# HELP murmur_ack_latency_p95_seconds P95 time from enqueue to ack for acked messages.",
+    "# TYPE murmur_ack_latency_p95_seconds gauge",
+    metricLine("murmur_ack_latency_p95_seconds", snapshot.ackLatencyP95Seconds),
+    "# HELP murmur_outbox_errors_last_hour Failed or DLQ outbox transitions in the last hour.",
+    "# TYPE murmur_outbox_errors_last_hour gauge",
+    metricLine("murmur_outbox_errors_last_hour", snapshot.errorRowsLastHour),
+    "# HELP murmur_outbox_retry_rows Current outbox rows waiting for retry.",
+    "# TYPE murmur_outbox_retry_rows gauge",
+    metricLine("murmur_outbox_retry_rows", snapshot.retryRows),
+    "# HELP murmur_outbox_dead_letter_rows Current outbox rows in dead-letter queue.",
+    "# TYPE murmur_outbox_dead_letter_rows gauge",
+    metricLine("murmur_outbox_dead_letter_rows", snapshot.deadLetterRows),
+    "# HELP murmur_metrics_generated_unixtime Unix timestamp when metrics were generated.",
+    "# TYPE murmur_metrics_generated_unixtime gauge",
+    metricLine("murmur_metrics_generated_unixtime", Math.floor(Date.parse(snapshot.generatedAt) / 1000)),
+  );
+
+  return `${lines.join("\n")}\n`;
+};
+
+export const createPrometheusHandler = (options: PrometheusExporterOptions = {}) => {
+  const dbPath = options.dbPath ?? ".data/murmur.db";
+  const now = options.now ?? (() => Date.now());
+
+  return (_req: IncomingMessage, res: ServerResponse) => {
+    try {
+      const snapshot = collectPrometheusSnapshot(dbPath, now);
+      const body = renderPrometheusMetrics(snapshot);
+      res.writeHead(200, {
+        "Content-Type": "text/plain; version=0.0.4; charset=utf-8",
+        "Cache-Control": "no-store",
+      });
+      res.end(body);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end(`# exporter error\nmurmur_exporter_up 0\n# error ${message}\n`);
+    }
+  };
+};
+
+export const startPrometheusExporter = (options: PrometheusExporterOptions = {}) => {
+  const host = options.host ?? process.env.METRICS_HOST ?? "0.0.0.0";
+  const port = options.port ?? Number(process.env.METRICS_PORT ?? 9464);
+  const server = createServer((req, res) => {
+    if (!req.url || req.url === "/metrics") {
+      return createPrometheusHandler(options)(req, res);
+    }
+    res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("Not found\n");
+  });
+
+  server.listen(port, host);
+  return server;
+};

--- a/scripts/prometheus-exporter.mjs
+++ b/scripts/prometheus-exporter.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { startPrometheusExporter } from "../packages/observability/dist/src/index.js";
+
+const dataDir = process.env.DATA_DIR || ".data";
+const dbPath = process.env.METRICS_DB_PATH || path.join(dataDir, "murmur.db");
+const host = process.env.METRICS_HOST || "0.0.0.0";
+const port = Number(process.env.METRICS_PORT || 9464);
+
+const server = startPrometheusExporter({ dbPath, host, port });
+
+server.on("listening", () => {
+  console.log(JSON.stringify({
+    level: "info",
+    msg: "Prometheus exporter listening",
+    host,
+    port,
+    dbPath,
+    metricsPath: "/metrics",
+    ts: new Date().toISOString(),
+  }));
+});
+
+server.on("error", (error) => {
+  console.error(JSON.stringify({
+    level: "fatal",
+    msg: "Prometheus exporter failed",
+    error: error.message,
+    ts: new Date().toISOString(),
+  }));
+  process.exit(1);
+});

--- a/tests/prometheus-exporter.test.mjs
+++ b/tests/prometheus-exporter.test.mjs
@@ -1,0 +1,95 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { collectPrometheusSnapshot, renderPrometheusMetrics } from "../packages/observability/dist/src/index.js";
+
+const makeDb = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-metrics-"));
+  const dbPath = path.join(dir, "murmur.db");
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE outbox (
+      msg_id TEXT PRIMARY KEY,
+      subject TEXT NOT NULL,
+      envelope_json TEXT NOT NULL,
+      status TEXT NOT NULL,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      next_attempt_at TEXT NOT NULL,
+      last_error TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      version INTEGER NOT NULL DEFAULT 1
+    );
+    CREATE TABLE local_messages (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      msg_id TEXT NOT NULL,
+      direction TEXT NOT NULL,
+      sender TEXT NOT NULL,
+      text TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      transport TEXT
+    );
+  `);
+  return { dir, dbPath, db };
+};
+
+test("collectPrometheusSnapshot aggregates outbox and message metrics", () => {
+  const { dir, dbPath, db } = makeDb();
+  const baseNow = Date.parse("2026-04-12T20:00:00.000Z");
+
+  db.prepare(`INSERT INTO outbox (msg_id, subject, envelope_json, status, attempts, next_attempt_at, last_error, created_at, updated_at, version)
+    VALUES (?, ?, '{}', ?, ?, ?, ?, ?, ?, 1)`).run(
+    "msg-pending", "msg.alpha", "pending", 0, "2026-04-12T19:40:00.000Z", null, "2026-04-12T19:30:00.000Z", "2026-04-12T19:30:00.000Z",
+  );
+  db.prepare(`INSERT INTO outbox (msg_id, subject, envelope_json, status, attempts, next_attempt_at, last_error, created_at, updated_at, version)
+    VALUES (?, ?, '{}', ?, ?, ?, ?, ?, ?, 1)`).run(
+    "msg-acked", "msg.alpha", "acked", 1, "2026-04-12T19:41:00.000Z", null, "2026-04-12T19:40:00.000Z", "2026-04-12T19:40:05.000Z",
+  );
+  db.prepare(`INSERT INTO outbox (msg_id, subject, envelope_json, status, attempts, next_attempt_at, last_error, created_at, updated_at, version)
+    VALUES (?, ?, '{}', ?, ?, ?, ?, ?, ?, 1)`).run(
+    "msg-failed", "msg.beta", "failed", 2, "2026-04-12T19:59:00.000Z", "timeout", "2026-04-12T19:50:00.000Z", "2026-04-12T19:59:00.000Z",
+  );
+  db.prepare(`INSERT INTO outbox (msg_id, subject, envelope_json, status, attempts, next_attempt_at, last_error, created_at, updated_at, version)
+    VALUES (?, ?, '{}', ?, ?, ?, ?, ?, ?, 1)`).run(
+    "msg-dlq", "msg.gamma", "dlq", 5, "2026-04-12T19:00:00.000Z", "poison", "2026-04-12T18:00:00.000Z", "2026-04-12T19:10:00.000Z",
+  );
+
+  db.prepare(`INSERT INTO local_messages (id, conversation_id, msg_id, direction, sender, text, created_at, transport)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+    .run("1", "conv-1", "msg-a", "inbound", "alice", "hello", "2026-04-12T19:45:00.000Z", "nats");
+  db.prepare(`INSERT INTO local_messages (id, conversation_id, msg_id, direction, sender, text, created_at, transport)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+    .run("2", "conv-1", "msg-b", "outbound", "bob", "world", "2026-04-12T19:50:00.000Z", "nats");
+  db.prepare(`INSERT INTO local_messages (id, conversation_id, msg_id, direction, sender, text, created_at, transport)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+    .run("3", "conv-2", "msg-c", "outbound", "bob", "older", "2026-04-12T15:00:00.000Z", "nats");
+
+  db.close();
+
+  const snapshot = collectPrometheusSnapshot(dbPath, () => baseNow);
+  assert.equal(snapshot.outboxDepth.pending, 1);
+  assert.equal(snapshot.outboxDepth.acked, 1);
+  assert.equal(snapshot.outboxDepth.failed, 1);
+  assert.equal(snapshot.outboxDepth.dlq, 1);
+  assert.equal(snapshot.outboxOldestPendingAgeSeconds, 1800);
+  assert.equal(snapshot.localMessagesTotal.inbound, 1);
+  assert.equal(snapshot.localMessagesTotal.outbound, 2);
+  assert.equal(snapshot.localMessagesLastHour.inbound, 1);
+  assert.equal(snapshot.localMessagesLastHour.outbound, 1);
+  assert.ok(Math.abs(snapshot.ackLatencyAvgSeconds - 5) < 0.01);
+  assert.ok(Math.abs(snapshot.ackLatencyP95Seconds - 5) < 0.01);
+  assert.equal(snapshot.retryRows, 1);
+  assert.equal(snapshot.deadLetterRows, 1);
+  assert.equal(snapshot.errorRowsLastHour, 2);
+
+  const metrics = renderPrometheusMetrics(snapshot);
+  assert.match(metrics, /murmur_outbox_depth\{status="pending"\} 1/);
+  assert.match(metrics, /murmur_ack_latency_avg_seconds 5/);
+  assert.match(metrics, /murmur_outbox_dead_letter_rows 1/);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add a Prometheus exporter backed by Murmur SQLite state
- expose /metrics via a small exporter script and npm script
- document usage and cover metrics aggregation with tests

## Testing
- npm run build
- node --test tests/*.test.mjs