### PR TITLE
feat(wake): WakeMonitor Phase 2 — loop-breaker + audit-gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ node scripts/murmur-notify-init.mjs openclaw
 ## Testing
 
 ```bash
-npm test                          # Build + all unit tests (29 tests)
+npm test                          # Build + all unit tests (34 tests)
 npm run test:integration          # ACK correlation integration
 npm run test:notify-smoke         # Notification adapter smoke
 npm run test:openclaw-bridge-smoke # OpenClaw bridge smoke

--- a/scripts/murmur-daemon.mjs
+++ b/scripts/murmur-daemon.mjs
@@ -12,7 +12,7 @@ import { SQLiteDedupeOutboxStore, SQLiteMessageStore } from "@murmurv2/core";
 import { decryptPayload, encryptPayload, signEnvelope, verifyEnvelopeSignature } from "@murmurv2/security";
 import { NotifyQueue, flushNotifyQueue, normalizeNotifyTargets } from "./notify-router.mjs";
 import { OpenClawBridgeQueue, flushOpenClawBridgeQueue, normalizeOpenClawTargets } from "./openclaw-bridge.mjs";
-import { WakeMonitor, createShellHook, normalizeWakeConfig } from "./wake-monitor.mjs";
+import { WakeMonitor, createAuditShellHook, createShellHook, normalizeWakeConfig } from "./wake-monitor.mjs";
 // vault-guard: optional content policy hook (not included in OSS release)
 
 const log = (level, msg, data) => {
@@ -108,18 +108,31 @@ const loadInboundAfter = async (cursor) => {
   }));
 };
 
+const enqueueWakeNotification = async (payload, reason) => {
+  log("warn", "WakeMonitor fallback notify", { reason, msgId: payload.msgId, from: payload.from });
+  if (effectiveNotifyTargets.length === 0) return;
+  notifyQueue.enqueueMessage({
+    ...payload,
+    text: `[WakeMonitor ${reason}] ${payload.text}`,
+  }, effectiveNotifyTargets);
+};
+
 const wakeMonitor = new WakeMonitor({
   ...wakeConfig,
   initialCursor: inboundCursor(),
   loadBacklogAfter: loadInboundAfter,
+  auditHook: createAuditShellHook({ command: wakeConfig.auditHook, log }),
   hook: createShellHook({ command: config.onReceive, log }),
+  notify: enqueueWakeNotification,
   log,
 });
 
 const proxyWakeMonitor = new WakeMonitor({
   ...wakeConfig,
   initialCursor: inboundCursor(),
+  auditHook: createAuditShellHook({ command: wakeConfig.auditHook, log }),
   hook: createShellHook({ command: config.proxyOnReceive, log }),
+  notify: enqueueWakeNotification,
   log,
 });
 

--- a/scripts/wake-monitor.mjs
+++ b/scripts/wake-monitor.mjs
@@ -5,11 +5,17 @@ const ensureObject = (value) => (value && typeof value === "object" ? value : {}
 export const normalizeWakeConfig = (config = {}) => {
   const wake = ensureObject(config.wake);
   const dedup = ensureObject(wake.dedup);
+  const loopBreaker = ensureObject(wake.loopBreaker);
   return {
     enabled: wake.enabled !== false,
     mode: wake.mode || "stateless",
+    auditHook: typeof wake.auditHook === "string" && wake.auditHook.trim() ? wake.auditHook.trim() : null,
     dedup: {
       cooldownMs: Number.isFinite(Number(dedup.cooldownMs)) ? Number(dedup.cooldownMs) : 300000,
+    },
+    loopBreaker: {
+      maxWakes: Number.isFinite(Number(loopBreaker.maxWakes)) ? Number(loopBreaker.maxWakes) : 5,
+      windowMs: Number.isFinite(Number(loopBreaker.windowMs)) ? Number(loopBreaker.windowMs) : 60000,
     },
   };
 };
@@ -32,17 +38,48 @@ export const createShellHook = ({ command, timeoutMs = 10000, baseEnv = process.
   });
 };
 
+export const createAuditShellHook = ({ command, timeoutMs = 10000, baseEnv = process.env, log = () => {} }) => {
+  if (!command) return null;
+  return (payload) => new Promise((resolve) => {
+    const env = {
+      ...baseEnv,
+      MURMUR_FROM: payload.from,
+      MURMUR_TEXT: payload.text,
+      MURMUR_MSG_ID: payload.msgId,
+      MURMUR_CONVERSATION_ID: payload.conversationId,
+      ...(payload.env || {}),
+    };
+    execFile("sh", ["-c", command], { env, timeout: timeoutMs }, (err, stdout) => {
+      if (err) {
+        log("warn", "wake audit hook failed", { error: err.message, msgId: payload.msgId });
+        resolve("deny");
+        return;
+      }
+      const verdict = String(stdout || "").split(/\r?\n/, 1)[0]?.trim();
+      resolve(verdict === "deny" || verdict === "require_approval" || verdict === "allow" ? verdict : "deny");
+    });
+  });
+};
+
 export class WakeMonitor {
   constructor(options = {}) {
     const wakeConfig = normalizeWakeConfig({ wake: options });
     this.enabled = options.enabled ?? wakeConfig.enabled;
     this.mode = options.mode ?? wakeConfig.mode;
     this.cooldownMs = options.dedup?.cooldownMs ?? wakeConfig.dedup.cooldownMs;
+    this.loopBreaker = {
+      maxWakes: options.loopBreaker?.maxWakes ?? wakeConfig.loopBreaker.maxWakes,
+      windowMs: options.loopBreaker?.windowMs ?? wakeConfig.loopBreaker.windowMs,
+    };
     this.hook = options.hook || null;
+    this.auditHook = options.auditHook || null;
+    this.notify = options.notify || null;
     this.loadBacklogAfter = options.loadBacklogAfter || null;
     this.now = options.now || (() => Date.now());
     this.log = options.log || (() => {});
     this.seen = new Map();
+    this.senderWindows = new Map();
+    this.suspendedSenders = new Map();
     this.queue = [];
     this.queuedKeys = new Set();
     this.processing = false;
@@ -87,6 +124,7 @@ export class WakeMonitor {
   async processPayload(payload) {
     const key = this.keyFor(payload);
     const now = this.now();
+    this.pruneSeen(now);
     const lastWakeAt = this.seen.get(key);
     if (lastWakeAt !== undefined && now - lastWakeAt < this.cooldownMs) {
       this.advanceCursor(payload);
@@ -95,6 +133,24 @@ export class WakeMonitor {
     }
 
     this.seen.set(key, now);
+    if (await this.isLoopBreakerBlocked(payload, now)) {
+      this.advanceCursor(payload);
+      return;
+    }
+
+    const verdict = await this.audit(payload);
+    if (verdict === "deny") {
+      this.log("warn", "WakeMonitor audit denied wake", { msgId: payload.msgId, conversationId: payload.conversationId, from: payload.from });
+      this.advanceCursor(payload);
+      return;
+    }
+    if (verdict === "require_approval") {
+      await this.notify?.(payload, "require_approval");
+      this.log("warn", "WakeMonitor audit requires approval", { msgId: payload.msgId, conversationId: payload.conversationId, from: payload.from });
+      this.advanceCursor(payload);
+      return;
+    }
+
     try {
       if (this.hook) await this.hook(payload);
       this.log("info", "WakeMonitor hook completed", { msgId: payload.msgId, conversationId: payload.conversationId });
@@ -104,6 +160,46 @@ export class WakeMonitor {
     } finally {
       this.advanceCursor(payload);
     }
+  }
+
+  pruneSeen(now = this.now()) {
+    for (const [key, wokeAt] of this.seen.entries()) {
+      if (now - wokeAt >= this.cooldownMs) this.seen.delete(key);
+    }
+  }
+
+  async isLoopBreakerBlocked(payload, now) {
+    const sender = payload.from || "unknown";
+    const suspendedUntil = this.suspendedSenders.get(sender);
+    if (suspendedUntil !== undefined) {
+      if (now < suspendedUntil) {
+        this.suspendedSenders.set(sender, now + this.loopBreaker.windowMs);
+        await this.notify?.(payload, "loop-breaker");
+        this.log("warn", "WakeMonitor loop-breaker suspended wake", { sender, msgId: payload.msgId, suspendedUntil: this.suspendedSenders.get(sender) });
+        return true;
+      }
+      this.suspendedSenders.delete(sender);
+    }
+
+    const since = now - this.loopBreaker.windowMs;
+    const window = (this.senderWindows.get(sender) || []).filter((ts) => ts > since);
+    if (window.length >= this.loopBreaker.maxWakes) {
+      this.suspendedSenders.set(sender, now + this.loopBreaker.windowMs);
+      this.senderWindows.set(sender, window);
+      await this.notify?.(payload, "loop-breaker");
+      this.log("warn", "WakeMonitor loop-breaker tripped", { sender, count: window.length + 1, msgId: payload.msgId });
+      return true;
+    }
+
+    window.push(now);
+    this.senderWindows.set(sender, window);
+    return false;
+  }
+
+  async audit(payload) {
+    if (!this.auditHook) return "allow";
+    const verdict = await this.auditHook(payload);
+    return verdict === "allow" || verdict === "require_approval" || verdict === "deny" ? verdict : "deny";
   }
 
   advanceCursor(payload) {

--- a/tests/wake-monitor-guards.test.mjs
+++ b/tests/wake-monitor-guards.test.mjs
@@ -1,0 +1,99 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { WakeMonitor } from "../scripts/wake-monitor.mjs";
+
+const message = (msgId, cursor, from = "agent-a") => ({
+  from,
+  text: msgId,
+  msgId,
+  conversationId: "conv-guards",
+  ts: `2026-06-20T00:01:${String(cursor).padStart(2, "0")}.000Z`,
+  cursor,
+});
+
+test("WakeMonitor loop-breaker trips after maxWakes and suspends sender", async () => {
+  const calls = [];
+  const notifications = [];
+  let now = 1000;
+  const monitor = new WakeMonitor({
+    loopBreaker: { maxWakes: 2, windowMs: 60000 },
+    hook: async (payload) => calls.push(payload.msgId),
+    notify: async (payload, reason) => notifications.push({ msgId: payload.msgId, reason }),
+    now: () => now,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+  now += 1000;
+  await monitor.onInbound(message("msg-2", 2));
+  now += 1000;
+  await monitor.onInbound(message("msg-3", 3));
+  now += 1000;
+  await monitor.onInbound(message("msg-4", 4));
+
+  assert.deepEqual(calls, ["msg-1", "msg-2"]);
+  assert.deepEqual(notifications.map((n) => n.msgId), ["msg-3", "msg-4"]);
+  assert.ok(notifications.every((n) => n.reason === "loop-breaker"));
+});
+
+test("WakeMonitor loop-breaker suspend clears after quiet window", async () => {
+  const calls = [];
+  const notifications = [];
+  let now = 1000;
+  const monitor = new WakeMonitor({
+    loopBreaker: { maxWakes: 1, windowMs: 60000 },
+    hook: async (payload) => calls.push(payload.msgId),
+    notify: async (payload, reason) => notifications.push({ msgId: payload.msgId, reason }),
+    now: () => now,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+  now += 1000;
+  await monitor.onInbound(message("msg-2", 2));
+  now += 61000;
+  await monitor.onInbound(message("msg-3", 3));
+
+  assert.deepEqual(calls, ["msg-1", "msg-3"]);
+  assert.deepEqual(notifications.map((n) => n.msgId), ["msg-2"]);
+});
+
+test("WakeMonitor audit deny skips hook", async () => {
+  const calls = [];
+  const monitor = new WakeMonitor({
+    auditHook: async () => "deny",
+    hook: async (payload) => calls.push(payload.msgId),
+    now: () => 1000,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+
+  assert.deepEqual(calls, []);
+});
+
+test("WakeMonitor audit require_approval skips hook and notifies", async () => {
+  const calls = [];
+  const notifications = [];
+  const monitor = new WakeMonitor({
+    auditHook: async () => "require_approval",
+    hook: async (payload) => calls.push(payload.msgId),
+    notify: async (payload, reason) => notifications.push({ msgId: payload.msgId, reason }),
+    now: () => 1000,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+
+  assert.deepEqual(calls, []);
+  assert.deepEqual(notifications, [{ msgId: "msg-1", reason: "require_approval" }]);
+});
+
+test("WakeMonitor audit allow calls hook", async () => {
+  const calls = [];
+  const monitor = new WakeMonitor({
+    auditHook: async () => "allow",
+    hook: async (payload) => calls.push(payload.msgId),
+    now: () => 1000,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+
+  assert.deepEqual(calls, ["msg-1"]);
+});


### PR DESCRIPTION
## Summary

Completes WakeMonitor Phase 2 guard coverage for #12:

- loop-breaker per sender
- audit-gate before wake hook
- notify fallback for suspended/approval-required wakes
- `seen` pruning so the cooldown map does not grow without bound

Guard order is now:

1. dedup
2. loop-breaker
3. audit-gate
4. wake hook

## Loop-breaker

Config:

```json
{
  "wake": {
    "loopBreaker": { "maxWakes": 5, "windowMs": 60000 }
  }
}
```

Defaults apply when the stanza is absent. If one sender exceeds `maxWakes` inside `windowMs`, auto-wake is suspended for that sender and WakeMonitor falls back to notify-only. Each suspended event extends the quiet window; auto-wake resumes after `windowMs` without events.

## Audit gate

Config:

```json
{
  "wake": {
    "auditHook": "path-or-command"
  }
}
```

If no audit hook is configured, the verdict defaults to `allow` for backward compatibility.

When configured, WakeMonitor runs the audit hook with the same env contract as wake hooks:

- `MURMUR_FROM`
- `MURMUR_TEXT`
- `MURMUR_MSG_ID`
- `MURMUR_CONVERSATION_ID`

The first stdout line is parsed as `allow`, `require_approval`, or `deny`:

- `allow`: call wake hook
- `deny`: drop and log
- `require_approval`: do not wake; enqueue notify and log

## Tests

Added deterministic unit coverage with injected clock:

- loop-breaker trips after `maxWakes` and suspends sender
- suspend clears after quiet window
- audit `deny` skips hook
- audit `require_approval` skips hook and notifies
- audit `allow` calls hook

## Verification

- `node --check scripts/wake-monitor.mjs`
- `node --check scripts/murmur-daemon.mjs`
- `npm run build`
- `npm run typecheck`
- `node --test tests/*.test.mjs` (34/34 pass)

Part of #12 (Phase 2)
