### PR TITLE
feat(broker-nats): add resilient reconnect defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ node scripts/murmur-notify-init.mjs openclaw
 ## Testing
 
 ```bash
-npm test                          # Build + all unit tests (24 tests)
+npm test                          # Build + all unit tests (26 tests)
 npm run test:integration          # ACK correlation integration
 npm run test:notify-smoke         # Notification adapter smoke
 npm run test:openclaw-bridge-smoke # OpenClaw bridge smoke

--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -1,4 +1,4 @@
-import { connect, type NatsConnection, StringCodec, type Subscription } from "nats";
+import { connect, type ConnectionOptions, type NatsConnection, StringCodec, type Subscription } from "nats";
 import {
   applyJitter,
   computeBackoffMs,
@@ -19,14 +19,40 @@ export interface BrokerConfig {
   connectMaxAttempts?: number;
   connectBaseBackoffMs?: number;
   connectJitterRatio?: number;
+  maxReconnectAttempts?: number;
+  reconnectTimeWait?: number;
+  reconnectJitter?: number;
+  pingInterval?: number;
+  maxPingOut?: number;
+  waitOnFirstConnect?: boolean;
+  onStatus?: (status: BrokerStatusEvent) => void;
 }
 
 export type MessageHandler = (envelope: EnvelopeV1) => Promise<void>;
+
+export interface BrokerStatusEvent {
+  type: string;
+  data?: unknown;
+  reconnects: number;
+}
+
+export const buildNatsConnectionOptions = (config: BrokerConfig): ConnectionOptions => ({
+  servers: config.url,
+  token: config.token,
+  maxReconnectAttempts: config.maxReconnectAttempts ?? -1,
+  reconnectTimeWait: config.reconnectTimeWait ?? 2000,
+  reconnectJitter: config.reconnectJitter ?? 500,
+  pingInterval: config.pingInterval ?? 20000,
+  maxPingOut: config.maxPingOut ?? 2,
+  waitOnFirstConnect: config.waitOnFirstConnect ?? true,
+});
 
 export class NatsBroker {
   private nc?: NatsConnection;
   private readonly sc = StringCodec();
   private readonly failedDeliveries = new Map<string, number>();
+  private reconnects = 0;
+  private statusLoop?: Promise<void>;
 
   constructor(private readonly config: BrokerConfig) {}
 
@@ -40,10 +66,8 @@ export class NatsBroker {
 
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       try {
-        this.nc = await connect({
-          servers: this.config.url,
-          token: this.config.token,
-        });
+        this.nc = await connect(buildNatsConnectionOptions(this.config));
+        this.startStatusLoop(this.nc);
         return;
       } catch (err) {
         lastErr = err;
@@ -60,6 +84,29 @@ export class NatsBroker {
     if (!this.nc) return;
     await this.nc.drain();
     this.nc = undefined;
+  }
+
+  getReconnectCount(): number {
+    return this.reconnects;
+  }
+
+  private startStatusLoop(nc: NatsConnection): void {
+    if (this.statusLoop) return;
+    this.statusLoop = (async () => {
+      for await (const status of nc.status()) {
+        if (status.type === "reconnect") this.reconnects += 1;
+        if (status.type === "disconnect" || status.type === "reconnect" || status.type === "update") {
+          const event = { type: status.type, data: status.data, reconnects: this.reconnects };
+          this.config.onStatus?.(event);
+          console.info("[NatsBroker.status]", event);
+        }
+      }
+    })().catch((err) => {
+      const e = err instanceof Error ? err : new Error(String(err));
+      console.error("[NatsBroker.status] loop crashed", { message: e.message, stack: e.stack });
+    }).finally(() => {
+      this.statusLoop = undefined;
+    });
   }
 
   async publish(subject: string, envelope: EnvelopeV1, policy?: SecurityPolicy): Promise<void> {

--- a/scripts/murmur-daemon.mjs
+++ b/scripts/murmur-daemon.mjs
@@ -224,7 +224,7 @@ const flushLoop = async () => {
 };
 
 const shutdown = async (signal) => {
-  log("info", "Shutdown signal received", { signal });
+  log("info", "Shutdown signal received, draining NATS", { signal });
   running = false;
   try {
     await broker.close();

--- a/tests/broker-reconnect-options.test.mjs
+++ b/tests/broker-reconnect-options.test.mjs
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildNatsConnectionOptions } from "../packages/broker-nats/dist/src/index.js";
+
+test("buildNatsConnectionOptions enables resilient reconnect defaults", () => {
+  const options = buildNatsConnectionOptions({
+    url: "nats://example.invalid:4222",
+    token: "secret",
+  });
+
+  assert.equal(options.servers, "nats://example.invalid:4222");
+  assert.equal(options.token, "secret");
+  assert.equal(options.maxReconnectAttempts, -1);
+  assert.equal(options.reconnectTimeWait, 2000);
+  assert.equal(options.reconnectJitter, 500);
+  assert.equal(options.pingInterval, 20000);
+  assert.equal(options.maxPingOut, 2);
+  assert.equal(options.waitOnFirstConnect, true);
+});
+
+test("buildNatsConnectionOptions allows bounded operator overrides", () => {
+  const options = buildNatsConnectionOptions({
+    url: "nats://example.invalid:4222",
+    maxReconnectAttempts: 10,
+    reconnectTimeWait: 5000,
+    reconnectJitter: 1000,
+    pingInterval: 30000,
+    maxPingOut: 3,
+    waitOnFirstConnect: false,
+  });
+
+  assert.equal(options.maxReconnectAttempts, 10);
+  assert.equal(options.reconnectTimeWait, 5000);
+  assert.equal(options.reconnectJitter, 1000);
+  assert.equal(options.pingInterval, 30000);
+  assert.equal(options.maxPingOut, 3);
+  assert.equal(options.waitOnFirstConnect, false);
+});


### PR DESCRIPTION
## Summary

Adds resilient NATS reconnect defaults and lifecycle visibility to the broker:

- `maxReconnectAttempts: -1`
- `reconnectTimeWait: 2000`
- `reconnectJitter: 500`
- `pingInterval: 20000`
- `maxPingOut: 2`
- `waitOnFirstConnect: true`

The defaults are inside the requested ranges and remain operator-overridable through `BrokerConfig`.

## Lifecycle visibility

`NatsBroker` now consumes `nc.status()` and handles the operational lifecycle events:

- `disconnect`
- `reconnect`
- `update`

It logs those events, increments an internal reconnect counter on reconnect, and exposes an `onStatus` hook for metrics/exporter integration without tying this broker package to the Prometheus package.

SIGTERM already drained through `broker.close()`; this PR makes the daemon shutdown log explicit: `Shutdown signal received, draining NATS`.

## Tests

Added deterministic unit coverage for NATS connection options without requiring live NATS in CI:

- resilient reconnect defaults
- bounded operator overrides

No live reconnect integration test is included in this PR; that should stay optional/skip-if-no-nats as discussed.

## Verification

- `npm run build`
- `npm run typecheck`
- `node --test tests/*.test.mjs` (26/26 pass)

Closes #10
