### PR TITLE
fix(broker): bound JetStream consumer redelivery

### DIFF
--- a/packages/broker-nats/dist/src/index.d.ts
+++ b/packages/broker-nats/dist/src/index.d.ts
@@ -5,6 +5,8 @@ export interface BrokerConfig {
     jetstream?: boolean;
     stream?: string;
     streamSubjects?: string[];
+    jetstreamMaxDeliver?: number;
+    jetstreamAckWaitMs?: number;
     token?: string;
     connectMaxAttempts?: number;
     connectBaseBackoffMs?: number;
@@ -43,6 +45,9 @@ export declare class NatsBroker {
     private jetStreamEnabled;
     private streamName;
     private streamSubjects;
+    private jetStreamMaxDeliver;
+    private jetStreamAckWaitNanos;
+    private buildJetStreamConsumerConfig;
     private ensureJetStream;
     private startStatusLoop;
     publish(subject: string, envelope: EnvelopeV1, policy?: SecurityPolicy): Promise<void>;

--- a/packages/broker-nats/dist/src/index.js
+++ b/packages/broker-nats/dist/src/index.js
@@ -66,6 +66,31 @@ export class NatsBroker {
     streamSubjects() {
         return this.config.streamSubjects ?? ["msg.>", "ack.>"];
     }
+    jetStreamMaxDeliver() {
+        const value = this.config.jetstreamMaxDeliver ?? 5;
+        if (!Number.isFinite(value) || value < 1) {
+            throw new Error("jetstream-max-deliver-invalid");
+        }
+        return Math.trunc(value);
+    }
+    jetStreamAckWaitNanos() {
+        const ackWaitMs = this.config.jetstreamAckWaitMs ?? 30000;
+        if (!Number.isFinite(ackWaitMs) || ackWaitMs <= 0) {
+            throw new Error("jetstream-ack-wait-invalid");
+        }
+        return Math.trunc(ackWaitMs * 1_000_000);
+    }
+    buildJetStreamConsumerConfig(subject, durableName) {
+        return {
+            durable_name: durableName,
+            name: durableName,
+            filter_subject: subject,
+            ack_policy: AckPolicy.Explicit,
+            deliver_policy: DeliverPolicy.All,
+            max_deliver: this.jetStreamMaxDeliver(),
+            ack_wait: this.jetStreamAckWaitNanos(),
+        };
+    }
     async ensureJetStream() {
         if (!this.jetStreamEnabled() || !this.nc)
             return;
@@ -144,19 +169,20 @@ export class NatsBroker {
             const decoded = JSON.parse(this.sc.decode(data));
             if (!isEnvelopeV1(decoded)) {
                 await this.publishAck(ackSubject, createAck("unknown", params.consumerId, "nack", "invalid-envelope"));
-                return;
+                return "ack";
             }
             msgId = decoded.msgId;
             ackSubject = `ack.${decoded.senderAgentId}`;
             const isDup = await params.dedupe.seen(decoded.msgId, params.consumerId);
             if (isDup) {
                 await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack", "duplicate-ignored"));
-                return;
+                return "ack";
             }
             await params.onMessage(decoded);
             await params.dedupe.markSeen(decoded.msgId, params.consumerId);
             this.failedDeliveries.delete(`${params.consumerId}:${decoded.msgId}`);
             await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack"));
+            return "ack";
         }
         catch (err) {
             const reason = err instanceof Error ? err.message : "handler-failed";
@@ -168,33 +194,36 @@ export class NatsBroker {
                 await params.dedupe.markSeen(msgId, params.consumerId);
                 this.failedDeliveries.delete(key);
                 await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", `poison-message:${reason}`));
-                return;
+                return "ack";
             }
             await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", reason));
+            return "retry";
         }
     }
     async ensureJetStreamConsumer(subject, durableName) {
         if (!this.jsm)
             throw new Error("jetstream-manager-unavailable");
         const stream = this.streamName();
+        const config = this.buildJetStreamConsumerConfig(subject, durableName);
+        let info;
         try {
-            const info = await this.jsm.consumers.info(stream, durableName);
-            const filterSubject = info.config.filter_subject;
-            if (filterSubject && filterSubject !== subject) {
-                throw new Error(`jetstream-consumer-filter-mismatch:${durableName}:${filterSubject}:${subject}`);
-            }
-            return;
+            info = await this.jsm.consumers.info(stream, durableName);
         }
         catch (err) {
             if (err instanceof Error && err.message.startsWith("jetstream-consumer-filter-mismatch:")) {
                 throw err;
             }
-            await this.jsm.consumers.add(stream, {
-                durable_name: durableName,
-                name: durableName,
-                filter_subject: subject,
-                ack_policy: AckPolicy.Explicit,
-                deliver_policy: DeliverPolicy.All,
+            await this.jsm.consumers.add(stream, config);
+            return;
+        }
+        const filterSubject = info.config.filter_subject;
+        if (filterSubject && filterSubject !== subject) {
+            throw new Error(`jetstream-consumer-filter-mismatch:${durableName}:${filterSubject}:${subject}`);
+        }
+        if (info.config.max_deliver !== config.max_deliver || info.config.ack_wait !== config.ack_wait) {
+            await this.jsm.consumers.update(stream, durableName, {
+                max_deliver: config.max_deliver,
+                ack_wait: config.ack_wait,
             });
         }
     }
@@ -207,8 +236,11 @@ export class NatsBroker {
         (async () => {
             for await (const m of messages) {
                 try {
-                    await onMessage(m.data);
-                    m.ack();
+                    const result = await onMessage(m.data);
+                    if (result === "retry")
+                        m.nak();
+                    else
+                        m.ack();
                 }
                 catch (err) {
                     m.nak();

--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -27,6 +27,8 @@ export interface BrokerConfig {
   jetstream?: boolean;
   stream?: string;
   streamSubjects?: string[];
+  jetstreamMaxDeliver?: number;
+  jetstreamAckWaitMs?: number;
   token?: string;
   connectMaxAttempts?: number;
   connectBaseBackoffMs?: number;
@@ -121,6 +123,34 @@ export class NatsBroker {
     return this.config.streamSubjects ?? ["msg.>", "ack.>"];
   }
 
+  private jetStreamMaxDeliver(): number {
+    const value = this.config.jetstreamMaxDeliver ?? 5;
+    if (!Number.isFinite(value) || value < 1) {
+      throw new Error("jetstream-max-deliver-invalid");
+    }
+    return Math.trunc(value);
+  }
+
+  private jetStreamAckWaitNanos(): number {
+    const ackWaitMs = this.config.jetstreamAckWaitMs ?? 30000;
+    if (!Number.isFinite(ackWaitMs) || ackWaitMs <= 0) {
+      throw new Error("jetstream-ack-wait-invalid");
+    }
+    return Math.trunc(ackWaitMs * 1_000_000);
+  }
+
+  private buildJetStreamConsumerConfig(subject: string, durableName: string) {
+    return {
+      durable_name: durableName,
+      name: durableName,
+      filter_subject: subject,
+      ack_policy: AckPolicy.Explicit,
+      deliver_policy: DeliverPolicy.All,
+      max_deliver: this.jetStreamMaxDeliver(),
+      ack_wait: this.jetStreamAckWaitNanos(),
+    };
+  }
+
   private async ensureJetStream(): Promise<void> {
     if (!this.jetStreamEnabled() || !this.nc) return;
     if (this.js && this.jsm) return;
@@ -202,14 +232,14 @@ export class NatsBroker {
       onMessage: MessageHandler;
       maxPoisonAttempts?: number;
     },
-  ): Promise<void> {
+  ): Promise<"ack" | "retry"> {
     let msgId = "unknown";
     let ackSubject = `ack.${params.consumerId}`;
     try {
       const decoded = JSON.parse(this.sc.decode(data));
       if (!isEnvelopeV1(decoded)) {
         await this.publishAck(ackSubject, createAck("unknown", params.consumerId, "nack", "invalid-envelope"));
-        return;
+        return "ack";
       }
 
       msgId = decoded.msgId;
@@ -217,13 +247,14 @@ export class NatsBroker {
       const isDup = await params.dedupe.seen(decoded.msgId, params.consumerId);
       if (isDup) {
         await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack", "duplicate-ignored"));
-        return;
+        return "ack";
       }
 
       await params.onMessage(decoded);
       await params.dedupe.markSeen(decoded.msgId, params.consumerId);
       this.failedDeliveries.delete(`${params.consumerId}:${decoded.msgId}`);
       await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack"));
+      return "ack";
     } catch (err) {
       const reason = err instanceof Error ? err.message : "handler-failed";
       const maxPoisonAttempts = params.maxPoisonAttempts ?? 3;
@@ -234,32 +265,36 @@ export class NatsBroker {
         await params.dedupe.markSeen(msgId, params.consumerId);
         this.failedDeliveries.delete(key);
         await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", `poison-message:${reason}`));
-        return;
+        return "ack";
       }
       await this.publishAck(ackSubject, createAck(msgId, params.consumerId, "nack", reason));
+      return "retry";
     }
   }
 
   private async ensureJetStreamConsumer(subject: string, durableName: string): Promise<void> {
     if (!this.jsm) throw new Error("jetstream-manager-unavailable");
     const stream = this.streamName();
+    const config = this.buildJetStreamConsumerConfig(subject, durableName);
+    let info;
     try {
-      const info = await this.jsm.consumers.info(stream, durableName);
-      const filterSubject = info.config.filter_subject;
-      if (filterSubject && filterSubject !== subject) {
-        throw new Error(`jetstream-consumer-filter-mismatch:${durableName}:${filterSubject}:${subject}`);
-      }
-      return;
+      info = await this.jsm.consumers.info(stream, durableName);
     } catch (err) {
       if (err instanceof Error && err.message.startsWith("jetstream-consumer-filter-mismatch:")) {
         throw err;
       }
-      await this.jsm.consumers.add(stream, {
-        durable_name: durableName,
-        name: durableName,
-        filter_subject: subject,
-        ack_policy: AckPolicy.Explicit,
-        deliver_policy: DeliverPolicy.All,
+      await this.jsm.consumers.add(stream, config);
+      return;
+    }
+
+    const filterSubject = info.config.filter_subject;
+    if (filterSubject && filterSubject !== subject) {
+      throw new Error(`jetstream-consumer-filter-mismatch:${durableName}:${filterSubject}:${subject}`);
+    }
+    if (info.config.max_deliver !== config.max_deliver || info.config.ack_wait !== config.ack_wait) {
+      await this.jsm.consumers.update(stream, durableName, {
+        max_deliver: config.max_deliver,
+        ack_wait: config.ack_wait,
       });
     }
   }
@@ -267,7 +302,7 @@ export class NatsBroker {
   private async consumeJetStream(
     subject: string,
     durableName: string,
-    onMessage: (data: Uint8Array) => Promise<void>,
+    onMessage: (data: Uint8Array) => Promise<"ack" | "retry" | void>,
   ): Promise<BrokerSubscription> {
     await this.ensureJetStreamConsumer(subject, durableName);
     if (!this.js) throw new Error("jetstream-client-unavailable");
@@ -278,8 +313,9 @@ export class NatsBroker {
     (async () => {
       for await (const m of messages) {
         try {
-          await onMessage(m.data);
-          m.ack();
+          const result = await onMessage(m.data);
+          if (result === "retry") m.nak();
+          else m.ack();
         } catch (err) {
           m.nak();
           const e = err instanceof Error ? err : new Error(String(err));

--- a/tests/broker-jetstream.test.mjs
+++ b/tests/broker-jetstream.test.mjs
@@ -18,9 +18,10 @@ const envelope = {
   signature: "sig",
 };
 
-const makeJetStreamBroker = ({ streamInfoThrows = true, messages = [] } = {}) => {
+const makeJetStreamBroker = ({ streamInfoThrows = true, consumerInfo, messages = [], brokerConfig = {} } = {}) => {
   const streamsAdded = [];
   const consumersAdded = [];
+  const consumersUpdated = [];
   const published = [];
   const acked = [];
   const nacked = [];
@@ -57,10 +58,14 @@ const makeJetStreamBroker = ({ streamInfoThrows = true, messages = [] } = {}) =>
     },
     consumers: {
       async info() {
+        if (consumerInfo) return consumerInfo;
         throw new Error("consumer-missing");
       },
       async add(stream, config) {
         consumersAdded.push({ stream, config });
+      },
+      async update(stream, durable, config) {
+        consumersUpdated.push({ stream, durable, config });
       },
     },
   };
@@ -97,10 +102,11 @@ const makeJetStreamBroker = ({ streamInfoThrows = true, messages = [] } = {}) =>
     jetstream: true,
     stream: "MURMUR",
     streamSubjects: ["msg.>", "ack.>"],
+    ...brokerConfig,
   });
   broker.nc = fakeNc;
 
-  return { broker, streamsAdded, consumersAdded, published, acked, nacked };
+  return { broker, streamsAdded, consumersAdded, consumersUpdated, published, acked, nacked };
 };
 
 test("JetStream publish ensures stream and uses envelope msgId as dedupe id", async () => {
@@ -156,10 +162,125 @@ test("JetStream subscribeWithAck creates durable explicit-ack consumer", async (
   assert.equal(consumersAdded[0].config.durable_name, "agent-receiver");
   assert.equal(consumersAdded[0].config.filter_subject, "msg.agent-receiver");
   assert.equal(consumersAdded[0].config.ack_policy, "explicit");
+  assert.equal(consumersAdded[0].config.max_deliver, 5);
+  assert.equal(consumersAdded[0].config.ack_wait, 30_000_000_000);
   assert.equal(published[0].subject, "ack.agent-sender");
   assert.equal(published[0].body.status, "ack");
   assert.equal(published[0].opts.msgID, `ack:${envelope.msgId}:agent-receiver:ack`);
   assert.equal(acked.length, 1);
+});
+
+test("JetStream consumer delivery limits are configurable", async () => {
+  const { broker, consumersAdded } = makeJetStreamBroker({
+    brokerConfig: {
+      jetstreamMaxDeliver: 2,
+      jetstreamAckWaitMs: 750,
+    },
+  });
+  const dedupe = {
+    async seen() { return false; },
+    async markSeen() {},
+  };
+
+  await broker.subscribeWithAck({
+    subject: "msg.agent-receiver",
+    consumerId: "agent-receiver",
+    dedupe,
+    onMessage: async () => {},
+  });
+
+  assert.equal(consumersAdded[0].config.max_deliver, 2);
+  assert.equal(consumersAdded[0].config.ack_wait, 750_000_000);
+});
+
+test("JetStream existing durable consumer is repaired when delivery limits drift", async () => {
+  const { broker, consumersAdded, consumersUpdated } = makeJetStreamBroker({
+    consumerInfo: {
+      config: {
+        durable_name: "agent-receiver",
+        filter_subject: "msg.agent-receiver",
+        max_deliver: -1,
+        ack_wait: 30_000_000_000,
+      },
+    },
+  });
+  const dedupe = {
+    async seen() { return false; },
+    async markSeen() {},
+  };
+
+  await broker.subscribeWithAck({
+    subject: "msg.agent-receiver",
+    consumerId: "agent-receiver",
+    dedupe,
+    onMessage: async () => {},
+  });
+
+  assert.equal(consumersAdded.length, 0);
+  assert.deepEqual(consumersUpdated, [{
+    stream: "MURMUR",
+    durable: "agent-receiver",
+    config: {
+      max_deliver: 5,
+      ack_wait: 30_000_000_000,
+    },
+  }]);
+});
+
+test("JetStream retryable handler failures are nacked for redelivery", async () => {
+  const { broker, published, acked, nacked } = makeJetStreamBroker({
+    messages: [sc.encode(JSON.stringify(envelope))],
+  });
+  const dedupe = {
+    async seen() { return false; },
+    async markSeen() {},
+  };
+
+  await broker.subscribeWithAck({
+    subject: "msg.agent-receiver",
+    consumerId: "agent-receiver",
+    dedupe,
+    maxPoisonAttempts: 99,
+    onMessage: async () => {
+      throw new Error("handler-down");
+    },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(acked.length, 0);
+  assert.equal(nacked.length, 1);
+  assert.equal(published[0].subject, "ack.agent-sender");
+  assert.equal(published[0].body.status, "nack");
+  assert.equal(published[0].body.reason, "handler-down");
+});
+
+test("JetStream poison-message terminal failure is acked", async () => {
+  const { broker, published, acked, nacked } = makeJetStreamBroker({
+    messages: [sc.encode(JSON.stringify(envelope))],
+  });
+  const dedupe = {
+    async seen() { return false; },
+    async markSeen() {},
+  };
+
+  await broker.subscribeWithAck({
+    subject: "msg.agent-receiver",
+    consumerId: "agent-receiver",
+    dedupe,
+    maxPoisonAttempts: 1,
+    onMessage: async () => {
+      throw new Error("bad-payload");
+    },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(acked.length, 1);
+  assert.equal(nacked.length, 0);
+  assert.equal(published[0].subject, "ack.agent-sender");
+  assert.equal(published[0].body.status, "nack");
+  assert.equal(published[0].body.reason, "poison-message:bad-payload");
 });
 
 test("JetStream ACK correlation consumes durable ack subject and updates outbox", async () => {


### PR DESCRIPTION
## Summary
- configure JetStream durable consumers with finite `max_deliver` and `ack_wait` defaults (`5`, `30000ms`) plus BrokerConfig overrides
- repair existing durable consumers when `max_deliver` / `ack_wait` drift from configured values
- make JetStream retryable handler failures `nak()` so broker redelivery and max-deliver advisories can fire; terminal poison failures still ack final state

## Verification
- `npm run build`
- `npm run test:unit` (52/52)
- isolated JetStream smoke on shared broker with unique stream/subjects, no broker restart: consumer `max_deliver=2`, `ack_wait=500000000`; observed exactly 2 deliveries and `$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES...`; stream cleaned up

## Notes
- No boevoy source edits.
- This closes the durability gap found after PR #30: consumers no longer default to NATS infinite delivery (`max_deliver=-1`).