### PR TITLE
feat(wake): persistent-session wake (Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ node scripts/murmur-notify-init.mjs openclaw
 ## Testing
 
 ```bash
-npm test                          # Build + all unit tests (34 tests)
+npm test                          # Build + all unit tests (37 tests)
 npm run test:integration          # ACK correlation integration
 npm run test:notify-smoke         # Notification adapter smoke
 npm run test:openclaw-bridge-smoke # OpenClaw bridge smoke

--- a/scripts/murmur-daemon.mjs
+++ b/scripts/murmur-daemon.mjs
@@ -12,7 +12,7 @@ import { SQLiteDedupeOutboxStore, SQLiteMessageStore } from "@murmurv2/core";
 import { decryptPayload, encryptPayload, signEnvelope, verifyEnvelopeSignature } from "@murmurv2/security";
 import { NotifyQueue, flushNotifyQueue, normalizeNotifyTargets } from "./notify-router.mjs";
 import { OpenClawBridgeQueue, flushOpenClawBridgeQueue, normalizeOpenClawTargets } from "./openclaw-bridge.mjs";
-import { WakeMonitor, createAuditShellHook, createShellHook, normalizeWakeConfig } from "./wake-monitor.mjs";
+import { WakeMonitor, createAuditShellHook, createShellHook, createTmuxInjector, normalizeWakeConfig } from "./wake-monitor.mjs";
 // vault-guard: optional content policy hook (not included in OSS release)
 
 const log = (level, msg, data) => {
@@ -123,6 +123,7 @@ const wakeMonitor = new WakeMonitor({
   loadBacklogAfter: loadInboundAfter,
   auditHook: createAuditShellHook({ command: wakeConfig.auditHook, log }),
   hook: createShellHook({ command: config.onReceive, log }),
+  injector: createTmuxInjector({ log }),
   notify: enqueueWakeNotification,
   log,
 });
@@ -132,6 +133,7 @@ const proxyWakeMonitor = new WakeMonitor({
   initialCursor: inboundCursor(),
   auditHook: createAuditShellHook({ command: wakeConfig.auditHook, log }),
   hook: createShellHook({ command: config.proxyOnReceive, log }),
+  injector: createTmuxInjector({ log }),
   notify: enqueueWakeNotification,
   log,
 });

--- a/scripts/wake-monitor.mjs
+++ b/scripts/wake-monitor.mjs
@@ -1,14 +1,25 @@
 import { execFile } from "node:child_process";
 
 const ensureObject = (value) => (value && typeof value === "object" ? value : {});
+const validMode = (mode) => mode === "persistent" || mode === "stateless";
 
 export const normalizeWakeConfig = (config = {}) => {
   const wake = ensureObject(config.wake);
   const dedup = ensureObject(wake.dedup);
   const loopBreaker = ensureObject(wake.loopBreaker);
+  const peers = Object.fromEntries(
+    Object.entries(ensureObject(wake.peers)).map(([agentId, peer]) => {
+      const value = ensureObject(peer);
+      return [agentId, {
+        mode: validMode(value.mode) ? value.mode : undefined,
+        target: typeof value.target === "string" && value.target.trim() ? value.target.trim() : undefined,
+      }];
+    }),
+  );
   return {
     enabled: wake.enabled !== false,
-    mode: wake.mode || "stateless",
+    mode: validMode(wake.mode) ? wake.mode : "stateless",
+    peers,
     auditHook: typeof wake.auditHook === "string" && wake.auditHook.trim() ? wake.auditHook.trim() : null,
     dedup: {
       cooldownMs: Number.isFinite(Number(dedup.cooldownMs)) ? Number(dedup.cooldownMs) : 300000,
@@ -17,6 +28,18 @@ export const normalizeWakeConfig = (config = {}) => {
       maxWakes: Number.isFinite(Number(loopBreaker.maxWakes)) ? Number(loopBreaker.maxWakes) : 5,
       windowMs: Number.isFinite(Number(loopBreaker.windowMs)) ? Number(loopBreaker.windowMs) : 60000,
     },
+  };
+};
+
+export const createTmuxInjector = ({ exec = execFile, log = () => {} } = {}) => {
+  const run = (args) => new Promise((resolve, reject) => {
+    exec("tmux", args, (err) => err ? reject(err) : resolve());
+  });
+  return async (payload, peer) => {
+    if (!peer?.target) throw new Error(`wake-persistent-target-missing:${payload.from}`);
+    await run(["send-keys", "-t", peer.target, "-l", payload.text]);
+    await run(["send-keys", "-t", peer.target, "Enter"]);
+    log("info", "WakeMonitor persistent injected", { msgId: payload.msgId, target: peer.target });
   };
 };
 
@@ -66,12 +89,14 @@ export class WakeMonitor {
     const wakeConfig = normalizeWakeConfig({ wake: options });
     this.enabled = options.enabled ?? wakeConfig.enabled;
     this.mode = options.mode ?? wakeConfig.mode;
+    this.peers = options.peers ?? wakeConfig.peers;
     this.cooldownMs = options.dedup?.cooldownMs ?? wakeConfig.dedup.cooldownMs;
     this.loopBreaker = {
       maxWakes: options.loopBreaker?.maxWakes ?? wakeConfig.loopBreaker.maxWakes,
       windowMs: options.loopBreaker?.windowMs ?? wakeConfig.loopBreaker.windowMs,
     };
     this.hook = options.hook || null;
+    this.injector = options.injector || null;
     this.auditHook = options.auditHook || null;
     this.notify = options.notify || null;
     this.loadBacklogAfter = options.loadBacklogAfter || null;
@@ -87,7 +112,7 @@ export class WakeMonitor {
   }
 
   async onInbound(payload) {
-    if (!this.enabled || this.mode !== "stateless") return;
+    if (!this.enabled) return;
     this.enqueue(payload);
     await this.drain();
   }
@@ -152,8 +177,15 @@ export class WakeMonitor {
     }
 
     try {
-      if (this.hook) await this.hook(payload);
-      this.log("info", "WakeMonitor hook completed", { msgId: payload.msgId, conversationId: payload.conversationId });
+      const peer = this.peerFor(payload);
+      if (peer.mode === "persistent") {
+        if (!this.injector) throw new Error(`wake-persistent-injector-missing:${payload.from}`);
+        await this.injector(payload, peer);
+        this.log("info", "WakeMonitor persistent wake completed", { msgId: payload.msgId, conversationId: payload.conversationId, target: peer.target });
+      } else {
+        if (this.hook) await this.hook(payload);
+        this.log("info", "WakeMonitor hook completed", { msgId: payload.msgId, conversationId: payload.conversationId });
+      }
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       this.log("warn", "WakeMonitor hook error", { error: e.message, msgId: payload.msgId });
@@ -209,5 +241,13 @@ export class WakeMonitor {
 
   keyFor(payload) {
     return payload.msgId;
+  }
+
+  peerFor(payload) {
+    const peer = ensureObject(this.peers?.[payload.from]);
+    return {
+      ...peer,
+      mode: validMode(peer.mode) ? peer.mode : this.mode,
+    };
   }
 }

--- a/tests/wake-persistent.test.mjs
+++ b/tests/wake-persistent.test.mjs
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { WakeMonitor } from "../scripts/wake-monitor.mjs";
+
+const message = (msgId, cursor, from = "agent-a") => ({
+  from,
+  text: `payload:${msgId}`,
+  msgId,
+  conversationId: "conv-persistent",
+  ts: `2026-06-20T00:02:${String(cursor).padStart(2, "0")}.000Z`,
+  cursor,
+});
+
+test("WakeMonitor persistent mode injects text and a separate Enter event", async () => {
+  const events = [];
+  const monitor = new WakeMonitor({
+    peers: { "agent-a": { mode: "persistent", target: "codex:1" } },
+    injector: async (payload, peer) => {
+      events.push({ type: "text", target: peer.target, text: payload.text });
+      events.push({ type: "enter", target: peer.target });
+    },
+    now: () => 1000,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+
+  assert.deepEqual(events, [
+    { type: "text", target: "codex:1", text: "payload:msg-1" },
+    { type: "enter", target: "codex:1" },
+  ]);
+});
+
+test("WakeMonitor persistent mode is gated by dedup, loop-breaker, and audit", async () => {
+  const injected = [];
+  const notifications = [];
+  let now = 1000;
+  const monitor = new WakeMonitor({
+    peers: { "agent-a": { mode: "persistent", target: "codex:1" } },
+    dedup: { cooldownMs: 300000 },
+    loopBreaker: { maxWakes: 1, windowMs: 60000 },
+    auditHook: async (payload) => payload.msgId === "msg-deny" ? "deny" : "allow",
+    injector: async (payload) => injected.push(payload.msgId),
+    notify: async (payload, reason) => notifications.push({ msgId: payload.msgId, reason }),
+    now: () => now,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+  now += 1000;
+  await monitor.onInbound(message("msg-1", 2));
+  now += 1000;
+  await monitor.onInbound(message("msg-2", 3));
+  now += 61000;
+  await monitor.onInbound(message("msg-deny", 4));
+
+  assert.deepEqual(injected, ["msg-1"]);
+  assert.deepEqual(notifications, [{ msgId: "msg-2", reason: "loop-breaker" }]);
+});
+
+test("WakeMonitor keeps stateless peers on hook path", async () => {
+  const hooks = [];
+  const injected = [];
+  const monitor = new WakeMonitor({
+    peers: { "agent-a": { mode: "stateless" } },
+    hook: async (payload) => hooks.push(payload.msgId),
+    injector: async (payload) => injected.push(payload.msgId),
+    now: () => 1000,
+  });
+
+  await monitor.onInbound(message("msg-1", 1));
+
+  assert.deepEqual(hooks, ["msg-1"]);
+  assert.deepEqual(injected, []);
+});


### PR DESCRIPTION
## Summary

Adds WakeMonitor persistent-session mode, opt-in per peer, so a Murmur inbound can wake an existing live agent session with its current context instead of spawning a fresh stateless hook.

This is the final mandatory monitor phase for #12.

## Persistent mode config

Default remains stateless/backward-compatible. Persistent wake is strictly opt-in per peer:

```json
{
  "wake": {
    "peers": {
      "agent-codex-volt": {
        "mode": "persistent",
        "target": "tmux-session:pane"
      }
    }
  }
}
```

No live environment session mapping is guessed in this PR. The operator must provide the exact tmux target for each peer.

## tmux injector

`createTmuxInjector()` sends text to the configured tmux pane using the safe two-command pattern:

1. `tmux send-keys -t <target> -l <text>`
2. `tmux send-keys -t <target> Enter`

This keeps `Enter` as a key event rather than literal text.

## Guard behavior

All existing WakeMonitor guards apply before persistent injection:

1. dedup
2. loop-breaker
3. audit-gate
4. injector

Stateless peers still use the existing hook path.

## Session mapping proposal

For production rollout, keep mapping explicit and operator-owned:

```json
{
  "wake": {
    "peers": {
      "agent-codex-volt": { "mode": "persistent", "target": "codex-volt:0.0" },
      "agent-jarvis": { "mode": "persistent", "target": "jarvis:0.0" }
    }
  }
}
```

Do not autodetect tmux panes in this PR: live session identity is operational state and should be configured deliberately.

## Tests

Added deterministic tests with a mocked injector:

- persistent mode injects text and a separate Enter event
- persistent mode is gated by dedup, loop-breaker, and audit
- stateless peers stay on the hook path

## Verification

- `node --check scripts/wake-monitor.mjs`
- `node --check scripts/murmur-daemon.mjs`
- `npm run build`
- `npm run typecheck`
- `node --test tests/*.test.mjs` (37/37 pass)

Closes #12
