### PR TITLE
fix(wake): reseed missing Codex app-server threads

### DIFF
--- a/scripts/codex-app-server-wake.mjs
+++ b/scripts/codex-app-server-wake.mjs
@@ -25,6 +25,29 @@ export const buildTurnStartRequest = ({ id = 1, threadId, text, metadata = {} })
   },
 });
 
+const buildThreadStartParams = () => ({
+  model: null,
+  modelProvider: null,
+  cwd: null,
+  runtimeWorkspaceRoots: null,
+  approvalPolicy: null,
+  approvalsReviewer: null,
+  sandbox: null,
+  permissions: null,
+  config: null,
+  serviceName: null,
+  baseInstructions: null,
+  developerInstructions: null,
+  personality: null,
+  ephemeral: false,
+  sessionStartSource: null,
+  threadSource: null,
+  environments: null,
+  dynamicTools: null,
+  selectedCapabilityRoots: null,
+  mockExperimentalField: null,
+});
+
 const buildInitializeRequest = (id) => ({
   id,
   method: "initialize",
@@ -133,13 +156,11 @@ export class CodexAppServerClient {
 export const createCodexAppServerInjector = ({ Client = CodexAppServerClient, log = () => {}, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) => {
   return async (payload, peer) => {
     const socketPath = peer?.socketPath || peer?.target;
-    const threadId = peer?.threadId;
     if (!socketPath) throw new Error(`codex-app-server-socket-missing:${payload.from}`);
-    if (!threadId) throw new Error(`codex-app-server-thread-missing:${payload.from}`);
 
     const client = new Client({ socketPath, timeoutMs });
     const text = buildCodexTurnText(payload);
-    const result = await client.request("turn/start", {
+    const startTurn = (threadId) => client.request("turn/start", {
       threadId,
       input: [{ type: "text", text, text_elements: [] }],
       responsesapiClientMetadata: {
@@ -148,6 +169,29 @@ export const createCodexAppServerInjector = ({ Client = CodexAppServerClient, lo
         murmur_from: payload.from || "",
       },
     });
+
+    let threadId = peer?.threadId;
+    if (!threadId) {
+      const started = await client.request("thread/start", buildThreadStartParams());
+      threadId = started?.thread?.id;
+      if (!threadId) throw new Error(`codex-app-server-thread-start-missing:${payload.from}`);
+      peer.threadId = threadId;
+      log("info", "Codex app-server wake thread seeded", { msgId: payload.msgId, threadId, socketPath });
+    }
+
+    let result;
+    try {
+      result = await startTurn(threadId);
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      if (!e.message.startsWith("codex-app-server-error:thread not found:")) throw e;
+      const started = await client.request("thread/start", buildThreadStartParams());
+      threadId = started?.thread?.id;
+      if (!threadId) throw new Error(`codex-app-server-thread-start-missing:${payload.from}`);
+      peer.threadId = threadId;
+      log("info", "Codex app-server wake thread re-seeded", { msgId: payload.msgId, threadId, socketPath });
+      result = await startTurn(threadId);
+    }
     log("info", "Codex app-server wake completed", { msgId: payload.msgId, threadId, socketPath });
     return result;
   };

--- a/tests/codex-app-server-wake.test.mjs
+++ b/tests/codex-app-server-wake.test.mjs
@@ -169,9 +169,57 @@ test("WakeMonitor gates Codex app-server wake before injector", async () => {
   assert.deepEqual(injected, [{ msgId: "msg-codex-1", mode: "codex_app_server", threadId: "thread-1" }]);
 });
 
-test("Codex app-server injector fails loud without socket or thread", async () => {
+test("Codex app-server injector re-seeds stale app-server threads", async () => {
+  const calls = [];
+  const logs = [];
+  class FakeClient {
+    async request(method, params) {
+      calls.push({ method, params });
+      if (method === "turn/start" && params.threadId === "stale-thread") {
+        throw new Error("codex-app-server-error:thread not found: stale-thread");
+      }
+      if (method === "thread/start") return { thread: { id: "fresh-thread" } };
+      return { turn: { id: "turn-1" } };
+    }
+  }
+  const peer = { mode: "codex_app_server", socketPath: "/tmp/codex.sock", threadId: "stale-thread" };
+  const injector = createCodexAppServerInjector({
+    Client: FakeClient,
+    log: (level, message, data) => logs.push({ level, message, data }),
+  });
+
+  const result = await injector(payload, peer);
+
+  assert.deepEqual(result, { turn: { id: "turn-1" } });
+  assert.equal(peer.threadId, "fresh-thread");
+  assert.deepEqual(calls.map((call) => call.method), ["turn/start", "thread/start", "turn/start"]);
+  assert.equal(calls[0].params.threadId, "stale-thread");
+  assert.equal(calls[2].params.threadId, "fresh-thread");
+  assert.equal(logs[0].message, "Codex app-server wake thread re-seeded");
+});
+
+test("Codex app-server injector seeds missing app-server threads", async () => {
+  const calls = [];
+  class FakeClient {
+    async request(method, params) {
+      calls.push({ method, params });
+      if (method === "thread/start") return { thread: { id: "fresh-thread" } };
+      return { turn: { id: "turn-1" } };
+    }
+  }
+  const peer = { mode: "codex_app_server", socketPath: "/tmp/codex.sock" };
+  const injector = createCodexAppServerInjector({ Client: FakeClient });
+
+  const result = await injector(payload, peer);
+
+  assert.deepEqual(result, { turn: { id: "turn-1" } });
+  assert.equal(peer.threadId, "fresh-thread");
+  assert.deepEqual(calls.map((call) => call.method), ["thread/start", "turn/start"]);
+  assert.equal(calls[1].params.threadId, "fresh-thread");
+});
+
+test("Codex app-server injector fails loud without socket", async () => {
   const injector = createCodexAppServerInjector();
 
   await assert.rejects(() => injector(payload, { mode: "codex_app_server", threadId: "thread-1" }), /socket-missing/);
-  await assert.rejects(() => injector(payload, { mode: "codex_app_server", socketPath: "/tmp/codex.sock" }), /thread-missing/);
 });


### PR DESCRIPTION
## Summary
- make the Codex app-server wake injector create a new app-server thread when `threadId` is missing
- retry `turn/start` after `codex-app-server-error:thread not found:*` by creating a fresh thread over the same Unix socket
- update the in-memory peer threadId after seeding/re-seeding so subsequent wakes use the fresh target

## Why
Today's wake incident had two separate failures: socket startup and stale/missing app-server thread registry. Runtime seed through `app-server-control.sock` proved native wake works, but the thread registry is lost when the app-server restarts. This PR makes the wake path self-heal instead of requiring manual thread seeding.

## Verification
- `npm run test:unit` (50/50 on branch from `origin/main`)
- Live runtime proof before this PR: JARVIS probe msgId `06aab233-9fa2-488c-b206-81f53aefed8a` produced `Codex app-server wake completed` and outbound `WAKE_PROBE_ACK_20260621_1748` after seeding through the daemon socket.

## Notes
- No boevoy source edits.
- This is independent of PR #32 (JetStream delivery limits).