### PR TITLE
feat(wake): native Codex app-server UDS wake

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ node scripts/murmur-notify-init.mjs openclaw
 ## Testing
 
 ```bash
-npm test                          # Build + all unit tests (40 tests)
+npm test                          # Build + all unit tests (44 tests)
 npm run test:integration          # ACK correlation integration
 npm run test:notify-smoke         # Notification adapter smoke
 npm run test:openclaw-bridge-smoke # OpenClaw bridge smoke

--- a/docs/wake-native.md
+++ b/docs/wake-native.md
@@ -41,8 +41,46 @@ Drain semantics:
 Codex is woken over the `codex app-server` Unix-socket transport
 (`--listen unix://…`): a NATS subscriber acts as a JSON-RPC client and issues
 `turn/start` on the live thread when a Murmur message arrives. Replaces the old
-`codex-murmur-watch` polling. Implementation lands separately from the
-Claude-side drain.
+`codex-murmur-watch` polling.
+
+Codex runtime facts verified against Codex CLI `0.141.0`:
+
+- `codex app-server --help` is present.
+- `--listen unix://PATH` is supported.
+- `codex app-server generate-ts --experimental` exposes JSON-RPC method
+  `turn/start` with `TurnStartParams { threadId, input }`.
+
+Configure a Codex peer as a persistent app-server wake target:
+
+```json
+{
+  "wake": {
+    "peers": {
+      "agent-jarvis": {
+        "mode": "codex_app_server",
+        "socketPath": "/home/codexworker/.codex/app-server.sock",
+        "threadId": "thread-id-of-live-codex-session"
+      }
+    }
+  }
+}
+```
+
+The daemon sends:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "turn/start",
+  "params": {
+    "threadId": "...",
+    "input": [{ "type": "text", "text": "[MURMUR WAKE]...", "text_elements": [] }]
+  }
+}
+```
+
+If the Unix socket or live `threadId` is absent, wake fails loud in daemon logs
+instead of silently falling back to polling.
 
 ## Why not tmux / OpenClaw
 

--- a/scripts/codex-app-server-wake.mjs
+++ b/scripts/codex-app-server-wake.mjs
@@ -1,0 +1,121 @@
+import net from "node:net";
+
+const DEFAULT_TIMEOUT_MS = 10000;
+
+export const buildCodexTurnText = (payload) => {
+  const lines = [
+    "[MURMUR WAKE]",
+    `from=${payload.from || "unknown"}`,
+    `conversationId=${payload.conversationId || ""}`,
+    `msgId=${payload.msgId || ""}`,
+    "",
+    payload.text || "",
+  ];
+  return lines.join("\n");
+};
+
+export const buildTurnStartRequest = ({ id = 1, threadId, text, metadata = {} }) => ({
+  jsonrpc: "2.0",
+  id,
+  method: "turn/start",
+  params: {
+    threadId,
+    input: [{ type: "text", text, text_elements: [] }],
+    responsesapiClientMetadata: metadata,
+  },
+});
+
+export class CodexAppServerClient {
+  constructor({ socketPath, timeoutMs = DEFAULT_TIMEOUT_MS, connect = net.createConnection } = {}) {
+    if (!socketPath) throw new Error("codex-app-server-socket-missing");
+    this.socketPath = socketPath;
+    this.timeoutMs = timeoutMs;
+    this.connect = connect;
+    this.nextId = 1;
+  }
+
+  request(method, params) {
+    const id = this.nextId++;
+    const request = { jsonrpc: "2.0", id, method, params };
+    return this.send(request, id);
+  }
+
+  send(request, expectedId = request.id) {
+    return new Promise((resolve, reject) => {
+      let buffer = "";
+      const socket = this.connect({ path: this.socketPath });
+      const timer = setTimeout(() => {
+        socket.destroy();
+        reject(new Error(`codex-app-server-timeout:${this.socketPath}`));
+      }, this.timeoutMs);
+
+      const cleanup = () => clearTimeout(timer);
+      socket.setEncoding("utf8");
+      socket.on("connect", () => {
+        socket.write(`${JSON.stringify(request)}\n`);
+      });
+      socket.on("data", (chunk) => {
+        buffer += chunk;
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          let message;
+          try {
+            message = JSON.parse(line);
+          } catch {
+            continue;
+          }
+          if (message.id !== expectedId) continue;
+          cleanup();
+          socket.end();
+          if (message.error) {
+            reject(new Error(`codex-app-server-error:${message.error.message || JSON.stringify(message.error)}`));
+          } else {
+            resolve(message.result);
+          }
+        }
+      });
+      socket.on("error", (err) => {
+        cleanup();
+        reject(new Error(`codex-app-server-connect-failed:${this.socketPath}:${err.message}`));
+      });
+      socket.on("close", () => {
+        cleanup();
+        if (!buffer.trim()) return;
+        try {
+          const message = JSON.parse(buffer);
+          if (message.id === expectedId) {
+            if (message.error) reject(new Error(`codex-app-server-error:${message.error.message || JSON.stringify(message.error)}`));
+            else resolve(message.result);
+          }
+        } catch {
+          reject(new Error(`codex-app-server-closed-with-partial-response:${this.socketPath}`));
+        }
+      });
+    });
+  }
+}
+
+export const createCodexAppServerInjector = ({ Client = CodexAppServerClient, log = () => {}, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) => {
+  return async (payload, peer) => {
+    const socketPath = peer?.socketPath || peer?.target;
+    const threadId = peer?.threadId;
+    if (!socketPath) throw new Error(`codex-app-server-socket-missing:${payload.from}`);
+    if (!threadId) throw new Error(`codex-app-server-thread-missing:${payload.from}`);
+
+    const client = new Client({ socketPath, timeoutMs });
+    const text = buildCodexTurnText(payload);
+    const result = await client.request("turn/start", {
+      threadId,
+      input: [{ type: "text", text, text_elements: [] }],
+      responsesapiClientMetadata: {
+        murmur_msg_id: payload.msgId || "",
+        murmur_conversation_id: payload.conversationId || "",
+        murmur_from: payload.from || "",
+      },
+    });
+    log("info", "Codex app-server wake completed", { msgId: payload.msgId, threadId, socketPath });
+    return result;
+  };
+};

--- a/scripts/murmur-daemon.mjs
+++ b/scripts/murmur-daemon.mjs
@@ -12,6 +12,7 @@ import { SQLiteDedupeOutboxStore, SQLiteMessageStore } from "@murmurv2/core";
 import { decryptPayload, encryptPayload, signEnvelope, verifyEnvelopeSignature } from "@murmurv2/security";
 import { NotifyQueue, flushNotifyQueue, normalizeNotifyTargets } from "./notify-router.mjs";
 import { OpenClawBridgeQueue, flushOpenClawBridgeQueue, normalizeOpenClawTargets } from "./openclaw-bridge.mjs";
+import { createCodexAppServerInjector } from "./codex-app-server-wake.mjs";
 import { WakeMonitor, createAuditShellHook, createShellHook, createTmuxInjector, normalizeWakeConfig } from "./wake-monitor.mjs";
 // vault-guard: optional content policy hook (not included in OSS release)
 
@@ -123,7 +124,12 @@ const wakeMonitor = new WakeMonitor({
   loadBacklogAfter: loadInboundAfter,
   auditHook: createAuditShellHook({ command: wakeConfig.auditHook, log }),
   hook: createShellHook({ command: config.onReceive, log }),
-  injector: createTmuxInjector({ log }),
+  injector: async (payload, peer) => {
+    if (peer.mode === "codex_app_server") {
+      return createCodexAppServerInjector({ log })(payload, peer);
+    }
+    return createTmuxInjector({ log })(payload, peer);
+  },
   notify: enqueueWakeNotification,
   log,
 });
@@ -133,7 +139,12 @@ const proxyWakeMonitor = new WakeMonitor({
   initialCursor: inboundCursor(),
   auditHook: createAuditShellHook({ command: wakeConfig.auditHook, log }),
   hook: createShellHook({ command: config.proxyOnReceive, log }),
-  injector: createTmuxInjector({ log }),
+  injector: async (payload, peer) => {
+    if (peer.mode === "codex_app_server") {
+      return createCodexAppServerInjector({ log })(payload, peer);
+    }
+    return createTmuxInjector({ log })(payload, peer);
+  },
   notify: enqueueWakeNotification,
   log,
 });

--- a/scripts/wake-monitor.mjs
+++ b/scripts/wake-monitor.mjs
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 
 const ensureObject = (value) => (value && typeof value === "object" ? value : {});
-const validMode = (mode) => mode === "persistent" || mode === "stateless";
+const validMode = (mode) => mode === "persistent" || mode === "stateless" || mode === "codex_app_server";
 
 export const normalizeWakeConfig = (config = {}) => {
   const wake = ensureObject(config.wake);
@@ -13,6 +13,8 @@ export const normalizeWakeConfig = (config = {}) => {
       return [agentId, {
         mode: validMode(value.mode) ? value.mode : undefined,
         target: typeof value.target === "string" && value.target.trim() ? value.target.trim() : undefined,
+        socketPath: typeof value.socketPath === "string" && value.socketPath.trim() ? value.socketPath.trim() : undefined,
+        threadId: typeof value.threadId === "string" && value.threadId.trim() ? value.threadId.trim() : undefined,
       }];
     }),
   );
@@ -178,7 +180,7 @@ export class WakeMonitor {
 
     try {
       const peer = this.peerFor(payload);
-      if (peer.mode === "persistent") {
+      if (peer.mode === "persistent" || peer.mode === "codex_app_server") {
         if (!this.injector) throw new Error(`wake-persistent-injector-missing:${payload.from}`);
         await this.injector(payload, peer);
         this.log("info", "WakeMonitor persistent wake completed", { msgId: payload.msgId, conversationId: payload.conversationId, target: peer.target });

--- a/tests/codex-app-server-wake.test.mjs
+++ b/tests/codex-app-server-wake.test.mjs
@@ -1,0 +1,103 @@
+import net from "node:net";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { WakeMonitor, normalizeWakeConfig } from "../scripts/wake-monitor.mjs";
+import { buildCodexTurnText, CodexAppServerClient, createCodexAppServerInjector } from "../scripts/codex-app-server-wake.mjs";
+
+const payload = {
+  from: "agent-jarvis",
+  text: "hello codex",
+  msgId: "msg-codex-1",
+  conversationId: "codex:task:test",
+  cursor: 1,
+};
+
+test("normalizeWakeConfig accepts Codex app-server peer settings", () => {
+  const config = normalizeWakeConfig({
+    wake: {
+      peers: {
+        "agent-jarvis": {
+          mode: "codex_app_server",
+          socketPath: "/tmp/codex.sock",
+          threadId: "thread-1",
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(config.peers["agent-jarvis"], {
+    mode: "codex_app_server",
+    target: undefined,
+    socketPath: "/tmp/codex.sock",
+    threadId: "thread-1",
+  });
+});
+
+test("Codex app-server injector sends turn/start over Unix socket", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-codex-wake-"));
+  const socketPath = path.join(dir, "codex.sock");
+  const received = [];
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      for (const line of chunk.split(/\r?\n/).filter(Boolean)) {
+        const request = JSON.parse(line);
+        received.push(request);
+        socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { turn: { id: "turn-1" } } })}\n`);
+      }
+    });
+  });
+  server.listen(socketPath);
+  await once(server, "listening");
+
+  const client = new CodexAppServerClient({ socketPath });
+  const result = await client.request("turn/start", {
+    threadId: "thread-1",
+    input: [{ type: "text", text: buildCodexTurnText(payload), text_elements: [] }],
+  });
+
+  server.close();
+  assert.deepEqual(result, { turn: { id: "turn-1" } });
+  assert.equal(received[0].method, "turn/start");
+  assert.equal(received[0].params.threadId, "thread-1");
+  assert.match(received[0].params.input[0].text, /msgId=msg-codex-1/);
+  assert.match(received[0].params.input[0].text, /hello codex/);
+});
+
+test("WakeMonitor gates Codex app-server wake before injector", async () => {
+  const injected = [];
+  let now = 1000;
+  const monitor = new WakeMonitor({
+    peers: {
+      "agent-jarvis": {
+        mode: "codex_app_server",
+        socketPath: "/tmp/codex.sock",
+        threadId: "thread-1",
+      },
+    },
+    dedup: { cooldownMs: 300000 },
+    loopBreaker: { maxWakes: 1, windowMs: 60000 },
+    auditHook: async (item) => item.msgId === "msg-deny" ? "deny" : "allow",
+    injector: async (item, peer) => injected.push({ msgId: item.msgId, mode: peer.mode, threadId: peer.threadId }),
+    now: () => now,
+  });
+
+  await monitor.onInbound(payload);
+  now += 1000;
+  await monitor.onInbound({ ...payload, cursor: 2 });
+  now += 61000;
+  await monitor.onInbound({ ...payload, msgId: "msg-deny", cursor: 3 });
+
+  assert.deepEqual(injected, [{ msgId: "msg-codex-1", mode: "codex_app_server", threadId: "thread-1" }]);
+});
+
+test("Codex app-server injector fails loud without socket or thread", async () => {
+  const injector = createCodexAppServerInjector();
+
+  await assert.rejects(() => injector(payload, { mode: "codex_app_server", threadId: "thread-1" }), /socket-missing/);
+  await assert.rejects(() => injector(payload, { mode: "codex_app_server", socketPath: "/tmp/codex.sock" }), /thread-missing/);
+});


### PR DESCRIPTION
Part of #25

Facts verified locally:
- `codex --version`: codex-cli 0.141.0.
- `codex app-server --help`: present.
- `codex app-server --listen unix://PATH`: supported by help output.
- `codex app-server generate-ts --experimental`: exposes `turn/start` with `TurnStartParams { threadId, input }`.
- Current runtime has no active control socket at `/home/codexworker/.codex/app-server-control/app-server-control.sock`, so live turn injection was not run from this session.

This PR adds the daemon wiring and fake Unix socket tests; runtime config still needs a live app-server socket path plus live Codex threadId.