### PR TITLE
feat(wake): mandatory WakeMonitor MVP (stateless + dedup + drain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ node scripts/murmur-notify-init.mjs openclaw
 ## Testing
 
 ```bash
-npm test                          # Build + all unit tests (26 tests)
+npm test                          # Build + all unit tests (29 tests)
 npm run test:integration          # ACK correlation integration
 npm run test:notify-smoke         # Notification adapter smoke
 npm run test:openclaw-bridge-smoke # OpenClaw bridge smoke

--- a/scripts/murmur-daemon.mjs
+++ b/scripts/murmur-daemon.mjs
@@ -3,8 +3,8 @@
  * murmur-daemon.mjs — Persistent agent-to-agent messaging daemon.
  */
 import { randomUUID } from "node:crypto";
-import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { DatabaseSync } from "node:sqlite";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { NatsBroker } from "@murmurv2/broker-nats";
@@ -12,6 +12,7 @@ import { SQLiteDedupeOutboxStore, SQLiteMessageStore } from "@murmurv2/core";
 import { decryptPayload, encryptPayload, signEnvelope, verifyEnvelopeSignature } from "@murmurv2/security";
 import { NotifyQueue, flushNotifyQueue, normalizeNotifyTargets } from "./notify-router.mjs";
 import { OpenClawBridgeQueue, flushOpenClawBridgeQueue, normalizeOpenClawTargets } from "./openclaw-bridge.mjs";
+import { WakeMonitor, createShellHook, normalizeWakeConfig } from "./wake-monitor.mjs";
 // vault-guard: optional content policy hook (not included in OSS release)
 
 const log = (level, msg, data) => {
@@ -53,6 +54,8 @@ const effectiveNotifyTargets = notifyTargets.length > 0 ? notifyTargets : envTel
 const openclawTargets = normalizeOpenClawTargets(config.notify);
 const notifyQueue = new NotifyQueue(dbPath);
 const openclawQueue = new OpenClawBridgeQueue(dbPath);
+const wakeDb = new DatabaseSync(dbPath);
+const wakeConfig = normalizeWakeConfig(config);
 
 log("info", "Daemon starting", {
   agentId,
@@ -68,6 +71,57 @@ log("info", "Daemon starting", {
 const store = new SQLiteDedupeOutboxStore(dbPath);
 const msgStore = new SQLiteMessageStore(dbPath);
 const broker = new NatsBroker({ url: natsUrl, token: natsToken });
+
+const inboundCursor = () => {
+  const row = wakeDb.prepare("SELECT COALESCE(MAX(rowid), 0) as cursor FROM local_messages WHERE direction = 'inbound'").get();
+  return Number(row?.cursor ?? 0);
+};
+
+const inboundCursorForMsg = (msgId) => {
+  const row = wakeDb.prepare("SELECT rowid as cursor FROM local_messages WHERE direction = 'inbound' AND msg_id = ? ORDER BY rowid DESC LIMIT 1").get(msgId);
+  return Number(row?.cursor ?? 0);
+};
+
+const loadInboundAfter = async (cursor) => {
+  const rows = wakeDb
+    .prepare(
+      `SELECT
+         rowid as cursor,
+         conversation_id as conversationId,
+         msg_id as msgId,
+         sender as "from",
+         text,
+         created_at as ts
+       FROM local_messages
+       WHERE direction = 'inbound' AND rowid > ?
+       ORDER BY rowid ASC
+       LIMIT 100`,
+    )
+    .all(cursor);
+  return rows.map((row) => ({
+    from: row.from,
+    text: row.text,
+    msgId: row.msgId,
+    conversationId: row.conversationId,
+    ts: row.ts,
+    cursor: Number(row.cursor),
+  }));
+};
+
+const wakeMonitor = new WakeMonitor({
+  ...wakeConfig,
+  initialCursor: inboundCursor(),
+  loadBacklogAfter: loadInboundAfter,
+  hook: createShellHook({ command: config.onReceive, log }),
+  log,
+});
+
+const proxyWakeMonitor = new WakeMonitor({
+  ...wakeConfig,
+  initialCursor: inboundCursor(),
+  hook: createShellHook({ command: config.proxyOnReceive, log }),
+  log,
+});
 
 const stableEnvelopePayload = (envelope) => JSON.stringify({
   schemaVersion: envelope.schemaVersion,
@@ -160,6 +214,7 @@ const onMessage = async (envelope) => {
     msgId: envelope.msgId,
     conversationId: envelope.conversationId,
     ts: new Date().toISOString(),
+    cursor: inboundCursorForMsg(envelope.msgId),
   };
 
   if (openclawTargets.length > 0) {
@@ -179,22 +234,7 @@ const onMessage = async (envelope) => {
     });
   }
 
-  if (config.onReceive) {
-    try {
-      const env = {
-        ...process.env,
-        MURMUR_FROM: senderId,
-        MURMUR_TEXT: plaintext,
-        MURMUR_MSG_ID: envelope.msgId,
-        MURMUR_CONVERSATION_ID: envelope.conversationId,
-      };
-      execFile("sh", ["-c", config.onReceive], { env, timeout: 10_000 }, (err) => {
-        if (err) log("warn", "onReceive hook failed", { error: err.message });
-      });
-    } catch (err) {
-      log("warn", "onReceive hook error", { error: err.message });
-    }
-  }
+  await wakeMonitor.onInbound(payload);
 };
 
 let running = true;
@@ -251,25 +291,14 @@ try {
     const proxyOnMessage = async (envelope, plaintext) => {
       const senderId = envelope.senderAgentId || "unknown";
       log("info", "Proxy message received", { subject: ps, from: senderId, len: plaintext?.length });
-      // Run LLM handler for proxy agents
-      if (config.proxyOnReceive) {
-        try {
-          const env = {
-            ...process.env,
-            MURMUR_FROM: senderId,
-            MURMUR_TEXT: plaintext,
-            MURMUR_MSG_ID: envelope.msgId,
-            MURMUR_CONVERSATION_ID: envelope.conversationId,
-            MURMUR_PROXY_AGENT: ps.replace("msg.", ""),
-          };
-          execFile("sh", ["-c", config.proxyOnReceive], { env, timeout: 60_000 }, (err, stdout, stderr) => {
-            if (err) log("warn", "proxyOnReceive hook failed", { error: err.message, stderr: stderr?.slice(0,200) });
-            else log("info", "proxyOnReceive hook completed", { stdout: stdout?.slice(0,100) });
-          });
-        } catch (err) {
-          log("warn", "proxyOnReceive hook error", { error: err.message });
-        }
-      }
+      await proxyWakeMonitor.onInbound({
+        from: senderId,
+        text: plaintext ?? "",
+        msgId: envelope.msgId,
+        conversationId: envelope.conversationId,
+        ts: new Date().toISOString(),
+        env: { MURMUR_PROXY_AGENT: ps.replace("msg.", "") },
+      });
     };
     await broker.subscribeWithAck({ subject: ps, consumerId: `${agentId}-proxy`, dedupe: store, onMessage: proxyOnMessage });
     log("info", "Subscribed (proxy)", { subject: ps });

--- a/scripts/wake-monitor.mjs
+++ b/scripts/wake-monitor.mjs
@@ -1,0 +1,117 @@
+import { execFile } from "node:child_process";
+
+const ensureObject = (value) => (value && typeof value === "object" ? value : {});
+
+export const normalizeWakeConfig = (config = {}) => {
+  const wake = ensureObject(config.wake);
+  const dedup = ensureObject(wake.dedup);
+  return {
+    enabled: wake.enabled !== false,
+    mode: wake.mode || "stateless",
+    dedup: {
+      cooldownMs: Number.isFinite(Number(dedup.cooldownMs)) ? Number(dedup.cooldownMs) : 300000,
+    },
+  };
+};
+
+export const createShellHook = ({ command, timeoutMs = 10000, baseEnv = process.env, log = () => {} }) => {
+  if (!command) return null;
+  return (payload) => new Promise((resolve) => {
+    const env = {
+      ...baseEnv,
+      MURMUR_FROM: payload.from,
+      MURMUR_TEXT: payload.text,
+      MURMUR_MSG_ID: payload.msgId,
+      MURMUR_CONVERSATION_ID: payload.conversationId,
+      ...(payload.env || {}),
+    };
+    execFile("sh", ["-c", command], { env, timeout: timeoutMs }, (err) => {
+      if (err) log("warn", "wake hook failed", { error: err.message, msgId: payload.msgId });
+      resolve();
+    });
+  });
+};
+
+export class WakeMonitor {
+  constructor(options = {}) {
+    const wakeConfig = normalizeWakeConfig({ wake: options });
+    this.enabled = options.enabled ?? wakeConfig.enabled;
+    this.mode = options.mode ?? wakeConfig.mode;
+    this.cooldownMs = options.dedup?.cooldownMs ?? wakeConfig.dedup.cooldownMs;
+    this.hook = options.hook || null;
+    this.loadBacklogAfter = options.loadBacklogAfter || null;
+    this.now = options.now || (() => Date.now());
+    this.log = options.log || (() => {});
+    this.seen = new Map();
+    this.queue = [];
+    this.queuedKeys = new Set();
+    this.processing = false;
+    this.cursor = Number.isFinite(Number(options.initialCursor)) ? Number(options.initialCursor) : 0;
+  }
+
+  async onInbound(payload) {
+    if (!this.enabled || this.mode !== "stateless") return;
+    this.enqueue(payload);
+    await this.drain();
+  }
+
+  enqueue(payload) {
+    if (!payload?.msgId) return;
+    const key = this.keyFor(payload);
+    if (this.queuedKeys.has(key)) return;
+    this.queuedKeys.add(key);
+    this.queue.push(payload);
+  }
+
+  async drain() {
+    if (this.processing) return;
+    this.processing = true;
+    try {
+      while (true) {
+        while (this.queue.length > 0) {
+          const payload = this.queue.shift();
+          this.queuedKeys.delete(this.keyFor(payload));
+          await this.processPayload(payload);
+        }
+
+        if (!this.loadBacklogAfter) break;
+        const backlog = await this.loadBacklogAfter(this.cursor);
+        if (!Array.isArray(backlog) || backlog.length === 0) break;
+        for (const payload of backlog) this.enqueue(payload);
+      }
+    } finally {
+      this.processing = false;
+    }
+  }
+
+  async processPayload(payload) {
+    const key = this.keyFor(payload);
+    const now = this.now();
+    const lastWakeAt = this.seen.get(key);
+    if (lastWakeAt !== undefined && now - lastWakeAt < this.cooldownMs) {
+      this.advanceCursor(payload);
+      this.log("info", "WakeMonitor duplicate dropped", { msgId: payload.msgId, conversationId: payload.conversationId });
+      return;
+    }
+
+    this.seen.set(key, now);
+    try {
+      if (this.hook) await this.hook(payload);
+      this.log("info", "WakeMonitor hook completed", { msgId: payload.msgId, conversationId: payload.conversationId });
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      this.log("warn", "WakeMonitor hook error", { error: e.message, msgId: payload.msgId });
+    } finally {
+      this.advanceCursor(payload);
+    }
+  }
+
+  advanceCursor(payload) {
+    const cursor = Number(payload?.cursor);
+    if (Number.isFinite(cursor) && cursor > this.cursor) this.cursor = cursor;
+  }
+
+  keyFor(payload) {
+    return payload.msgId;
+  }
+}

--- a/tests/wake-monitor.test.mjs
+++ b/tests/wake-monitor.test.mjs
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { WakeMonitor } from "../scripts/wake-monitor.mjs";
+
+const message = (msgId, cursor, text = msgId) => ({
+  from: "agent-a",
+  text,
+  msgId,
+  conversationId: "conv-1",
+  ts: `2026-06-20T00:00:${String(cursor).padStart(2, "0")}.000Z`,
+  cursor,
+});
+
+test("WakeMonitor calls hook once for a new msgId", async () => {
+  const calls = [];
+  const monitor = new WakeMonitor({
+    hook: async (payload) => calls.push(payload.msgId),
+    now: () => 1000,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+
+  assert.deepEqual(calls, ["msg-1"]);
+});
+
+test("WakeMonitor drops duplicate msgId within cooldown window", async () => {
+  const calls = [];
+  let now = 1000;
+  const monitor = new WakeMonitor({
+    dedup: { cooldownMs: 300000 },
+    hook: async (payload) => calls.push(payload.msgId),
+    now: () => now,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+  now += 1000;
+  await monitor.onInbound(message("msg-1", 2));
+
+  assert.deepEqual(calls, ["msg-1"]);
+});
+
+test("WakeMonitor drains inbound backlog FIFO until idle", async () => {
+  const calls = [];
+  const backlog = [
+    message("msg-2", 2),
+    message("msg-3", 3),
+  ];
+  const monitor = new WakeMonitor({
+    hook: async (payload) => calls.push(payload.msgId),
+    loadBacklogAfter: async (cursor) => {
+      const rows = backlog.filter((row) => row.cursor > cursor);
+      backlog.length = 0;
+      return rows;
+    },
+    now: () => 1000,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+
+  assert.deepEqual(calls, ["msg-1", "msg-2", "msg-3"]);
+});


### PR DESCRIPTION
## Summary

Adds WakeMonitor Phase 1 MVP for #12 as a mandatory daemon subsystem.

This PR implements the stateless mode only:

- new `scripts/wake-monitor.mjs`
- default config is enabled/stateless when `wake` stanza is absent
- supports `wake: { enabled: true, mode: "stateless", dedup: { cooldownMs: 300000 } }`
- routes `onReceive` through WakeMonitor after inbound is appended to `local_messages`
- routes `proxyOnReceive` through WakeMonitor as well, preserving `MURMUR_PROXY_AGENT`
- preserves hook env contract: `MURMUR_FROM`, `MURMUR_TEXT`, `MURMUR_MSG_ID`, `MURMUR_CONVERSATION_ID`

## Guards in this phase

- Dedup: `msgId` cooldown window, default 300000ms. Duplicate msgIds inside the window do not invoke the hook.
- Drain loop: WakeMonitor processes queued inbound FIFO, then re-checks `local_messages` by `rowid` cursor until idle.

Persistent/tmux injection, loop-breaker, and audit-gate are intentionally left for follow-up PRs under #12.

## Notes

- The production daemon initializes the WakeMonitor cursor to the current inbound `local_messages` max rowid so startup does not wake old historical messages.
- Proxy wake events do not drain normal `local_messages` backlog, avoiding accidental proxy hook execution for non-proxy inbound messages.

## Verification

- `node --check scripts/wake-monitor.mjs`
- `node --check scripts/murmur-daemon.mjs`
- `npm run build`
- `npm run typecheck`
- `node --test tests/*.test.mjs` (29/29 pass)

Part of #12 (Phase 1)
