### PR TITLE
fix(broker-nats): route ACK to sender, not consumer (stop retry-spam)

### DIFF
--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -86,11 +86,11 @@ export class NatsBroker {
     await this.connect();
 
     const sub = this.nc!.subscribe(params.subject);
-    const ackSubject = `ack.${params.consumerId}`;
 
     (async () => {
       for await (const m of sub) {
         let msgId = "unknown";
+        let ackSubject = `ack.${params.consumerId}`;
         try {
           const decoded = JSON.parse(this.sc.decode(m.data));
           if (!isEnvelopeV1(decoded)) {
@@ -99,6 +99,7 @@ export class NatsBroker {
           }
 
           msgId = decoded.msgId;
+          ackSubject = `ack.${decoded.senderAgentId}`;
           const isDup = await params.dedupe.seen(decoded.msgId, params.consumerId);
           if (isDup) {
             await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack", "duplicate-ignored"));

--- a/tests/broker-ack-subject.test.mjs
+++ b/tests/broker-ack-subject.test.mjs
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { StringCodec } from "nats";
+import { NatsBroker } from "../packages/broker-nats/dist/src/index.js";
+
+const sc = StringCodec();
+
+const envelope = {
+  schemaVersion: "1.0",
+  msgId: "msg-ack-subject",
+  conversationId: "conv-ack-subject",
+  senderAgentId: "agent-sender",
+  recipients: ["agent-receiver"],
+  createdAt: new Date().toISOString(),
+  payloadCiphertext: Buffer.from("x").toString("base64"),
+  payloadNonce: "nonce",
+  signature: "sig",
+};
+
+test("subscribeWithAck publishes ack to original sender ack subject", async () => {
+  const published = [];
+  const fakeSub = {
+    async *[Symbol.asyncIterator]() {
+      yield { data: sc.encode(JSON.stringify(envelope)) };
+    },
+  };
+  const fakeNc = {
+    subscribe(subject) {
+      assert.equal(subject, "msg.agent-receiver");
+      return fakeSub;
+    },
+    publish(subject, data) {
+      published.push({ subject, body: JSON.parse(sc.decode(data)) });
+    },
+    async drain() {},
+  };
+  const dedupe = {
+    async seen() { return false; },
+    async markSeen() {},
+  };
+  const broker = new NatsBroker({ url: "nats://example.invalid" });
+  broker.nc = fakeNc;
+
+  await broker.subscribeWithAck({
+    subject: "msg.agent-receiver",
+    consumerId: "agent-receiver",
+    dedupe,
+    onMessage: async () => {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(published.length, 1);
+  assert.equal(published[0].subject, "ack.agent-sender");
+  assert.equal(published[0].body.msgId, envelope.msgId);
+  assert.equal(published[0].body.consumerId, "agent-receiver");
+  assert.equal(published[0].body.status, "ack");
+});


### PR DESCRIPTION
## Root cause

`subscribeWithAck` published ACK/NACK frames to `ack.${consumerId}`. The sender listens on its own ACK correlation subject, so this routed delivery acknowledgements to the receiver/consumer instead of the original sender and can leave the sender outbox retrying already-delivered messages.

## Fix

After decoding a valid envelope, derive the ACK subject from `decoded.senderAgentId`:

- before: `ack.${params.consumerId}`
- after: `ack.${decoded.senderAgentId}`

Invalid envelopes still fall back to the consumer ACK subject because no sender identity can be trusted before validation.

## Credit

Independent discovery credit: Stas / agent-Max flagged the upstream ACK-routing issue; this PR ports the already-tested local runtime fix back to the public repo.

## Verification

- `npm ci`
- `npm run build`
- `npm run typecheck`
- `node --test tests/*.test.mjs` (24/24 pass)

Closes #8