### PR TITLE
feat(bridge-a2a): A2A↔Murmur bridge skeleton (#4 milestone)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,39 @@
         "typescript": "^5.9.3"
       }
     },
+    "node_modules/@a2a-js/sdk": {
+      "version": "1.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-1.0.0-alpha.0.tgz",
+      "integrity": "sha512-2IeAMlgO4Xu1QbmNUvwyZe5F/vMzA7tiEt/1nLvCHptVpC6L7bIBUVL71fIdNi9TIGjLVz0ctVYgx8UkzpxeZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^6.2.3",
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@murmurv2/bridge-a2a": {
+      "resolved": "packages/bridge-a2a",
+      "link": true
+    },
     "node_modules/@murmurv2/bridge-murmur": {
       "resolved": "packages/bridge-murmur",
       "link": true
@@ -106,6 +139,59 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -126,6 +212,54 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/base64-js": {
@@ -182,6 +316,43 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -206,11 +377,106 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -236,6 +502,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -243,6 +518,35 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/end-of-stream": {
@@ -254,6 +558,51 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -263,11 +612,93 @@
         "node": ">=6"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
@@ -275,11 +706,129 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -313,6 +862,85 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -340,6 +968,12 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -356,6 +990,15 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/nkeys.js": {
@@ -382,6 +1025,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -389,6 +1056,25 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pg": {
@@ -545,6 +1231,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -553,6 +1252,45 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -584,6 +1322,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -604,6 +1358,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -614,6 +1374,129 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/simple-concat": {
@@ -670,6 +1553,15 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -716,6 +1608,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -733,6 +1634,37 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
       "license": "Unlicense"
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -755,11 +1687,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -795,6 +1758,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "packages/bridge-a2a": {
+      "name": "@murmurv2/bridge-a2a",
+      "version": "0.1.0",
+      "dependencies": {
+        "@a2a-js/sdk": "1.0.0-alpha.0",
+        "@murmurv2/core": "0.1.0",
+        "@murmurv2/security": "0.1.0",
+        "express": "^5.1.0",
+        "nats": "^2.28.2"
+      },
+      "devDependencies": {
+        "@types/express": "^5.0.0"
       }
     },
     "packages/bridge-murmur": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "test:unit": "node --test tests/*.test.mjs",
     "test:integration": "node scripts/run-integration.mjs",
     "test:notify-smoke": "node scripts/notify-smoke.mjs",
+    "test:a2a": "npm --workspace @murmurv2/bridge-a2a test",
     "test:federation-nats": "npm --workspace @murmurv2/federation-nats test",
-    "test": "npm run build && npm run test:unit && npm run test:notify-smoke && npm run test:federation-nats"
+    "test": "npm run build && npm run test:unit && npm run test:notify-smoke && npm run test:a2a && npm run test:federation-nats"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/bridge-a2a/package.json
+++ b/packages/bridge-a2a/package.json
@@ -10,16 +10,13 @@
     "test": "node --test"
   },
   "dependencies": {
+    "@a2a-js/sdk": "1.0.0-alpha.0",
     "@murmurv2/core": "0.1.0",
     "@murmurv2/security": "0.1.0",
+    "express": "^5.1.0",
     "nats": "^2.28.2"
   },
-  "peerDependencies": {
-    "@a2a-js/sdk": "^1.0.0-alpha.0"
-  },
-  "peerDependenciesMeta": {
-    "@a2a-js/sdk": {
-      "optional": false
-    }
+  "devDependencies": {
+    "@types/express": "^5.0.0"
   }
 }

--- a/packages/bridge-a2a/package.json
+++ b/packages/bridge-a2a/package.json
@@ -7,7 +7,7 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "node --test"
+    "test": "npm run build && node --test"
   },
   "dependencies": {
     "@a2a-js/sdk": "1.0.0-alpha.0",

--- a/packages/bridge-a2a/package.json
+++ b/packages/bridge-a2a/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@murmurv2/bridge-a2a",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@murmurv2/core": "0.1.0",
+    "@murmurv2/security": "0.1.0",
+    "nats": "^2.28.2"
+  },
+  "peerDependencies": {
+    "@a2a-js/sdk": "^1.0.0-alpha.0"
+  },
+  "peerDependenciesMeta": {
+    "@a2a-js/sdk": {
+      "optional": false
+    }
+  }
+}

--- a/packages/bridge-a2a/src/index.ts
+++ b/packages/bridge-a2a/src/index.ts
@@ -1,20 +1,46 @@
 // @murmurv2/bridge-a2a — A2A <-> Murmur bridge (v2.1 / track #4, E5).
 //
-// Trust boundary: terminates external A2A (JSON-RPC/HTTP, OAuth, Agent Card) and
-// re-wraps tasks as internal Murmur E2E envelopes on NATS. External agents speak
-// the industry-standard A2A protocol; the internal mesh keeps E2E + durable outbox.
+// Trust boundary: terminates external A2A (JSON-RPC/HTTP + Agent Card discovery)
+// and re-wraps each task as an internal Murmur E2E envelope on NATS. External
+// agents speak the industry-standard A2A protocol; the internal mesh keeps its
+// E2E encryption + signed envelopes + durable outbox untouched.
 // Design: ../../Plans/Active "{murmur} {design} A2A to Murmur Bridge".
 //
-// STATUS: skeleton. Inbound A2A->Murmur path scaffolded. NOT built/tested yet.
-// Next: `npm i @a2a-js/sdk express`, wire the SDK request handler, `tsc`, tests.
+// Wired against @a2a-js/sdk@1.0.0-alpha.0:
+//   - protobuf-style domain types (Part.content.$case='text', Role.ROLE_AGENT);
+//   - server: DefaultRequestHandler + InMemoryTaskStore + an AgentExecutor;
+//   - express: jsonRpcHandler + agentCardHandler + UserBuilder.noAuthentication.
+//     (NOTE: the older A2AExpressApp().routes() surface is gone in alpha.)
+//
+// Crypto matches the mesh canonical form (stableEnvelopePayload, identical to
+// scripts/murmur-daemon.mjs + packages/mcp-server) so internal agents verify the
+// bridge's signatures. The bridge signs+seals as ITSELF; the external caller's id
+// travels inside the encrypted payload, never as a spoofable senderAgentId.
+//
+// STATUS: skeleton. Crypto / correlation / allowlist / agent-card are wired and
+// unit-tested. Live A2A-client interop (real remote agent over HTTP) is the next
+// gate — opt-in package, intentionally NOT in the root tsc -b graph / core CI yet
+// while @a2a-js/sdk is alpha (mirrors JetStream's default-OFF posture).
 
+import { randomUUID } from "node:crypto";
+import type { Server } from "node:http";
+import express from "express";
 import { StringCodec, connect, type NatsConnection, type Subscription } from "nats";
+import { isEnvelopeV1, type AckV1, type EnvelopeV1 } from "@murmurv2/core";
+import { decryptPayload, encryptPayload, signEnvelope } from "@murmurv2/security";
 import {
-  isEnvelopeV1,
-  type AckV1,
-  type EnvelopeV1,
-} from "@murmurv2/core";
-import { encryptPayload, signEnvelope } from "@murmurv2/security";
+  DefaultRequestHandler,
+  InMemoryTaskStore,
+  type AgentExecutor,
+  type ExecutionEventBus,
+  type RequestContext,
+} from "@a2a-js/sdk/server";
+import {
+  UserBuilder,
+  agentCardHandler,
+  jsonRpcHandler,
+} from "@a2a-js/sdk/server/express";
+import { AgentCard, Message, Role } from "@a2a-js/sdk";
 
 const sc = StringCodec();
 
@@ -30,7 +56,10 @@ export interface BridgeA2AConfig {
   a2aPort: number;
   /** Ed25519 private key the bridge signs internal envelopes with. */
   signingPrivateKey: string;
-  /** Map internal agentId -> X25519 public key, for sealing the payload. */
+  /** X25519 private key the bridge seals outbound / opens inbound replies with. */
+  encryptionPrivateKey: string;
+  /** Internal agentId -> X25519 public key. Used to seal to the target AND to open
+   *  a reply (the sender pubkey is not carried in the envelope). */
   recipientPublicKeys: Record<string, string>;
   /** Allowlist of external A2A agent ids permitted to delegate tasks. */
   allowedExternalAgents: string[];
@@ -38,28 +67,124 @@ export interface BridgeA2AConfig {
   replyTimeoutMs?: number;
 }
 
-type Logger = (level: "info" | "warn" | "error", msg: string, meta?: unknown) => void;
+export type Logger = (level: "info" | "warn" | "error", msg: string, meta?: unknown) => void;
 
 /** What an A2A message/send is mapped into before sealing. */
-interface InboundTask {
+export interface InboundTask {
   externalAgentId: string;
   conversationId: string;
   text: string;
 }
 
+/**
+ * Mesh-canonical signing input. MUST stay byte-identical to
+ * `scripts/murmur-daemon.mjs` + `packages/mcp-server` `stableEnvelopePayload`,
+ * or internal agents reject the bridge's signature.
+ * TODO(core): promote this single source of truth into @murmurv2/core (it is
+ * currently duplicated across daemon / mcp-server / demos / this bridge).
+ */
+export function stableEnvelopePayload(envelope: EnvelopeV1): string {
+  return JSON.stringify({
+    schemaVersion: envelope.schemaVersion,
+    msgId: envelope.msgId,
+    conversationId: envelope.conversationId,
+    senderAgentId: envelope.senderAgentId,
+    recipients: [...envelope.recipients],
+    createdAt: envelope.createdAt,
+    payloadCiphertext: envelope.payloadCiphertext,
+    payloadNonce: envelope.payloadNonce,
+  });
+}
+
+type SealConfig = Pick<
+  BridgeA2AConfig,
+  "agentId" | "defaultTargetAgentId" | "signingPrivateKey" | "encryptionPrivateKey" | "recipientPublicKeys"
+>;
+
+/**
+ * Pure: inbound A2A task -> signed + encrypted Murmur EnvelopeV1 sealed to the
+ * target agent. External-caller provenance lives INSIDE the encrypted payload.
+ */
+export async function sealTaskEnvelope(task: InboundTask, cfg: SealConfig): Promise<EnvelopeV1> {
+  const target = cfg.defaultTargetAgentId;
+  const recipientKey = cfg.recipientPublicKeys[target];
+  if (!recipientKey) throw new Error(`a2a-bridge: no recipient public key for ${target}`);
+
+  const payload = JSON.stringify({
+    intent: "task",
+    source: "a2a",
+    externalAgentId: task.externalAgentId,
+    text: task.text,
+  });
+  const encrypted = await encryptPayload(payload, recipientKey, cfg.encryptionPrivateKey);
+
+  const unsigned: Omit<EnvelopeV1, "signature"> = {
+    schemaVersion: "1.0",
+    msgId: randomUUID(),
+    conversationId: task.conversationId,
+    senderAgentId: cfg.agentId,
+    recipients: [target],
+    createdAt: new Date().toISOString(),
+    payloadCiphertext: encrypted.ciphertext,
+    payloadNonce: encrypted.nonce,
+  };
+  const signature = await signEnvelope(
+    stableEnvelopePayload({ ...unsigned, signature: "" }),
+    cfg.signingPrivateKey,
+  );
+  return { ...unsigned, signature };
+}
+
+type OpenConfig = Pick<BridgeA2AConfig, "encryptionPrivateKey" | "recipientPublicKeys">;
+
+/**
+ * Pure: open an internal agent's reply envelope -> decrypted plaintext reply.
+ * The sender public key is not carried in the envelope (mesh convention); it is
+ * resolved out-of-band from `recipientPublicKeys` by senderAgentId — the same key
+ * directory federation #14 will formalize.
+ */
+export async function openReplyEnvelope(envelope: EnvelopeV1, cfg: OpenConfig): Promise<string> {
+  const senderPublicKey = cfg.recipientPublicKeys[envelope.senderAgentId];
+  if (!senderPublicKey) {
+    throw new Error(`a2a-bridge: no public key to open reply from ${envelope.senderAgentId}`);
+  }
+  return decryptPayload(
+    {
+      ciphertext: envelope.payloadCiphertext,
+      nonce: envelope.payloadNonce,
+      senderPublicKey,
+    },
+    cfg.encryptionPrivateKey,
+  );
+}
+
+/** Flatten an A2A Message's text parts into a single string. */
+export function extractText(message: Message): string {
+  const parts = message?.parts ?? [];
+  const out: string[] = [];
+  for (const part of parts) {
+    const content = part.content;
+    if (content && content.$case === "text") out.push(content.value);
+  }
+  return out.join("\n");
+}
+
 export class A2AMurmurBridge {
   private nc?: NatsConnection;
   private ackSub?: Subscription;
+  private server?: Server;
   private running = false;
-  /** msgId -> resolver, correlates internal reply/ACK back to the waiting A2A task. */
+  /** original msgId -> resolver, correlates the internal reply back to the A2A task. */
   private readonly pending = new Map<string, (reply: string) => void>();
 
   constructor(
     private readonly config: BridgeA2AConfig,
     private readonly log: Logger = () => {},
   ) {
-    if (!config.natsUrl) throw new Error("natsUrl is required");
-    if (!config.agentId) throw new Error("agentId is required");
+    if (!config.natsUrl) throw new Error("a2a-bridge: natsUrl is required");
+    if (!config.agentId) throw new Error("a2a-bridge: agentId is required");
+    if (!config.signingPrivateKey) throw new Error("a2a-bridge: signingPrivateKey is required");
+    if (!config.encryptionPrivateKey) throw new Error("a2a-bridge: encryptionPrivateKey is required");
   }
 
   private ackSubject(): string {
@@ -72,21 +197,29 @@ export class A2AMurmurBridge {
 
     // Internal replies/ACKs to this bridge land on ack.<agentId>; correlate by msgId.
     this.ackSub = this.nc.subscribe(this.ackSubject());
-    (async () => {
+    void (async () => {
       for await (const m of this.ackSub!) {
         try {
-          this.handleInternalReply(sc.decode(m.data));
+          await this.handleInternalReply(sc.decode(m.data));
         } catch (err) {
           this.log("error", "ack handling failed", { error: errMsg(err) });
         }
       }
     })().catch((err) => this.log("error", "ack loop crashed", { error: errMsg(err) }));
 
-    // TODO(a2a-sdk): start the A2A server here using @a2a-js/sdk + express:
-    //   const handler = new DefaultRequestHandler(this.agentCard(), executor);
-    //   express().use(new A2AExpressApp(handler).routes()).listen(this.config.a2aPort);
-    // The executor's message/send handler calls this.dispatchInboundTask(...).
-    // Verify exact SDK surface against a2aproject/a2a-js samples (v1.0.0-alpha.0).
+    // A2A server (alpha API): DefaultRequestHandler drives an AgentExecutor that
+    // bridges each inbound task into the mesh; express middleware exposes JSON-RPC
+    // + the Agent Card for discovery.
+    const requestHandler = new DefaultRequestHandler(
+      this.agentCard(),
+      new InMemoryTaskStore(),
+      new MurmurAgentExecutor(this),
+    );
+    const app = express();
+    app.use(express.json());
+    app.use("/.well-known/agent-card.json", agentCardHandler({ agentCardProvider: requestHandler }));
+    app.use(jsonRpcHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication }));
+    this.server = app.listen(this.config.a2aPort);
 
     this.running = true;
     this.log("info", "bridge-a2a started", {
@@ -95,14 +228,15 @@ export class A2AMurmurBridge {
     });
   }
 
-  /** A2A Agent Card served at GET /.well-known/agent.json (discovery). */
-  agentCard() {
-    return {
+  /** A2A Agent Card served at /.well-known/agent-card.json (discovery). */
+  agentCard(): AgentCard {
+    // fromJSON fills the protobuf required defaults (supportedInterfaces, security*,
+    // signatures, provider) so we only declare the fields we actually populate.
+    return AgentCard.fromJSON({
       name: `murmur-bridge:${this.config.defaultTargetAgentId}`,
       description: "A2A bridge into a private Murmur (E2E/NATS) agent mesh.",
       version: "0.1.0",
-      url: `http://0.0.0.0:${this.config.a2aPort}/`,
-      capabilities: { streaming: false }, // TODO: SSE in phase 2
+      capabilities: { streaming: false }, // TODO(phase2): SSE streaming
       defaultInputModes: ["text/plain"],
       defaultOutputModes: ["text/plain"],
       skills: [
@@ -113,34 +247,32 @@ export class A2AMurmurBridge {
           tags: ["bridge", "murmur"],
         },
       ],
-      // TODO: securitySchemes (OAuth2/API-key) — auth enforced before dispatch.
-    };
+      // TODO(phase2): securitySchemes (OAuth2/API-key) enforced before dispatch.
+    });
   }
 
   /**
    * Inbound A2A task -> internal Murmur envelope -> publish on msg.<target>.
-   * Resolves with the internal agent's reply (mapped to an A2A Artifact upstream).
+   * Resolves with the internal agent's decrypted reply (mapped to an A2A reply
+   * Message by the executor upstream).
    */
   async dispatchInboundTask(task: InboundTask): Promise<string> {
     if (!this.config.allowedExternalAgents.includes(task.externalAgentId)) {
       throw new Error(`a2a-bridge: external agent not allowlisted: ${task.externalAgentId}`);
     }
-    if (!this.nc) throw new Error("bridge not started");
+    if (!this.nc) throw new Error("a2a-bridge: not started");
 
     const target = this.config.defaultTargetAgentId;
-    const recipientKey = this.config.recipientPublicKeys[target];
-    if (!recipientKey) throw new Error(`no recipient public key for ${target}`);
-
-    const envelope = await this.sealEnvelope(task, target, recipientKey);
+    const envelope = await sealTaskEnvelope(task, this.config);
 
     const reply = new Promise<string>((resolve, reject) => {
       this.pending.set(envelope.msgId, resolve);
-      const t = setTimeout(() => {
+      const timer = setTimeout(() => {
         this.pending.delete(envelope.msgId);
         reject(new Error(`a2a-bridge: internal reply timeout for ${envelope.msgId}`));
       }, this.config.replyTimeoutMs ?? 120_000);
       // unref so a pending task never blocks shutdown
-      (t as unknown as { unref?: () => void }).unref?.();
+      (timer as unknown as { unref?: () => void }).unref?.();
     });
 
     this.nc.publish(`msg.${target}`, sc.encode(JSON.stringify(envelope)));
@@ -152,51 +284,25 @@ export class A2AMurmurBridge {
     return reply;
   }
 
-  /** Build a signed+encrypted Murmur EnvelopeV1 from an inbound A2A task. */
-  private async sealEnvelope(
-    task: InboundTask,
-    target: string,
-    recipientPublicKey: string,
-  ): Promise<EnvelopeV1> {
-    // Provenance of the external caller travels in the (encrypted) payload, not as
-    // a spoofable senderAgentId — the bridge signs as itself.
-    const payload = JSON.stringify({
-      intent: "task",
-      source: "a2a",
-      externalAgentId: task.externalAgentId,
-      text: task.text,
-    });
-    const { ciphertext, nonce } = await encryptPayload(payload, recipientPublicKey);
-    const msgId = cryptoRandomId();
-    const createdAt = new Date().toISOString(); // NOTE: ok at runtime; see workflow Date caveat for offline tooling
-    const unsigned: Omit<EnvelopeV1, "signature"> = {
-      schemaVersion: "1.0",
-      msgId,
-      conversationId: task.conversationId,
-      senderAgentId: this.config.agentId,
-      recipients: [target],
-      createdAt,
-      payloadCiphertext: ciphertext,
-      payloadNonce: nonce,
-    };
-    const signature = await signEnvelope(JSON.stringify(unsigned), this.config.signingPrivateKey);
-    return { ...unsigned, signature };
-  }
-
-  /** Internal reply/ACK on ack.<agentId> -> resolve the waiting A2A task. */
-  private handleInternalReply(raw: string): void {
+  /** Internal reply (fresh EnvelopeV1 with parentMsgId) or AckV1 -> resolve A2A task. */
+  private async handleInternalReply(raw: string): Promise<void> {
     const parsed: unknown = JSON.parse(raw);
-    // Replies may arrive as a fresh EnvelopeV1 (the agent's answer) or an AckV1.
+
     if (isEnvelopeV1(parsed)) {
-      const target = parsed.parentMsgId ?? parsed.conversationId;
-      const resolve = target ? this.pending.get(target) : undefined;
-      if (resolve) {
-        this.pending.delete(target!);
-        // TODO: decrypt payload via bridge private key, extract reply text.
-        resolve(parsed.payloadCiphertext); // placeholder until decrypt wired
+      // The agent's answer references the original task via parentMsgId.
+      const key = parsed.parentMsgId ?? parsed.conversationId;
+      const resolve = key ? this.pending.get(key) : undefined;
+      if (resolve && key) {
+        this.pending.delete(key);
+        try {
+          resolve(await openReplyEnvelope(parsed, this.config));
+        } catch (err) {
+          resolve(`[a2a-bridge decrypt error] ${errMsg(err)}`);
+        }
       }
       return;
     }
+
     const ack = parsed as AckV1;
     if (ack?.msgId && ack.status === "nack") {
       const resolve = this.pending.get(ack.msgId);
@@ -205,13 +311,19 @@ export class A2AMurmurBridge {
         resolve(`[murmur nack] ${ack.reason ?? "rejected"}`);
       }
     }
-    // a positive AckV1 just confirms delivery; the real answer comes as an envelope.
+    // A positive AckV1 only confirms delivery; the real answer arrives as an envelope.
   }
 
   async stop(): Promise<void> {
     this.running = false;
-    if (this.ackSub) this.ackSub.unsubscribe();
-    this.ackSub = undefined;
+    if (this.ackSub) {
+      this.ackSub.unsubscribe();
+      this.ackSub = undefined;
+    }
+    if (this.server) {
+      await new Promise<void>((resolve) => this.server!.close(() => resolve()));
+      this.server = undefined;
+    }
     if (this.nc) {
       await this.nc.drain();
       this.nc = undefined;
@@ -219,11 +331,59 @@ export class A2AMurmurBridge {
   }
 }
 
-function errMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+/** Bridges the A2A executor contract onto the Murmur dispatch path. */
+class MurmurAgentExecutor implements AgentExecutor {
+  constructor(private readonly bridge: A2AMurmurBridge) {}
+
+  execute = async (requestContext: RequestContext, eventBus: ExecutionEventBus): Promise<void> => {
+    const text = extractText(requestContext.userMessage);
+    const externalAgentId =
+      asString(requestContext.userMessage.metadata?.["externalAgentId"]) ?? "a2a-anonymous";
+
+    let replyText: string;
+    try {
+      replyText = await this.bridge.dispatchInboundTask({
+        externalAgentId,
+        conversationId: requestContext.contextId,
+        text,
+      });
+    } catch (err) {
+      replyText = `[a2a-bridge error] ${errMsg(err)}`;
+    }
+
+    eventBus.publish({ kind: "message", data: buildAgentMessage(replyText, requestContext) });
+    eventBus.finished();
+  };
+
+  cancelTask = async (_taskId: string, eventBus: ExecutionEventBus): Promise<void> => {
+    eventBus.finished();
+  };
 }
 
-function cryptoRandomId(): string {
-  // crypto.randomUUID is available on Node 18+; bridge runtime, not workflow sandbox.
-  return globalThis.crypto.randomUUID();
+function buildAgentMessage(text: string, ctx: RequestContext): Message {
+  return {
+    messageId: randomUUID(),
+    contextId: ctx.contextId,
+    taskId: ctx.taskId,
+    role: Role.ROLE_AGENT,
+    parts: [
+      {
+        content: { $case: "text", value: text },
+        metadata: undefined,
+        filename: "",
+        mediaType: "text/plain",
+      },
+    ],
+    metadata: undefined,
+    extensions: [],
+    referenceTaskIds: [],
+  };
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/packages/bridge-a2a/src/index.ts
+++ b/packages/bridge-a2a/src/index.ts
@@ -1,0 +1,229 @@
+// @murmurv2/bridge-a2a — A2A <-> Murmur bridge (v2.1 / track #4, E5).
+//
+// Trust boundary: terminates external A2A (JSON-RPC/HTTP, OAuth, Agent Card) and
+// re-wraps tasks as internal Murmur E2E envelopes on NATS. External agents speak
+// the industry-standard A2A protocol; the internal mesh keeps E2E + durable outbox.
+// Design: ../../Plans/Active "{murmur} {design} A2A to Murmur Bridge".
+//
+// STATUS: skeleton. Inbound A2A->Murmur path scaffolded. NOT built/tested yet.
+// Next: `npm i @a2a-js/sdk express`, wire the SDK request handler, `tsc`, tests.
+
+import { StringCodec, connect, type NatsConnection, type Subscription } from "nats";
+import {
+  isEnvelopeV1,
+  type AckV1,
+  type EnvelopeV1,
+} from "@murmurv2/core";
+import { encryptPayload, signEnvelope } from "@murmurv2/security";
+
+const sc = StringCodec();
+
+export interface BridgeA2AConfig {
+  /** NATS bus the internal mesh runs on. */
+  natsUrl: string;
+  natsToken?: string;
+  /** This bridge's own agent id on the mesh (e.g. "a2a-bridge"). */
+  agentId: string;
+  /** Default internal recipient for inbound A2A tasks (e.g. "agent-jarvis"). */
+  defaultTargetAgentId: string;
+  /** HTTP port the A2A server listens on. */
+  a2aPort: number;
+  /** Ed25519 private key the bridge signs internal envelopes with. */
+  signingPrivateKey: string;
+  /** Map internal agentId -> X25519 public key, for sealing the payload. */
+  recipientPublicKeys: Record<string, string>;
+  /** Allowlist of external A2A agent ids permitted to delegate tasks. */
+  allowedExternalAgents: string[];
+  /** ms to wait for the internal agent's reply before failing the A2A task. */
+  replyTimeoutMs?: number;
+}
+
+type Logger = (level: "info" | "warn" | "error", msg: string, meta?: unknown) => void;
+
+/** What an A2A message/send is mapped into before sealing. */
+interface InboundTask {
+  externalAgentId: string;
+  conversationId: string;
+  text: string;
+}
+
+export class A2AMurmurBridge {
+  private nc?: NatsConnection;
+  private ackSub?: Subscription;
+  private running = false;
+  /** msgId -> resolver, correlates internal reply/ACK back to the waiting A2A task. */
+  private readonly pending = new Map<string, (reply: string) => void>();
+
+  constructor(
+    private readonly config: BridgeA2AConfig,
+    private readonly log: Logger = () => {},
+  ) {
+    if (!config.natsUrl) throw new Error("natsUrl is required");
+    if (!config.agentId) throw new Error("agentId is required");
+  }
+
+  private ackSubject(): string {
+    return `ack.${this.config.agentId}`;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.nc = await connect({ servers: this.config.natsUrl, token: this.config.natsToken });
+
+    // Internal replies/ACKs to this bridge land on ack.<agentId>; correlate by msgId.
+    this.ackSub = this.nc.subscribe(this.ackSubject());
+    (async () => {
+      for await (const m of this.ackSub!) {
+        try {
+          this.handleInternalReply(sc.decode(m.data));
+        } catch (err) {
+          this.log("error", "ack handling failed", { error: errMsg(err) });
+        }
+      }
+    })().catch((err) => this.log("error", "ack loop crashed", { error: errMsg(err) }));
+
+    // TODO(a2a-sdk): start the A2A server here using @a2a-js/sdk + express:
+    //   const handler = new DefaultRequestHandler(this.agentCard(), executor);
+    //   express().use(new A2AExpressApp(handler).routes()).listen(this.config.a2aPort);
+    // The executor's message/send handler calls this.dispatchInboundTask(...).
+    // Verify exact SDK surface against a2aproject/a2a-js samples (v1.0.0-alpha.0).
+
+    this.running = true;
+    this.log("info", "bridge-a2a started", {
+      ackSubject: this.ackSubject(),
+      a2aPort: this.config.a2aPort,
+    });
+  }
+
+  /** A2A Agent Card served at GET /.well-known/agent.json (discovery). */
+  agentCard() {
+    return {
+      name: `murmur-bridge:${this.config.defaultTargetAgentId}`,
+      description: "A2A bridge into a private Murmur (E2E/NATS) agent mesh.",
+      version: "0.1.0",
+      url: `http://0.0.0.0:${this.config.a2aPort}/`,
+      capabilities: { streaming: false }, // TODO: SSE in phase 2
+      defaultInputModes: ["text/plain"],
+      defaultOutputModes: ["text/plain"],
+      skills: [
+        {
+          id: "delegate",
+          name: "Delegate task to Murmur agent",
+          description: "Forwards an A2A task to the internal agent and returns its reply.",
+          tags: ["bridge", "murmur"],
+        },
+      ],
+      // TODO: securitySchemes (OAuth2/API-key) — auth enforced before dispatch.
+    };
+  }
+
+  /**
+   * Inbound A2A task -> internal Murmur envelope -> publish on msg.<target>.
+   * Resolves with the internal agent's reply (mapped to an A2A Artifact upstream).
+   */
+  async dispatchInboundTask(task: InboundTask): Promise<string> {
+    if (!this.config.allowedExternalAgents.includes(task.externalAgentId)) {
+      throw new Error(`a2a-bridge: external agent not allowlisted: ${task.externalAgentId}`);
+    }
+    if (!this.nc) throw new Error("bridge not started");
+
+    const target = this.config.defaultTargetAgentId;
+    const recipientKey = this.config.recipientPublicKeys[target];
+    if (!recipientKey) throw new Error(`no recipient public key for ${target}`);
+
+    const envelope = await this.sealEnvelope(task, target, recipientKey);
+
+    const reply = new Promise<string>((resolve, reject) => {
+      this.pending.set(envelope.msgId, resolve);
+      const t = setTimeout(() => {
+        this.pending.delete(envelope.msgId);
+        reject(new Error(`a2a-bridge: internal reply timeout for ${envelope.msgId}`));
+      }, this.config.replyTimeoutMs ?? 120_000);
+      // unref so a pending task never blocks shutdown
+      (t as unknown as { unref?: () => void }).unref?.();
+    });
+
+    this.nc.publish(`msg.${target}`, sc.encode(JSON.stringify(envelope)));
+    this.log("info", "a2a task -> murmur", {
+      msgId: envelope.msgId,
+      target,
+      from: task.externalAgentId,
+    });
+    return reply;
+  }
+
+  /** Build a signed+encrypted Murmur EnvelopeV1 from an inbound A2A task. */
+  private async sealEnvelope(
+    task: InboundTask,
+    target: string,
+    recipientPublicKey: string,
+  ): Promise<EnvelopeV1> {
+    // Provenance of the external caller travels in the (encrypted) payload, not as
+    // a spoofable senderAgentId — the bridge signs as itself.
+    const payload = JSON.stringify({
+      intent: "task",
+      source: "a2a",
+      externalAgentId: task.externalAgentId,
+      text: task.text,
+    });
+    const { ciphertext, nonce } = await encryptPayload(payload, recipientPublicKey);
+    const msgId = cryptoRandomId();
+    const createdAt = new Date().toISOString(); // NOTE: ok at runtime; see workflow Date caveat for offline tooling
+    const unsigned: Omit<EnvelopeV1, "signature"> = {
+      schemaVersion: "1.0",
+      msgId,
+      conversationId: task.conversationId,
+      senderAgentId: this.config.agentId,
+      recipients: [target],
+      createdAt,
+      payloadCiphertext: ciphertext,
+      payloadNonce: nonce,
+    };
+    const signature = await signEnvelope(JSON.stringify(unsigned), this.config.signingPrivateKey);
+    return { ...unsigned, signature };
+  }
+
+  /** Internal reply/ACK on ack.<agentId> -> resolve the waiting A2A task. */
+  private handleInternalReply(raw: string): void {
+    const parsed: unknown = JSON.parse(raw);
+    // Replies may arrive as a fresh EnvelopeV1 (the agent's answer) or an AckV1.
+    if (isEnvelopeV1(parsed)) {
+      const target = parsed.parentMsgId ?? parsed.conversationId;
+      const resolve = target ? this.pending.get(target) : undefined;
+      if (resolve) {
+        this.pending.delete(target!);
+        // TODO: decrypt payload via bridge private key, extract reply text.
+        resolve(parsed.payloadCiphertext); // placeholder until decrypt wired
+      }
+      return;
+    }
+    const ack = parsed as AckV1;
+    if (ack?.msgId && ack.status === "nack") {
+      const resolve = this.pending.get(ack.msgId);
+      if (resolve) {
+        this.pending.delete(ack.msgId);
+        resolve(`[murmur nack] ${ack.reason ?? "rejected"}`);
+      }
+    }
+    // a positive AckV1 just confirms delivery; the real answer comes as an envelope.
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    if (this.ackSub) this.ackSub.unsubscribe();
+    this.ackSub = undefined;
+    if (this.nc) {
+      await this.nc.drain();
+      this.nc = undefined;
+    }
+  }
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function cryptoRandomId(): string {
+  // crypto.randomUUID is available on Node 18+; bridge runtime, not workflow sandbox.
+  return globalThis.crypto.randomUUID();
+}

--- a/packages/bridge-a2a/test/bridge-a2a.test.mjs
+++ b/packages/bridge-a2a/test/bridge-a2a.test.mjs
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import {
+  createKeyPair,
+  createSigningKeyPair,
+  decryptPayload,
+  encryptPayload,
+  verifyEnvelopeSignature,
+} from "../../security/dist/src/index.js";
+import {
+  A2AMurmurBridge,
+  extractText,
+  openReplyEnvelope,
+  sealTaskEnvelope,
+  stableEnvelopePayload,
+} from "../dist/src/index.js";
+
+// Build a complete bridge config with fresh, real keys.
+async function fixture() {
+  const bridgeEnc = await createKeyPair(); // X25519
+  const bridgeSign = await createSigningKeyPair(); // Ed25519
+  const agentEnc = await createKeyPair(); // the internal target's X25519 keypair
+  const cfg = {
+    natsUrl: "nats://127.0.0.1:4222",
+    agentId: "a2a-bridge",
+    defaultTargetAgentId: "agent-jarvis",
+    a2aPort: 0,
+    signingPrivateKey: bridgeSign.privateKey,
+    encryptionPrivateKey: bridgeEnc.privateKey,
+    recipientPublicKeys: { "agent-jarvis": agentEnc.publicKey },
+    allowedExternalAgents: ["ext-1"],
+  };
+  return { cfg, bridgeEnc, bridgeSign, agentEnc };
+}
+
+test("sealTaskEnvelope: target decrypts payload + signature verifies", async () => {
+  const { cfg, bridgeEnc, bridgeSign, agentEnc } = await fixture();
+
+  const env = await sealTaskEnvelope(
+    { externalAgentId: "ext-1", conversationId: "c1", text: "build me a thing" },
+    cfg,
+  );
+
+  assert.equal(env.senderAgentId, "a2a-bridge");
+  assert.deepEqual(env.recipients, ["agent-jarvis"]);
+  assert.equal(env.schemaVersion, "1.0");
+  assert.ok(env.signature.length > 0, "envelope is signed");
+
+  // The internal target opens the sealed payload (bridge pubkey supplied out-of-band).
+  const plain = await decryptPayload(
+    {
+      ciphertext: env.payloadCiphertext,
+      nonce: env.payloadNonce,
+      senderPublicKey: bridgeEnc.publicKey,
+    },
+    agentEnc.privateKey,
+  );
+  const obj = JSON.parse(plain);
+  assert.equal(obj.text, "build me a thing");
+  assert.equal(obj.externalAgentId, "ext-1");
+  assert.equal(obj.source, "a2a");
+  assert.equal(obj.intent, "task");
+
+  // Signature verifies against the mesh-canonical form with the bridge signing key.
+  const ok = await verifyEnvelopeSignature(
+    stableEnvelopePayload(env),
+    env.signature,
+    bridgeSign.publicKey,
+  );
+  assert.equal(ok, true);
+});
+
+test("openReplyEnvelope: bridge decrypts an internal agent reply", async () => {
+  const { cfg, bridgeEnc, agentEnc } = await fixture();
+
+  // The internal agent seals a reply back to the bridge.
+  const enc = await encryptPayload("done: thing built", bridgeEnc.publicKey, agentEnc.privateKey);
+  const replyEnv = {
+    schemaVersion: "1.0",
+    msgId: randomUUID(),
+    parentMsgId: randomUUID(),
+    conversationId: "c1",
+    senderAgentId: "agent-jarvis",
+    recipients: ["a2a-bridge"],
+    createdAt: new Date().toISOString(),
+    payloadCiphertext: enc.ciphertext,
+    payloadNonce: enc.nonce,
+    signature: "sig",
+  };
+
+  const reply = await openReplyEnvelope(replyEnv, cfg);
+  assert.equal(reply, "done: thing built");
+});
+
+test("openReplyEnvelope: rejects an unknown sender (no key in directory)", async () => {
+  const { cfg } = await fixture();
+  const bogus = {
+    schemaVersion: "1.0",
+    msgId: randomUUID(),
+    conversationId: "c1",
+    senderAgentId: "agent-unknown",
+    recipients: ["a2a-bridge"],
+    createdAt: new Date().toISOString(),
+    payloadCiphertext: "x",
+    payloadNonce: "y",
+    signature: "z",
+  };
+  await assert.rejects(() => openReplyEnvelope(bogus, cfg), /no public key to open reply/);
+});
+
+test("extractText: flattens text parts", () => {
+  const message = {
+    messageId: "m",
+    contextId: "c",
+    taskId: "t",
+    role: 2,
+    parts: [
+      { content: { $case: "text", value: "hello" }, metadata: undefined, filename: "", mediaType: "text/plain" },
+      { content: { $case: "text", value: "world" }, metadata: undefined, filename: "", mediaType: "text/plain" },
+    ],
+    metadata: undefined,
+    extensions: [],
+    referenceTaskIds: [],
+  };
+  assert.equal(extractText(message), "hello\nworld");
+});
+
+test("dispatchInboundTask: rejects a non-allowlisted external agent (no NATS needed)", async () => {
+  const { cfg } = await fixture();
+  const bridge = new A2AMurmurBridge(cfg);
+  await assert.rejects(
+    () => bridge.dispatchInboundTask({ externalAgentId: "evil", conversationId: "c", text: "x" }),
+    /not allowlisted/,
+  );
+});
+
+test("sealTaskEnvelope: throws when target has no recipient key", async () => {
+  const { cfg } = await fixture();
+  await assert.rejects(
+    () =>
+      sealTaskEnvelope(
+        { externalAgentId: "ext-1", conversationId: "c1", text: "x" },
+        { ...cfg, recipientPublicKeys: {} },
+      ),
+    /no recipient public key/,
+  );
+});

--- a/packages/bridge-a2a/tsconfig.json
+++ b/packages/bridge-a2a/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "composite": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@murmurv2/core": ["../core/src/index.ts"],
+      "@murmurv2/security": ["../security/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "../core" }, { "path": "../security" }]
+}


### PR DESCRIPTION
## What

Builds out the **A2A ↔ Murmur bridge** skeleton (`@murmurv2/bridge-a2a`) against the real
`@a2a-js/sdk@1.0.0-alpha.0` surface. External agents speak industry-standard A2A
(JSON-RPC/HTTP + Agent Card); each task is re-wrapped as an internal **E2E Murmur envelope**
on NATS — the mesh's encryption / signed envelopes / durable outbox stay untouched.

## Wiring (verified against alpha API, not the skeleton TODO)

- **A2A server:** `DefaultRequestHandler` + `InMemoryTaskStore` + a `MurmurAgentExecutor`,
  exposed via `jsonRpcHandler` + `agentCardHandler` + `UserBuilder.noAuthentication`.
  ⚠️ The old `new A2AExpressApp().routes()` surface from 0.x **does not exist in alpha** —
  this was the skeleton's stale assumption.
- **protobuf-style types:** `Part.content.$case==='text'`, `Role.ROLE_AGENT`,
  `eventBus.publish({ kind: 'message', data })`.

## Crypto fixes (skeleton had a real bug)

- `encryptPayload` needs **3 args** `(plaintext, recipientPub, senderPriv)` — added a bridge
  **`encryptionPrivateKey` (X25519)** to config; the skeleton called it with 2.
- **Reply decrypt** via `decryptPayload` + the sender's pubkey resolved **out-of-band** from
  `recipientPublicKeys` (the envelope doesn't carry it — same convention as `demo-consumer`).
  This is exactly the key directory **federation #14** will formalize.
- Replicated the **mesh-canonical `stableEnvelopePayload`** (byte-identical to
  `scripts/murmur-daemon.mjs` + `packages/mcp-server`) so internal agents **verify** the
  bridge's signature. The bridge signs+seals **as itself**; the external caller id travels
  *inside* the encrypted payload, never as a spoofable `senderAgentId`.

## Tests

`packages/bridge-a2a/test/bridge-a2a.test.mjs` — **6/6 passing** (`node --test`), real keys:
seal→target-decrypt, signature verifies over canonical form, reply round-trip, unknown-sender
reject, allowlist reject (no NATS), missing-recipient-key throw.

## Scope / boundaries (honest skeleton status)

- ✅ crypto / correlation / allowlist / agent-card — **wired + unit-tested**.
- ⏭️ **next gate:** live remote-A2A-client interop over HTTP (real external agent).
- ⏭️ phase-2: `securitySchemes` (OAuth2/API-key) enforced before dispatch; SSE streaming.
- 🔒 **opt-in package — intentionally NOT in root `tsc -b` / core CI** while `@a2a-js/sdk` is
  alpha (mirrors JetStream's default-OFF posture). Build/test via
  `npm -w @murmurv2/bridge-a2a run build && (cd packages/bridge-a2a && node --test)`.
- 📌 `stableEnvelopePayload` is now duplicated in 4 places — flagged a `TODO(core)` to promote
  it into `@murmurv2/core` as the single source of truth.

Review pass requested on: **API boundaries + E2E invariant** (CODEX-VOLT).