### PR TITLE
[codex] use WS-over-UDS for Codex app-server wake

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Murmur V2 wakes agents through native runtime mechanisms instead of tmux or
 OpenClaw:
 
 - Claude Code: `asyncRewake` hook via `scripts/wake-drain-claude.sh`.
-- Codex CLI: app-server Unix socket JSON-RPC `turn/start` via
+- Codex CLI: app-server WS-over-UDS `turn/start` via
   `scripts/codex-app-server-wake.mjs`.
 - Human notification remains on Telegram/webhook notify queues.
 

--- a/docs/wake-native.md
+++ b/docs/wake-native.md
@@ -36,17 +36,20 @@ Drain semantics:
   drain, so repeated hook invocations do not double-wake the same message.
 - Cursor writes use a temporary file plus rename where the filesystem allows it.
 
-## Codex CLI - App-Server UDS
+## Codex CLI - App-Server WS-over-UDS
 
-Codex is woken over the `codex app-server` Unix-socket transport
-(`--listen unix://…`): a NATS subscriber acts as a JSON-RPC client and issues
-`turn/start` on the live thread when a Murmur message arrives. Replaces the old
-`codex-murmur-watch` polling.
+Codex is woken over the `codex app-server` WebSocket protocol on a Unix-domain
+socket (`--listen unix://...` or managed remote-control socket): the daemon acts
+as a WebSocket client, sends the app-server `initialize` handshake, and then
+issues `turn/start` on the live thread when a Murmur message arrives. This
+replaces the old `codex-murmur-watch` polling path.
 
 Codex runtime facts verified against Codex CLI `0.141.0`:
 
 - `codex app-server --help` is present.
-- `--listen unix://PATH` is supported.
+- `--listen unix://PATH` and `--remote unix://PATH` are supported.
+- `codex remote-control start --json` is idempotent and returns
+  `.daemon.socketPath`.
 - `codex app-server generate-ts --experimental` exposes JSON-RPC method
   `turn/start` with `TurnStartParams { threadId, input }`.
 
@@ -66,11 +69,24 @@ Configure a Codex peer as an app-server wake target:
 }
 ```
 
-The daemon sends:
+The daemon connects with a `ws+unix://SOCKET:/` client URL. It first sends:
 
 ```json
 {
-  "jsonrpc": "2.0",
+  "id": "init-1",
+  "method": "initialize",
+  "params": {
+    "clientInfo": { "name": "murmur-codex-app-server-wake" },
+    "capabilities": { "experimentalApi": true, "requestAttestation": false }
+  }
+}
+```
+
+After the app-server responds, the daemon sends `initialized` and then:
+
+```json
+{
+  "id": 1,
   "method": "turn/start",
   "params": {
     "threadId": "...",
@@ -84,6 +100,93 @@ instead of silently falling back to polling.
 
 The previous `persistent` tmux backend has been removed from the wake path.
 Native wake modes are `stateless` shell hooks and `codex_app_server`.
+
+### Codex Autostart Sequence
+
+Autostart belongs in the Codex launcher wrapper, not in the Murmur daemon. The
+launcher owns the live TUI process and is the only layer that can know which
+session thread was just attached.
+
+1. Start or attach the managed app-server before launching the TUI:
+
+   ```bash
+   codex remote-control start --json
+   ```
+
+   Parse `.daemon.socketPath` from stdout. Current Codex `0.141.0` returns a
+   shape like:
+
+   ```json
+   {
+     "status": "connected",
+     "daemon": {
+       "status": "alreadyRunning",
+       "socketPath": "/home/codexworker/.codex/app-server-control/app-server-control.sock"
+     }
+   }
+   ```
+
+2. Launch the interactive session against that socket:
+
+   ```bash
+   codex --remote "unix://${CODEX_APP_SERVER_SOCKET}" "$@"
+   ```
+
+   For the vault launcher, this belongs in the session startup entrypoint that
+   wraps the real Codex process, not in `codexx` if that wrapper is intentionally
+   kept as a dumb `cd && exec codex "$@"` launcher.
+
+3. Capture the live `threadId` automatically after the remote session starts.
+   Codex writes session JSONL under
+   `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl`. The first line is a
+   `session_meta` event; use `.payload.id` as the app-server `threadId`. The
+   same UUID is embedded in the rollout file name, but the JSONL field is the
+   stable capture point.
+
+   Launcher implementation sketch:
+
+   ```bash
+   session_file="$(ls -t "$CODEX_HOME"/sessions/*/*/*/rollout-*.jsonl | head -n 1)"
+   thread_id="$(head -n 1 "$session_file" | jq -r 'select(.type=="session_meta") | .payload.id')"
+   ```
+
+   A production launcher should filter by launch timestamp and current `$PWD`
+   (`.payload.cwd`) before accepting the file, so parallel Codex sessions do not
+   race the capture.
+
+4. Wire the Codex peer in the agent config before daemon restart:
+
+   ```json
+   {
+     "wake": {
+       "peers": {
+         "agent-jarvis": {
+           "mode": "codex_app_server",
+           "socketPath": "/home/codexworker/.codex/app-server-control/app-server-control.sock",
+           "threadId": "019ee8b4-382a-76c3-a266-16056dc6108b"
+         }
+       }
+     }
+   }
+   ```
+
+   For the Codex worker deployment, the target file is
+   `.data-codex-volt/agent-config.json`. Update it atomically: write a temporary
+   JSON file, validate it with `jq empty`, then rename over the old config.
+
+5. Restart the Murmur daemon after the config write:
+
+   ```bash
+   sudo systemctl restart murmur-daemon
+   ```
+
+   If the daemon is run directly instead of systemd, stop the old process and
+   start `node scripts/murmur-daemon.mjs` with the same `DATA_DIR` and
+   environment. The daemon reads `wake.peers` only at startup.
+
+With those five steps in the launcher, a new Codex session brings up remote
+control, captures its own app-server thread, wires Murmur wake routing, and
+restarts the daemon without a manual copy/paste step.
 
 ## Why not tmux / OpenClaw
 

--- a/docs/wake-native.md
+++ b/docs/wake-native.md
@@ -103,6 +103,15 @@ Native wake modes are `stateless` shell hooks and `codex_app_server`.
 
 ### Codex Autostart Sequence
 
+> **Diagnostic / opt-in only.** This sequence only covers
+> app-server-managed Codex sessions launched with `--remote`. It is not a
+> community-grade native wake solution: plain `codex` and desktop-launched Codex
+> sessions are not covered because Codex app-server instances are isolated per
+> client and currently do not talk to each other. Keep issue #25 open for the
+> real product goal. The strategic community-grade path is MCP-channel wake:
+> MCP custom notification -> active-session user submission through a supported
+> `[mcp_servers]` configuration surface.
+
 Autostart belongs in the Codex launcher wrapper, not in the Murmur daemon. The
 launcher owns the live TUI process and is the only layer that can know which
 session thread was just attached.

--- a/scripts/codex-app-server-wake.mjs
+++ b/scripts/codex-app-server-wake.mjs
@@ -1,6 +1,7 @@
-import net from "node:net";
+import WebSocket from "ws";
 
 const DEFAULT_TIMEOUT_MS = 10000;
+const INITIALIZE_TIMEOUT_MS = 10000;
 
 export const buildCodexTurnText = (payload) => {
   const lines = [
@@ -15,7 +16,6 @@ export const buildCodexTurnText = (payload) => {
 };
 
 export const buildTurnStartRequest = ({ id = 1, threadId, text, metadata = {} }) => ({
-  jsonrpc: "2.0",
   id,
   method: "turn/start",
   params: {
@@ -25,73 +25,106 @@ export const buildTurnStartRequest = ({ id = 1, threadId, text, metadata = {} })
   },
 });
 
+const buildInitializeRequest = (id) => ({
+  id,
+  method: "initialize",
+  params: {
+    clientInfo: {
+      name: "murmur-codex-app-server-wake",
+      title: "Murmur Codex App-Server Wake",
+      version: "0.1.0",
+    },
+    capabilities: {
+      experimentalApi: true,
+      requestAttestation: false,
+      optOutNotificationMethods: [
+        "command/exec/outputDelta",
+        "item/agentMessage/delta",
+        "item/plan/delta",
+        "item/fileChange/outputDelta",
+        "item/reasoning/summaryTextDelta",
+        "item/reasoning/textDelta",
+      ],
+    },
+  },
+});
+
 export class CodexAppServerClient {
-  constructor({ socketPath, timeoutMs = DEFAULT_TIMEOUT_MS, connect = net.createConnection } = {}) {
+  constructor({ socketPath, timeoutMs = DEFAULT_TIMEOUT_MS, WebSocketImpl = WebSocket } = {}) {
     if (!socketPath) throw new Error("codex-app-server-socket-missing");
     this.socketPath = socketPath;
     this.timeoutMs = timeoutMs;
-    this.connect = connect;
+    this.WebSocketImpl = WebSocketImpl;
     this.nextId = 1;
   }
 
   request(method, params) {
     const id = this.nextId++;
-    const request = { jsonrpc: "2.0", id, method, params };
+    const request = { id, method, params };
     return this.send(request, id);
   }
 
   send(request, expectedId = request.id) {
     return new Promise((resolve, reject) => {
-      let buffer = "";
-      const socket = this.connect({ path: this.socketPath });
+      let settled = false;
+      let initialized = false;
+      const initId = `init-${this.nextId++}`;
+      const url = `ws+unix://${this.socketPath}:/`;
+      const socket = new this.WebSocketImpl(url, {
+        perMessageDeflate: false,
+        handshakeTimeout: Math.min(this.timeoutMs, INITIALIZE_TIMEOUT_MS),
+      });
       const timer = setTimeout(() => {
-        socket.destroy();
-        reject(new Error(`codex-app-server-timeout:${this.socketPath}`));
+        finish(new Error(`codex-app-server-timeout:${this.socketPath}`));
       }, this.timeoutMs);
 
-      const cleanup = () => clearTimeout(timer);
-      socket.setEncoding("utf8");
-      socket.on("connect", () => {
-        socket.write(`${JSON.stringify(request)}\n`);
-      });
-      socket.on("data", (chunk) => {
-        buffer += chunk;
-        const lines = buffer.split(/\r?\n/);
-        buffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (!line.trim()) continue;
-          let message;
-          try {
-            message = JSON.parse(line);
-          } catch {
-            continue;
-          }
-          if (message.id !== expectedId) continue;
-          cleanup();
-          socket.end();
+      const finish = (err, result) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try {
+          socket.close();
+        } catch {
+          // Ignore close races; the request already has a terminal result.
+        }
+        if (err) reject(err);
+        else resolve(result);
+      };
+
+      const sendJson = (message) => socket.send(JSON.stringify(message));
+
+      socket.on("open", () => sendJson(buildInitializeRequest(initId)));
+      socket.on("message", (data) => {
+        let message;
+        try {
+          message = JSON.parse(data.toString("utf8"));
+        } catch {
+          return;
+        }
+
+        if (message.id === initId) {
           if (message.error) {
-            reject(new Error(`codex-app-server-error:${message.error.message || JSON.stringify(message.error)}`));
-          } else {
-            resolve(message.result);
+            finish(new Error(`codex-app-server-initialize-error:${message.error.message || JSON.stringify(message.error)}`));
+            return;
           }
+          initialized = true;
+          sendJson({ method: "initialized" });
+          sendJson(request);
+          return;
+        }
+
+        if (message.id !== expectedId) return;
+        if (message.error) {
+          finish(new Error(`codex-app-server-error:${message.error.message || JSON.stringify(message.error)}`));
+        } else {
+          finish(null, message.result);
         }
       });
       socket.on("error", (err) => {
-        cleanup();
-        reject(new Error(`codex-app-server-connect-failed:${this.socketPath}:${err.message}`));
+        finish(new Error(`codex-app-server-connect-failed:${this.socketPath}:${err.message}`));
       });
       socket.on("close", () => {
-        cleanup();
-        if (!buffer.trim()) return;
-        try {
-          const message = JSON.parse(buffer);
-          if (message.id === expectedId) {
-            if (message.error) reject(new Error(`codex-app-server-error:${message.error.message || JSON.stringify(message.error)}`));
-            else resolve(message.result);
-          }
-        } catch {
-          reject(new Error(`codex-app-server-closed-with-partial-response:${this.socketPath}`));
-        }
+        if (!settled) finish(new Error(`codex-app-server-closed-before-response:${this.socketPath}:${initialized ? "after-initialize" : "before-initialize"}`));
       });
     });
   }

--- a/tests/codex-app-server-wake.test.mjs
+++ b/tests/codex-app-server-wake.test.mjs
@@ -1,12 +1,13 @@
-import net from "node:net";
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 import { once } from "node:events";
+import { WebSocketServer } from "ws";
 import { WakeMonitor, normalizeWakeConfig } from "../scripts/wake-monitor.mjs";
-import { buildCodexTurnText, CodexAppServerClient, createCodexAppServerInjector } from "../scripts/codex-app-server-wake.mjs";
+import { buildCodexTurnText, buildTurnStartRequest, CodexAppServerClient, createCodexAppServerInjector } from "../scripts/codex-app-server-wake.mjs";
 
 const payload = {
   from: "agent-jarvis",
@@ -36,22 +37,42 @@ test("normalizeWakeConfig accepts Codex app-server peer settings", () => {
   });
 });
 
-test("Codex app-server injector sends turn/start over Unix socket", async () => {
+test("buildTurnStartRequest builds Codex turn/start params", () => {
+  const request = buildTurnStartRequest({
+    id: 7,
+    threadId: "thread-1",
+    text: buildCodexTurnText(payload),
+    metadata: { murmur_msg_id: payload.msgId },
+  });
+
+  assert.equal(request.id, 7);
+  assert.equal(request.method, "turn/start");
+  assert.equal(request.params.threadId, "thread-1");
+  assert.equal(request.params.responsesapiClientMetadata.murmur_msg_id, payload.msgId);
+  assert.match(request.params.input[0].text, /msgId=msg-codex-1/);
+});
+
+test("Codex app-server client initializes before turn/start over WS-over-UDS", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-codex-wake-"));
   const socketPath = path.join(dir, "codex.sock");
   const received = [];
-  const server = net.createServer((socket) => {
-    socket.setEncoding("utf8");
-    socket.on("data", (chunk) => {
-      for (const line of chunk.split(/\r?\n/).filter(Boolean)) {
-        const request = JSON.parse(line);
-        received.push(request);
-        socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { turn: { id: "turn-1" } } })}\n`);
+  const httpServer = http.createServer();
+  const wsServer = new WebSocketServer({ server: httpServer });
+
+  wsServer.on("connection", (socket) => {
+    socket.on("message", (data) => {
+      const request = JSON.parse(data.toString("utf8"));
+      received.push(request);
+      if (request.method === "initialize") {
+        socket.send(JSON.stringify({ id: request.id, result: { protocolVersion: "0.1.0" } }));
+      }
+      if (request.method === "turn/start") {
+        socket.send(JSON.stringify({ id: request.id, result: { turn: { id: "turn-1" } } }));
       }
     });
   });
-  server.listen(socketPath);
-  await once(server, "listening");
+  httpServer.listen(socketPath);
+  await once(httpServer, "listening");
 
   const client = new CodexAppServerClient({ socketPath });
   const result = await client.request("turn/start", {
@@ -59,12 +80,66 @@ test("Codex app-server injector sends turn/start over Unix socket", async () => 
     input: [{ type: "text", text: buildCodexTurnText(payload), text_elements: [] }],
   });
 
-  server.close();
+  wsServer.close();
+  httpServer.close();
+
   assert.deepEqual(result, { turn: { id: "turn-1" } });
-  assert.equal(received[0].method, "turn/start");
-  assert.equal(received[0].params.threadId, "thread-1");
-  assert.match(received[0].params.input[0].text, /msgId=msg-codex-1/);
-  assert.match(received[0].params.input[0].text, /hello codex/);
+  assert.equal(received[0].method, "initialize");
+  assert.equal(received[0].params.clientInfo.name, "murmur-codex-app-server-wake");
+  assert.equal(received[1].method, "initialized");
+  assert.equal(received[2].method, "turn/start");
+  assert.equal(received[2].params.threadId, "thread-1");
+  assert.match(received[2].params.input[0].text, /msgId=msg-codex-1/);
+  assert.match(received[2].params.input[0].text, /hello codex/);
+});
+
+test("Codex app-server client fails loud on initialize errors", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-codex-wake-"));
+  const socketPath = path.join(dir, "codex.sock");
+  const httpServer = http.createServer();
+  const wsServer = new WebSocketServer({ server: httpServer });
+
+  wsServer.on("connection", (socket) => {
+    socket.on("message", (data) => {
+      const request = JSON.parse(data.toString("utf8"));
+      if (request.method === "initialize") {
+        socket.send(JSON.stringify({ id: request.id, error: { message: "denied" } }));
+      }
+    });
+  });
+  httpServer.listen(socketPath);
+  await once(httpServer, "listening");
+
+  const client = new CodexAppServerClient({ socketPath });
+  await assert.rejects(
+    () => client.request("turn/start", { threadId: "thread-1", input: [] }),
+    /codex-app-server-initialize-error:denied/,
+  );
+
+  wsServer.close();
+  httpServer.close();
+});
+
+test("Codex app-server client reports close before response", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-codex-wake-"));
+  const socketPath = path.join(dir, "codex.sock");
+  const httpServer = http.createServer();
+  const wsServer = new WebSocketServer({ server: httpServer });
+
+  wsServer.on("connection", (socket) => {
+    socket.close();
+  });
+  httpServer.listen(socketPath);
+  await once(httpServer, "listening");
+
+  const client = new CodexAppServerClient({ socketPath });
+  await assert.rejects(
+    () => client.request("turn/start", { threadId: "thread-1", input: [] }),
+    /codex-app-server-closed-before-response:.*:before-initialize/,
+  );
+
+  wsServer.close();
+  httpServer.close();
 });
 
 test("WakeMonitor gates Codex app-server wake before injector", async () => {


### PR DESCRIPTION
Closes #25 — native WS-over-UDS Codex app-server wake, daemon-driven E2E verified