### PR TITLE
feat(broker): add optional JetStream durability

### DIFF
--- a/packages/broker-nats/dist/src/index.d.ts
+++ b/packages/broker-nats/dist/src/index.d.ts
@@ -1,0 +1,82 @@
+import { type ConnectionOptions, type Subscription } from "nats";
+import { createAck, type EnvelopeV1, type DedupeStore, type OutboxStore, type SecurityPolicy } from "@murmurv2/core";
+export interface BrokerConfig {
+    url: string;
+    jetstream?: boolean;
+    stream?: string;
+    streamSubjects?: string[];
+    token?: string;
+    connectMaxAttempts?: number;
+    connectBaseBackoffMs?: number;
+    connectJitterRatio?: number;
+    maxReconnectAttempts?: number;
+    reconnectTimeWait?: number;
+    reconnectJitter?: number;
+    pingInterval?: number;
+    maxPingOut?: number;
+    waitOnFirstConnect?: boolean;
+    onStatus?: (status: BrokerStatusEvent) => void;
+}
+export type MessageHandler = (envelope: EnvelopeV1) => Promise<void>;
+export type BrokerSubscription = Subscription | {
+    unsubscribe(): void | Promise<void>;
+};
+export interface BrokerStatusEvent {
+    type: string;
+    data?: unknown;
+    reconnects: number;
+}
+export declare const buildNatsConnectionOptions: (config: BrokerConfig) => ConnectionOptions;
+export declare class NatsBroker {
+    private readonly config;
+    private nc?;
+    private js?;
+    private jsm?;
+    private readonly sc;
+    private readonly failedDeliveries;
+    private reconnects;
+    private statusLoop?;
+    constructor(config: BrokerConfig);
+    connect(): Promise<void>;
+    close(): Promise<void>;
+    getReconnectCount(): number;
+    private jetStreamEnabled;
+    private streamName;
+    private streamSubjects;
+    private ensureJetStream;
+    private startStatusLoop;
+    publish(subject: string, envelope: EnvelopeV1, policy?: SecurityPolicy): Promise<void>;
+    publishAck(subject: string, envelope: ReturnType<typeof createAck>): Promise<void>;
+    private processEnvelopeFrame;
+    private ensureJetStreamConsumer;
+    private consumeJetStream;
+    subscribeWithAck(params: {
+        subject: string;
+        consumerId: string;
+        dedupe: DedupeStore;
+        onMessage: MessageHandler;
+        maxPoisonAttempts?: number;
+    }): Promise<BrokerSubscription>;
+    startAckCorrelation(params: {
+        outbox: OutboxStore;
+        ackSubject: string;
+        consumerId?: string;
+    }): Promise<BrokerSubscription>;
+    private processAckFrame;
+    /**
+     * Basic outbox worker:
+     * - picks due records
+     * - publishes
+     * - marks sent/failed/dlq
+     * - ACK correlation handled via startAckCorrelation(...)
+     */
+    flushOutbox(params: {
+        outbox: OutboxStore;
+        maxAttempts?: number;
+        batchSize?: number;
+        baseBackoffMs?: number;
+        jitterRatio?: number;
+        ackTimeoutMs?: number;
+        policy?: SecurityPolicy;
+    }): Promise<void>;
+}

--- a/packages/broker-nats/dist/src/index.js
+++ b/packages/broker-nats/dist/src/index.js
@@ -1,0 +1,327 @@
+import { AckPolicy, connect, DeliverPolicy, StringCodec, } from "nats";
+import { applyJitter, computeBackoffMs, createAck, isEnvelopeV1, validateEnvelopePolicy, } from "@murmurv2/core";
+export const buildNatsConnectionOptions = (config) => ({
+    servers: config.url,
+    token: config.token,
+    maxReconnectAttempts: config.maxReconnectAttempts ?? -1,
+    reconnectTimeWait: config.reconnectTimeWait ?? 2000,
+    reconnectJitter: config.reconnectJitter ?? 500,
+    pingInterval: config.pingInterval ?? 20000,
+    maxPingOut: config.maxPingOut ?? 2,
+    waitOnFirstConnect: config.waitOnFirstConnect ?? true,
+});
+export class NatsBroker {
+    config;
+    nc;
+    js;
+    jsm;
+    sc = StringCodec();
+    failedDeliveries = new Map();
+    reconnects = 0;
+    statusLoop;
+    constructor(config) {
+        this.config = config;
+    }
+    async connect() {
+        if (this.nc) {
+            await this.ensureJetStream();
+            return;
+        }
+        const maxAttempts = this.config.connectMaxAttempts ?? 5;
+        const baseBackoffMs = this.config.connectBaseBackoffMs ?? 250;
+        const jitterRatio = this.config.connectJitterRatio ?? 0.2;
+        let lastErr;
+        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+            try {
+                this.nc = await connect(buildNatsConnectionOptions(this.config));
+                this.startStatusLoop(this.nc);
+                await this.ensureJetStream();
+                return;
+            }
+            catch (err) {
+                lastErr = err;
+                if (attempt >= maxAttempts)
+                    break;
+                const sleepMs = applyJitter(computeBackoffMs(attempt, baseBackoffMs), jitterRatio);
+                await new Promise((resolve) => setTimeout(resolve, sleepMs));
+            }
+        }
+        throw lastErr instanceof Error ? lastErr : new Error("nats-connect-failed");
+    }
+    async close() {
+        if (!this.nc)
+            return;
+        await this.nc.drain();
+        this.nc = undefined;
+    }
+    getReconnectCount() {
+        return this.reconnects;
+    }
+    jetStreamEnabled() {
+        return this.config.jetstream === true || !!this.config.stream;
+    }
+    streamName() {
+        return this.config.stream ?? "MURMUR";
+    }
+    streamSubjects() {
+        return this.config.streamSubjects ?? ["msg.>", "ack.>"];
+    }
+    async ensureJetStream() {
+        if (!this.jetStreamEnabled() || !this.nc)
+            return;
+        if (this.js && this.jsm)
+            return;
+        this.jsm = await this.nc.jetstreamManager();
+        const stream = this.streamName();
+        const subjects = this.streamSubjects();
+        try {
+            const info = await this.jsm.streams.info(stream);
+            const currentSubjects = new Set(info.config.subjects ?? []);
+            const missingSubjects = subjects.filter((subject) => !currentSubjects.has(subject));
+            if (missingSubjects.length > 0) {
+                await this.jsm.streams.update(stream, {
+                    ...info.config,
+                    subjects: [...currentSubjects, ...missingSubjects],
+                });
+            }
+        }
+        catch {
+            await this.jsm.streams.add({
+                name: stream,
+                subjects,
+            });
+        }
+        this.js = this.nc.jetstream();
+    }
+    startStatusLoop(nc) {
+        if (this.statusLoop)
+            return;
+        this.statusLoop = (async () => {
+            for await (const status of nc.status()) {
+                if (status.type === "reconnect")
+                    this.reconnects += 1;
+                if (status.type === "disconnect" || status.type === "reconnect" || status.type === "update") {
+                    const event = { type: status.type, data: status.data, reconnects: this.reconnects };
+                    this.config.onStatus?.(event);
+                    console.info("[NatsBroker.status]", event);
+                }
+            }
+        })().catch((err) => {
+            const e = err instanceof Error ? err : new Error(String(err));
+            console.error("[NatsBroker.status] loop crashed", { message: e.message, stack: e.stack });
+        }).finally(() => {
+            this.statusLoop = undefined;
+        });
+    }
+    async publish(subject, envelope, policy) {
+        const violations = validateEnvelopePolicy(envelope, policy);
+        if (violations.length > 0) {
+            throw new Error(`policy-rejected:${violations.join("|")}`);
+        }
+        await this.connect();
+        const payload = this.sc.encode(JSON.stringify(envelope));
+        if (this.js) {
+            await this.js.publish(subject, payload, { msgID: envelope.msgId });
+            return;
+        }
+        this.nc.publish(subject, payload);
+    }
+    async publishAck(subject, envelope) {
+        await this.connect();
+        const payload = this.sc.encode(JSON.stringify(envelope));
+        if (this.js) {
+            await this.js.publish(subject, payload, {
+                msgID: `ack:${envelope.msgId}:${envelope.consumerId}:${envelope.status}`,
+            });
+            return;
+        }
+        this.nc.publish(subject, payload);
+    }
+    async processEnvelopeFrame(data, params) {
+        let msgId = "unknown";
+        let ackSubject = `ack.${params.consumerId}`;
+        try {
+            const decoded = JSON.parse(this.sc.decode(data));
+            if (!isEnvelopeV1(decoded)) {
+                await this.publishAck(ackSubject, createAck("unknown", params.consumerId, "nack", "invalid-envelope"));
+                return;
+            }
+            msgId = decoded.msgId;
+            ackSubject = `ack.${decoded.senderAgentId}`;
+            const isDup = await params.dedupe.seen(decoded.msgId, params.consumerId);
+            if (isDup) {
+                await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack", "duplicate-ignored"));
+                return;
+            }
+            await params.onMessage(decoded);
+            await params.dedupe.markSeen(decoded.msgId, params.consumerId);
+            this.failedDeliveries.delete(`${params.consumerId}:${decoded.msgId}`);
+            await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack"));
+        }
+        catch (err) {
+            const reason = err instanceof Error ? err.message : "handler-failed";
+            const maxPoisonAttempts = params.maxPoisonAttempts ?? 3;
+            const key = `${params.consumerId}:${msgId}`;
+            const failures = (this.failedDeliveries.get(key) ?? 0) + 1;
+            this.failedDeliveries.set(key, failures);
+            if (msgId !== "unknown" && failures >= maxPoisonAttempts) {
+                await params.dedupe.markSeen(msgId, params.consumerId);
+                this.failedDeliveries.delete(key);
+                await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", `poison-message:${reason}`));
+                return;
+            }
+            await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", reason));
+        }
+    }
+    async ensureJetStreamConsumer(subject, durableName) {
+        if (!this.jsm)
+            throw new Error("jetstream-manager-unavailable");
+        const stream = this.streamName();
+        try {
+            const info = await this.jsm.consumers.info(stream, durableName);
+            const filterSubject = info.config.filter_subject;
+            if (filterSubject && filterSubject !== subject) {
+                throw new Error(`jetstream-consumer-filter-mismatch:${durableName}:${filterSubject}:${subject}`);
+            }
+            return;
+        }
+        catch (err) {
+            if (err instanceof Error && err.message.startsWith("jetstream-consumer-filter-mismatch:")) {
+                throw err;
+            }
+            await this.jsm.consumers.add(stream, {
+                durable_name: durableName,
+                name: durableName,
+                filter_subject: subject,
+                ack_policy: AckPolicy.Explicit,
+                deliver_policy: DeliverPolicy.All,
+            });
+        }
+    }
+    async consumeJetStream(subject, durableName, onMessage) {
+        await this.ensureJetStreamConsumer(subject, durableName);
+        if (!this.js)
+            throw new Error("jetstream-client-unavailable");
+        const consumer = await this.js.consumers.get(this.streamName(), durableName);
+        const messages = await consumer.consume();
+        (async () => {
+            for await (const m of messages) {
+                try {
+                    await onMessage(m.data);
+                    m.ack();
+                }
+                catch (err) {
+                    m.nak();
+                    const e = err instanceof Error ? err : new Error(String(err));
+                    console.error("[NatsBroker.consumeJetStream] message failed", {
+                        subject,
+                        durableName,
+                        message: e.message,
+                        stack: e.stack,
+                    });
+                }
+            }
+        })().catch((err) => {
+            const e = err instanceof Error ? err : new Error(String(err));
+            console.error("[NatsBroker.consumeJetStream] loop crashed", { subject, durableName, message: e.message, stack: e.stack });
+        });
+        return {
+            unsubscribe: () => {
+                void messages.close();
+            },
+        };
+    }
+    async subscribeWithAck(params) {
+        await this.connect();
+        if (this.js) {
+            return this.consumeJetStream(params.subject, params.consumerId, (data) => this.processEnvelopeFrame(data, params));
+        }
+        const sub = this.nc.subscribe(params.subject);
+        (async () => {
+            for await (const m of sub) {
+                await this.processEnvelopeFrame(m.data, params);
+            }
+        })().catch((err) => {
+            const e = err instanceof Error ? err : new Error(String(err));
+            console.error("[NatsBroker.subscribeWithAck] loop crashed", { message: e.message, stack: e.stack });
+        });
+        return sub;
+    }
+    async startAckCorrelation(params) {
+        await this.connect();
+        if (this.js) {
+            const consumerId = params.consumerId ?? `${params.ackSubject.replaceAll(".", "-")}-consumer`;
+            return this.consumeJetStream(params.ackSubject, consumerId, async (data) => {
+                await this.processAckFrame(data, params.outbox);
+            });
+        }
+        const sub = this.nc.subscribe(params.ackSubject);
+        (async () => {
+            for await (const m of sub) {
+                await this.processAckFrame(m.data, params.outbox);
+            }
+        })().catch((err) => {
+            const e = err instanceof Error ? err : new Error(String(err));
+            console.error("[NatsBroker.startAckCorrelation] loop crashed", { message: e.message, stack: e.stack });
+        });
+        return sub;
+    }
+    async processAckFrame(data, outbox) {
+        try {
+            const decoded = JSON.parse(this.sc.decode(data));
+            if (typeof decoded.msgId !== "string" || decoded.msgId.length === 0)
+                return;
+            if (decoded.status === "ack") {
+                await outbox.markAcked(decoded.msgId);
+                return;
+            }
+            if (decoded.status === "nack") {
+                await outbox.markFailed(decoded.msgId, decoded.reason ?? "nack", new Date().toISOString());
+            }
+        }
+        catch (err) {
+            const e = err instanceof Error ? err : new Error(String(err));
+            console.error("[NatsBroker.startAckCorrelation] malformed ack frame", {
+                message: e.message,
+                stack: e.stack,
+                raw: this.sc.decode(data),
+            });
+        }
+    }
+    /**
+     * Basic outbox worker:
+     * - picks due records
+     * - publishes
+     * - marks sent/failed/dlq
+     * - ACK correlation handled via startAckCorrelation(...)
+     */
+    async flushOutbox(params) {
+        const maxAttempts = params.maxAttempts ?? 5;
+        if (params.ackTimeoutMs && params.outbox.requeueStaleSent) {
+            await params.outbox.requeueStaleSent(params.ackTimeoutMs);
+        }
+        const due = await params.outbox.claimDue(params.batchSize ?? 50);
+        for (const rec of due) {
+            try {
+                await this.publish(rec.subject, rec.envelope, params.policy);
+                await params.outbox.markSent(rec.msgId);
+            }
+            catch (err) {
+                const nextAttemptNum = rec.attempts + 1;
+                const reason = err instanceof Error ? err.message : "publish-failed";
+                if (reason.startsWith("policy-rejected:")) {
+                    await params.outbox.markDlq(rec.msgId, reason);
+                    continue;
+                }
+                if (nextAttemptNum >= maxAttempts) {
+                    await params.outbox.markDlq(rec.msgId, reason);
+                    continue;
+                }
+                const backoffMs = computeBackoffMs(nextAttemptNum, params.baseBackoffMs ?? 500);
+                const withJitter = applyJitter(backoffMs, params.jitterRatio ?? 0.2);
+                const nextAt = new Date(Date.now() + withJitter).toISOString();
+                await params.outbox.markFailed(rec.msgId, reason, nextAt);
+            }
+        }
+    }
+}

--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -1,4 +1,14 @@
-import { connect, type ConnectionOptions, type NatsConnection, StringCodec, type Subscription } from "nats";
+import {
+  AckPolicy,
+  connect,
+  DeliverPolicy,
+  type ConnectionOptions,
+  type JetStreamClient,
+  type JetStreamManager,
+  type NatsConnection,
+  StringCodec,
+  type Subscription,
+} from "nats";
 import {
   applyJitter,
   computeBackoffMs,
@@ -14,7 +24,9 @@ import {
 
 export interface BrokerConfig {
   url: string;
+  jetstream?: boolean;
   stream?: string;
+  streamSubjects?: string[];
   token?: string;
   connectMaxAttempts?: number;
   connectBaseBackoffMs?: number;
@@ -29,6 +41,7 @@ export interface BrokerConfig {
 }
 
 export type MessageHandler = (envelope: EnvelopeV1) => Promise<void>;
+export type BrokerSubscription = Subscription | { unsubscribe(): void | Promise<void> };
 
 export interface BrokerStatusEvent {
   type: string;
@@ -49,6 +62,8 @@ export const buildNatsConnectionOptions = (config: BrokerConfig): ConnectionOpti
 
 export class NatsBroker {
   private nc?: NatsConnection;
+  private js?: JetStreamClient;
+  private jsm?: JetStreamManager;
   private readonly sc = StringCodec();
   private readonly failedDeliveries = new Map<string, number>();
   private reconnects = 0;
@@ -57,7 +72,10 @@ export class NatsBroker {
   constructor(private readonly config: BrokerConfig) {}
 
   async connect(): Promise<void> {
-    if (this.nc) return;
+    if (this.nc) {
+      await this.ensureJetStream();
+      return;
+    }
 
     const maxAttempts = this.config.connectMaxAttempts ?? 5;
     const baseBackoffMs = this.config.connectBaseBackoffMs ?? 250;
@@ -68,6 +86,7 @@ export class NatsBroker {
       try {
         this.nc = await connect(buildNatsConnectionOptions(this.config));
         this.startStatusLoop(this.nc);
+        await this.ensureJetStream();
         return;
       } catch (err) {
         lastErr = err;
@@ -88,6 +107,46 @@ export class NatsBroker {
 
   getReconnectCount(): number {
     return this.reconnects;
+  }
+
+  private jetStreamEnabled(): boolean {
+    return this.config.jetstream === true || !!this.config.stream;
+  }
+
+  private streamName(): string {
+    return this.config.stream ?? "MURMUR";
+  }
+
+  private streamSubjects(): string[] {
+    return this.config.streamSubjects ?? ["msg.>", "ack.>"];
+  }
+
+  private async ensureJetStream(): Promise<void> {
+    if (!this.jetStreamEnabled() || !this.nc) return;
+    if (this.js && this.jsm) return;
+
+    this.jsm = await this.nc.jetstreamManager();
+    const stream = this.streamName();
+    const subjects = this.streamSubjects();
+
+    try {
+      const info = await this.jsm.streams.info(stream);
+      const currentSubjects = new Set(info.config.subjects ?? []);
+      const missingSubjects = subjects.filter((subject) => !currentSubjects.has(subject));
+      if (missingSubjects.length > 0) {
+        await this.jsm.streams.update(stream, {
+          ...info.config,
+          subjects: [...currentSubjects, ...missingSubjects],
+        });
+      }
+    } catch {
+      await this.jsm.streams.add({
+        name: stream,
+        subjects,
+      });
+    }
+
+    this.js = this.nc.jetstream();
   }
 
   private startStatusLoop(nc: NatsConnection): void {
@@ -115,12 +174,133 @@ export class NatsBroker {
       throw new Error(`policy-rejected:${violations.join("|")}`);
     }
     await this.connect();
-    this.nc!.publish(subject, this.sc.encode(JSON.stringify(envelope)));
+    const payload = this.sc.encode(JSON.stringify(envelope));
+    if (this.js) {
+      await this.js.publish(subject, payload, { msgID: envelope.msgId });
+      return;
+    }
+    this.nc!.publish(subject, payload);
   }
 
   async publishAck(subject: string, envelope: ReturnType<typeof createAck>): Promise<void> {
     await this.connect();
-    this.nc!.publish(subject, this.sc.encode(JSON.stringify(envelope)));
+    const payload = this.sc.encode(JSON.stringify(envelope));
+    if (this.js) {
+      await this.js.publish(subject, payload, {
+        msgID: `ack:${envelope.msgId}:${envelope.consumerId}:${envelope.status}`,
+      });
+      return;
+    }
+    this.nc!.publish(subject, payload);
+  }
+
+  private async processEnvelopeFrame(
+    data: Uint8Array,
+    params: {
+      consumerId: string;
+      dedupe: DedupeStore;
+      onMessage: MessageHandler;
+      maxPoisonAttempts?: number;
+    },
+  ): Promise<void> {
+    let msgId = "unknown";
+    let ackSubject = `ack.${params.consumerId}`;
+    try {
+      const decoded = JSON.parse(this.sc.decode(data));
+      if (!isEnvelopeV1(decoded)) {
+        await this.publishAck(ackSubject, createAck("unknown", params.consumerId, "nack", "invalid-envelope"));
+        return;
+      }
+
+      msgId = decoded.msgId;
+      ackSubject = `ack.${decoded.senderAgentId}`;
+      const isDup = await params.dedupe.seen(decoded.msgId, params.consumerId);
+      if (isDup) {
+        await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack", "duplicate-ignored"));
+        return;
+      }
+
+      await params.onMessage(decoded);
+      await params.dedupe.markSeen(decoded.msgId, params.consumerId);
+      this.failedDeliveries.delete(`${params.consumerId}:${decoded.msgId}`);
+      await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack"));
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : "handler-failed";
+      const maxPoisonAttempts = params.maxPoisonAttempts ?? 3;
+      const key = `${params.consumerId}:${msgId}`;
+      const failures = (this.failedDeliveries.get(key) ?? 0) + 1;
+      this.failedDeliveries.set(key, failures);
+      if (msgId !== "unknown" && failures >= maxPoisonAttempts) {
+        await params.dedupe.markSeen(msgId, params.consumerId);
+        this.failedDeliveries.delete(key);
+        await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", `poison-message:${reason}`));
+        return;
+      }
+      await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", reason));
+    }
+  }
+
+  private async ensureJetStreamConsumer(subject: string, durableName: string): Promise<void> {
+    if (!this.jsm) throw new Error("jetstream-manager-unavailable");
+    const stream = this.streamName();
+    try {
+      const info = await this.jsm.consumers.info(stream, durableName);
+      const filterSubject = info.config.filter_subject;
+      if (filterSubject && filterSubject !== subject) {
+        throw new Error(`jetstream-consumer-filter-mismatch:${durableName}:${filterSubject}:${subject}`);
+      }
+      return;
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith("jetstream-consumer-filter-mismatch:")) {
+        throw err;
+      }
+      await this.jsm.consumers.add(stream, {
+        durable_name: durableName,
+        name: durableName,
+        filter_subject: subject,
+        ack_policy: AckPolicy.Explicit,
+        deliver_policy: DeliverPolicy.All,
+      });
+    }
+  }
+
+  private async consumeJetStream(
+    subject: string,
+    durableName: string,
+    onMessage: (data: Uint8Array) => Promise<void>,
+  ): Promise<BrokerSubscription> {
+    await this.ensureJetStreamConsumer(subject, durableName);
+    if (!this.js) throw new Error("jetstream-client-unavailable");
+
+    const consumer = await this.js.consumers.get(this.streamName(), durableName);
+    const messages = await consumer.consume();
+
+    (async () => {
+      for await (const m of messages) {
+        try {
+          await onMessage(m.data);
+          m.ack();
+        } catch (err) {
+          m.nak();
+          const e = err instanceof Error ? err : new Error(String(err));
+          console.error("[NatsBroker.consumeJetStream] message failed", {
+            subject,
+            durableName,
+            message: e.message,
+            stack: e.stack,
+          });
+        }
+      }
+    })().catch((err) => {
+      const e = err instanceof Error ? err : new Error(String(err));
+      console.error("[NatsBroker.consumeJetStream] loop crashed", { subject, durableName, message: e.message, stack: e.stack });
+    });
+
+    return {
+      unsubscribe: () => {
+        void messages.close();
+      },
+    };
   }
 
   async subscribeWithAck(params: {
@@ -129,48 +309,18 @@ export class NatsBroker {
     dedupe: DedupeStore;
     onMessage: MessageHandler;
     maxPoisonAttempts?: number;
-  }): Promise<Subscription> {
+  }): Promise<BrokerSubscription> {
     await this.connect();
+
+    if (this.js) {
+      return this.consumeJetStream(params.subject, params.consumerId, (data) => this.processEnvelopeFrame(data, params));
+    }
 
     const sub = this.nc!.subscribe(params.subject);
 
     (async () => {
       for await (const m of sub) {
-        let msgId = "unknown";
-        let ackSubject = `ack.${params.consumerId}`;
-        try {
-          const decoded = JSON.parse(this.sc.decode(m.data));
-          if (!isEnvelopeV1(decoded)) {
-            await this.publishAck(ackSubject, createAck("unknown", params.consumerId, "nack", "invalid-envelope"));
-            continue;
-          }
-
-          msgId = decoded.msgId;
-          ackSubject = `ack.${decoded.senderAgentId}`;
-          const isDup = await params.dedupe.seen(decoded.msgId, params.consumerId);
-          if (isDup) {
-            await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack", "duplicate-ignored"));
-            continue;
-          }
-
-          await params.onMessage(decoded);
-          await params.dedupe.markSeen(decoded.msgId, params.consumerId);
-          this.failedDeliveries.delete(`${params.consumerId}:${decoded.msgId}`);
-          await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack"));
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : "handler-failed";
-          const maxPoisonAttempts = params.maxPoisonAttempts ?? 3;
-          const key = `${params.consumerId}:${msgId}`;
-          const failures = (this.failedDeliveries.get(key) ?? 0) + 1;
-          this.failedDeliveries.set(key, failures);
-          if (msgId !== "unknown" && failures >= maxPoisonAttempts) {
-            await params.dedupe.markSeen(msgId, params.consumerId);
-            this.failedDeliveries.delete(key);
-            await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", `poison-message:${reason}`));
-            continue;
-          }
-          await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", reason));
-        }
+        await this.processEnvelopeFrame(m.data, params);
       }
     })().catch((err) => {
       const e = err instanceof Error ? err : new Error(String(err));
@@ -183,36 +333,22 @@ export class NatsBroker {
   async startAckCorrelation(params: {
     outbox: OutboxStore;
     ackSubject: string;
-  }): Promise<Subscription> {
+    consumerId?: string;
+  }): Promise<BrokerSubscription> {
     await this.connect();
+
+    if (this.js) {
+      const consumerId = params.consumerId ?? `${params.ackSubject.replaceAll(".", "-")}-consumer`;
+      return this.consumeJetStream(params.ackSubject, consumerId, async (data) => {
+        await this.processAckFrame(data, params.outbox);
+      });
+    }
+
     const sub = this.nc!.subscribe(params.ackSubject);
 
     (async () => {
       for await (const m of sub) {
-        try {
-          const decoded = JSON.parse(this.sc.decode(m.data)) as AckV1;
-          if (typeof decoded.msgId !== "string" || decoded.msgId.length === 0) continue;
-
-          if (decoded.status === "ack") {
-            await params.outbox.markAcked(decoded.msgId);
-            continue;
-          }
-
-          if (decoded.status === "nack") {
-            await params.outbox.markFailed(
-              decoded.msgId,
-              decoded.reason ?? "nack",
-              new Date().toISOString(),
-            );
-          }
-        } catch (err) {
-          const e = err instanceof Error ? err : new Error(String(err));
-          console.error("[NatsBroker.startAckCorrelation] malformed ack frame", {
-            message: e.message,
-            stack: e.stack,
-            raw: this.sc.decode(m.data),
-          });
-        }
+        await this.processAckFrame(m.data, params.outbox);
       }
     })().catch((err) => {
       const e = err instanceof Error ? err : new Error(String(err));
@@ -220,6 +356,33 @@ export class NatsBroker {
     });
 
     return sub;
+  }
+
+  private async processAckFrame(data: Uint8Array, outbox: OutboxStore): Promise<void> {
+    try {
+      const decoded = JSON.parse(this.sc.decode(data)) as AckV1;
+      if (typeof decoded.msgId !== "string" || decoded.msgId.length === 0) return;
+
+      if (decoded.status === "ack") {
+        await outbox.markAcked(decoded.msgId);
+        return;
+      }
+
+      if (decoded.status === "nack") {
+        await outbox.markFailed(
+          decoded.msgId,
+          decoded.reason ?? "nack",
+          new Date().toISOString(),
+        );
+      }
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      console.error("[NatsBroker.startAckCorrelation] malformed ack frame", {
+        message: e.message,
+        stack: e.stack,
+        raw: this.sc.decode(data),
+      });
+    }
   }
 
   /**

--- a/scripts/murmur-daemon.mjs
+++ b/scripts/murmur-daemon.mjs
@@ -34,6 +34,10 @@ try {
 const { agentId, natsUrl, natsToken, subject, peers, keys } = config;
 const dbPath = path.join(dataDir, "murmur.db");
 const flushIntervalMs = Number(process.env.FLUSH_INTERVAL_MS) || 2000;
+const jetstreamConfig = config.jetstream || {};
+const jetstreamEnabled = jetstreamConfig.enabled ?? process.env.MURMUR_JETSTREAM === "1";
+const jetstreamStream = jetstreamConfig.stream || process.env.MURMUR_JETSTREAM_STREAM || "MURMUR";
+const jetstreamSubjects = jetstreamConfig.subjects || ["msg.>", "ack.>"];
 const notifyTargets = normalizeNotifyTargets(config.notify);
 const envTelegramFallback = (() => {
   const botToken = process.env.MURMUR_TELEGRAM_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN;
@@ -53,13 +57,23 @@ log("info", "Daemon starting", {
   natsUrl,
   dbPath,
   flushIntervalMs,
+  jetstreamEnabled,
+  jetstreamStream: jetstreamEnabled ? jetstreamStream : undefined,
   notifyTargets: effectiveNotifyTargets.map((t) => `${t.type}:${t.channel}`),
   notifyFallbackFromEnv: envTelegramFallback.length > 0,
 });
 
 const store = new SQLiteDedupeOutboxStore(dbPath);
 const msgStore = new SQLiteMessageStore(dbPath);
-const broker = new NatsBroker({ url: natsUrl, token: natsToken });
+const broker = new NatsBroker({
+  url: natsUrl,
+  token: natsToken,
+  jetstream: jetstreamEnabled,
+  stream: jetstreamEnabled ? jetstreamStream : undefined,
+  streamSubjects: jetstreamSubjects,
+});
+
+const durableSafe = (value) => value.replace(/[^A-Za-z0-9_-]/g, "-");
 
 const inboundCursor = () => {
   const row = wakeDb.prepare("SELECT COALESCE(MAX(rowid), 0) as cursor FROM local_messages WHERE direction = 'inbound'").get();
@@ -261,11 +275,11 @@ try {
         env: { MURMUR_PROXY_AGENT: ps.replace("msg.", "") },
       });
     };
-    await broker.subscribeWithAck({ subject: ps, consumerId: `${agentId}-proxy`, dedupe: store, onMessage: proxyOnMessage });
+    await broker.subscribeWithAck({ subject: ps, consumerId: `${agentId}-proxy-${durableSafe(ps)}`, dedupe: store, onMessage: proxyOnMessage });
     log("info", "Subscribed (proxy)", { subject: ps });
   }
 
-  await broker.startAckCorrelation({ outbox: store, ackSubject: `ack.${agentId}` });
+  await broker.startAckCorrelation({ outbox: store, ackSubject: `ack.${agentId}`, consumerId: `${agentId}-ack` });
   log("info", "ACK correlation started", { ackSubject: `ack.${agentId}` });
 
   const pendingNotify = notifyQueue.pendingCount();

--- a/tests/broker-jetstream.test.mjs
+++ b/tests/broker-jetstream.test.mjs
@@ -1,0 +1,192 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { StringCodec } from "nats";
+import { NatsBroker } from "../packages/broker-nats/dist/src/index.js";
+import { createAck } from "../packages/core/dist/src/index.js";
+
+const sc = StringCodec();
+
+const envelope = {
+  schemaVersion: "1.0",
+  msgId: "msg-js-1",
+  conversationId: "conv-js-1",
+  senderAgentId: "agent-sender",
+  recipients: ["agent-receiver"],
+  createdAt: new Date().toISOString(),
+  payloadCiphertext: Buffer.from("x").toString("base64"),
+  payloadNonce: "nonce",
+  signature: "sig",
+};
+
+const makeJetStreamBroker = ({ streamInfoThrows = true, messages = [] } = {}) => {
+  const streamsAdded = [];
+  const consumersAdded = [];
+  const published = [];
+  const acked = [];
+  const nacked = [];
+
+  const fakeMessages = {
+    async *[Symbol.asyncIterator]() {
+      for (const data of messages) {
+        yield {
+          data,
+          ack() {
+            acked.push(data);
+          },
+          nak() {
+            nacked.push(data);
+          },
+        };
+      }
+    },
+    async close() {},
+  };
+
+  const fakeJsm = {
+    streams: {
+      async info() {
+        if (streamInfoThrows) throw new Error("stream-missing");
+        return { config: { name: "MURMUR", subjects: ["msg.>"] } };
+      },
+      async add(config) {
+        streamsAdded.push(config);
+      },
+      async update(_stream, config) {
+        streamsAdded.push(config);
+      },
+    },
+    consumers: {
+      async info() {
+        throw new Error("consumer-missing");
+      },
+      async add(stream, config) {
+        consumersAdded.push({ stream, config });
+      },
+    },
+  };
+
+  const fakeJs = {
+    async publish(subject, data, opts) {
+      published.push({ subject, body: JSON.parse(sc.decode(data)), opts });
+    },
+    consumers: {
+      async get(stream, durable) {
+        return {
+          stream,
+          durable,
+          async consume() {
+            return fakeMessages;
+          },
+        };
+      },
+    },
+  };
+
+  const fakeNc = {
+    async jetstreamManager() {
+      return fakeJsm;
+    },
+    jetstream() {
+      return fakeJs;
+    },
+    async drain() {},
+  };
+
+  const broker = new NatsBroker({
+    url: "nats://example.invalid",
+    jetstream: true,
+    stream: "MURMUR",
+    streamSubjects: ["msg.>", "ack.>"],
+  });
+  broker.nc = fakeNc;
+
+  return { broker, streamsAdded, consumersAdded, published, acked, nacked };
+};
+
+test("JetStream publish ensures stream and uses envelope msgId as dedupe id", async () => {
+  const { broker, streamsAdded, published } = makeJetStreamBroker();
+
+  await broker.publish("msg.agent-receiver", envelope);
+
+  assert.deepEqual(streamsAdded[0], { name: "MURMUR", subjects: ["msg.>", "ack.>"] });
+  assert.equal(published.length, 1);
+  assert.equal(published[0].subject, "msg.agent-receiver");
+  assert.equal(published[0].body.msgId, envelope.msgId);
+  assert.equal(published[0].opts.msgID, envelope.msgId);
+});
+
+test("JetStream disabled keeps core NATS publish path", async () => {
+  const published = [];
+  const broker = new NatsBroker({ url: "nats://example.invalid" });
+  broker.nc = {
+    publish(subject, data) {
+      published.push({ subject, body: JSON.parse(sc.decode(data)) });
+    },
+    async jetstreamManager() {
+      throw new Error("jetstream-manager-should-not-be-called");
+    },
+    async drain() {},
+  };
+
+  await broker.publish("msg.agent-receiver", envelope);
+
+  assert.deepEqual(published, [{ subject: "msg.agent-receiver", body: envelope }]);
+});
+
+test("JetStream subscribeWithAck creates durable explicit-ack consumer", async () => {
+  const { broker, consumersAdded, published, acked } = makeJetStreamBroker({
+    messages: [sc.encode(JSON.stringify(envelope))],
+  });
+  const dedupe = {
+    async seen() { return false; },
+    async markSeen() {},
+  };
+
+  await broker.subscribeWithAck({
+    subject: "msg.agent-receiver",
+    consumerId: "agent-receiver",
+    dedupe,
+    onMessage: async () => {},
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(consumersAdded.length, 1);
+  assert.equal(consumersAdded[0].stream, "MURMUR");
+  assert.equal(consumersAdded[0].config.durable_name, "agent-receiver");
+  assert.equal(consumersAdded[0].config.filter_subject, "msg.agent-receiver");
+  assert.equal(consumersAdded[0].config.ack_policy, "explicit");
+  assert.equal(published[0].subject, "ack.agent-sender");
+  assert.equal(published[0].body.status, "ack");
+  assert.equal(published[0].opts.msgID, `ack:${envelope.msgId}:agent-receiver:ack`);
+  assert.equal(acked.length, 1);
+});
+
+test("JetStream ACK correlation consumes durable ack subject and updates outbox", async () => {
+  const ack = createAck(envelope.msgId, "agent-receiver", "ack");
+  const { broker, consumersAdded, acked } = makeJetStreamBroker({
+    messages: [sc.encode(JSON.stringify(ack))],
+  });
+  const marked = [];
+  const outbox = {
+    async markAcked(msgId) {
+      marked.push(["acked", msgId]);
+    },
+    async markFailed(msgId, reason) {
+      marked.push(["failed", msgId, reason]);
+    },
+  };
+
+  await broker.startAckCorrelation({
+    outbox,
+    ackSubject: "ack.agent-sender",
+    consumerId: "agent-sender-ack",
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(consumersAdded[0].config.durable_name, "agent-sender-ack");
+  assert.equal(consumersAdded[0].config.filter_subject, "ack.agent-sender");
+  assert.deepEqual(marked, [["acked", envelope.msgId]]);
+  assert.equal(acked.length, 1);
+});


### PR DESCRIPTION
## Summary
- add opt-in JetStream durability to `@murmurv2/broker-nats` while keeping SQLite outbox as the local source of truth
- ensure stream creation/update defaults to `MURMUR` with `msg.>` and `ack.>` subjects
- publish message and ACK frames through JetStream with deterministic `msgID` values when enabled
- consume inbound and ACK subjects through durable explicit-ack consumers
- wire `murmur-daemon.mjs` config/env flags without changing the default core NATS path
- include rebuilt broker dist artifacts from `tsc`

## Config
JetStream remains disabled by default. Enable with either config:

```json
{
  "jetstream": {
    "enabled": true,
    "stream": "MURMUR",
    "subjects": ["msg.>", "ack.>"]
  }
}
```

or env:

```bash
MURMUR_JETSTREAM=1
MURMUR_JETSTREAM_STREAM=MURMUR
```

## Notes
- SQLite outbox/retry state is unchanged and remains the application source of truth.
- JetStream is used as broker-side durability and replay for message/ACK subjects only when explicitly enabled.
- Proxy consumers now include the subscribed subject in the durable name to avoid filter-subject conflicts.

## Verification
- `npm test` passes: build, 48 unit tests, notify-smoke PASS.
- Added JetStream unit coverage for stream ensure, deterministic publish dedupe IDs, durable explicit-ack consume, ACK correlation, and disabled/backward-compatible core NATS publish.
- Live Docker integration was not run in this Codex environment: `docker compose` plugin is unavailable and direct docker socket access is denied.