### PR TITLE
feat(federation): org/agent addressing + signed key directory (#14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@murmurv2/federation": {
+      "resolved": "packages/federation",
+      "link": true
+    },
     "node_modules/@murmurv2/mcp-server": {
       "resolved": "packages/mcp-server",
       "link": true
@@ -830,6 +834,13 @@
       "version": "0.1.0",
       "dependencies": {
         "pg": "^8.16.3"
+      }
+    },
+    "packages/federation": {
+      "name": "@murmurv2/federation",
+      "version": "0.1.0",
+      "dependencies": {
+        "@murmurv2/security": "0.1.0"
       }
     },
     "packages/mcp-server": {

--- a/packages/federation/package.json
+++ b/packages/federation/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@murmurv2/federation",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@murmurv2/security": "0.1.0"
+  }
+}

--- a/packages/federation/src/index.ts
+++ b/packages/federation/src/index.ts
@@ -1,0 +1,155 @@
+// @murmurv2/federation — cross-org addressing + signed peer/key directory.
+// Federation E4 / track #14, JARVIS's half of the split.
+//   - JARVIS (here): org/agent addressing API + signed key directory (roster).
+//   - CODEX-VOLT:     NATS leaf-node / per-org account `fed.*` subject contract + smoke.
+//
+// Interlock: an address `org/agentId` selects the transport subject on Codex's side;
+// before any cross-org encrypt/verify, `bridge-murmur` fetches the PARTNER org's
+// roster (this module) and verifies its Ed25519 signature against a pinned org key.
+// The roster is the ONLY net-new crypto surface federation adds (PRD E4, line 126).
+//
+// Joint back-compat invariant: a BARE `agentId` (no slash) ⇒ the LOCAL org — so
+// today's single-org mesh keeps working untouched.
+//
+// STATUS: skeleton. Addressing + roster sign/verify/lookup are pure + unit-tested.
+// Live cross-org fetch/transport (Codex's leaf-node contract) is the integration gate.
+
+import { signEnvelope, verifyEnvelopeSignature } from "@murmurv2/security";
+
+// ─────────────────────────── Addressing ───────────────────────────
+
+export interface AgentAddress {
+  /** Owning organization id (e.g. "aimindset"). */
+  org: string;
+  /** Agent id within the org (e.g. "agent-jarvis"). */
+  agentId: string;
+}
+
+const TOKEN_RE = /^[A-Za-z0-9._-]+$/;
+
+function validateToken(value: string, label: string): void {
+  if (!value || !TOKEN_RE.test(value)) {
+    throw new Error(`federation: invalid ${label}: ${JSON.stringify(value)}`);
+  }
+}
+
+/**
+ * Parse `org/agentId` or a bare `agentId`. A bare id resolves to `localOrg`
+ * (back-compat invariant). Exactly one slash is allowed.
+ */
+export function parseAddress(raw: string, localOrg: string): AgentAddress {
+  validateToken(localOrg, "localOrg");
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new Error("federation: empty address");
+  }
+  const slash = raw.indexOf("/");
+  if (slash === -1) {
+    validateToken(raw, "agentId");
+    return { org: localOrg, agentId: raw };
+  }
+  const org = raw.slice(0, slash);
+  const agentId = raw.slice(slash + 1);
+  if (agentId.includes("/")) throw new Error(`federation: nested slash in address: ${raw}`);
+  validateToken(org, "org");
+  validateToken(agentId, "agentId");
+  return { org, agentId };
+}
+
+/** Canonical `org/agentId` string. */
+export function formatAddress(addr: AgentAddress): string {
+  validateToken(addr.org, "org");
+  validateToken(addr.agentId, "agentId");
+  return `${addr.org}/${addr.agentId}`;
+}
+
+/** True when the address is served by the local org (no federation hop). */
+export function isLocal(addr: AgentAddress, localOrg: string): boolean {
+  return addr.org === localOrg;
+}
+
+// ──────────────────── Signed key directory (roster) ────────────────────
+
+/** Public keys an agent advertises to peers. */
+export interface AgentKeys {
+  /** X25519 public key (base64) — peers seal E2E payloads to this. */
+  encryptPublicKey: string;
+  /** Ed25519 public key (base64) — peers verify this agent's envelope signatures. */
+  verifyPublicKey: string;
+}
+
+/** The unsigned roster an org publishes for its agents. */
+export interface RosterBody {
+  org: string;
+  /** Monotonic version; consumers reject a lower version than last seen. */
+  version: number;
+  /** ISO timestamp. NOTE: ok at runtime; offline tooling must inject the time. */
+  issuedAt: string;
+  /** agentId -> advertised keys. */
+  agents: Record<string, AgentKeys>;
+}
+
+/** A roster plus the org's Ed25519 signature over its canonical form. */
+export interface SignedRoster extends RosterBody {
+  /** Ed25519 signature (base64) over canonicalRoster(body). */
+  signature: string;
+  /** The org's Ed25519 directory-signing public key (base64), pinned out-of-band. */
+  signingPublicKey: string;
+}
+
+/**
+ * Canonical signing input: fixed field order + agents sorted by id, so the bytes
+ * are independent of object insertion order. MUST stay identical on sign + verify.
+ */
+export function canonicalRoster(body: RosterBody): string {
+  const agents: Record<string, AgentKeys> = {};
+  for (const id of Object.keys(body.agents).sort()) {
+    const k = body.agents[id];
+    agents[id] = { encryptPublicKey: k.encryptPublicKey, verifyPublicKey: k.verifyPublicKey };
+  }
+  return JSON.stringify({
+    org: body.org,
+    version: body.version,
+    issuedAt: body.issuedAt,
+    agents,
+  });
+}
+
+/** Sign a roster body with the org's Ed25519 directory-signing keypair. */
+export async function signRoster(
+  body: RosterBody,
+  signingPrivateKey: string,
+  signingPublicKey: string,
+): Promise<SignedRoster> {
+  if (!Number.isInteger(body.version) || body.version < 1) {
+    throw new Error("federation: roster version must be a positive integer");
+  }
+  const signature = await signEnvelope(canonicalRoster(body), signingPrivateKey);
+  return { ...body, signature, signingPublicKey };
+}
+
+/**
+ * Verify a signed roster against its embedded signingPublicKey. The caller MUST
+ * have pinned/trusted that key for `roster.org` out-of-band (e.g. partner key
+ * exchange) — this only proves the roster was signed by whoever holds it.
+ */
+export async function verifyRoster(roster: SignedRoster): Promise<boolean> {
+  if (!roster || !roster.signature || !roster.signingPublicKey) return false;
+  const body: RosterBody = {
+    org: roster.org,
+    version: roster.version,
+    issuedAt: roster.issuedAt,
+    agents: roster.agents,
+  };
+  try {
+    return await verifyEnvelopeSignature(canonicalRoster(body), roster.signature, roster.signingPublicKey);
+  } catch {
+    return false;
+  }
+}
+
+/** Look up an agent's advertised keys in a roster. Throws if absent. */
+export function lookupAgentKeys(roster: SignedRoster, agentId: string): AgentKeys {
+  const keys = roster.agents[agentId];
+  if (!keys) throw new Error(`federation: agent not in roster ${roster.org}: ${agentId}`);
+  return keys;
+}

--- a/packages/federation/test/federation.test.mjs
+++ b/packages/federation/test/federation.test.mjs
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createKeyPair, createSigningKeyPair } from "../../security/dist/src/index.js";
+import {
+  canonicalRoster,
+  formatAddress,
+  isLocal,
+  lookupAgentKeys,
+  parseAddress,
+  signRoster,
+  verifyRoster,
+} from "../dist/src/index.js";
+
+// ─── Addressing ───
+
+test("parseAddress: bare agentId resolves to local org (back-compat)", () => {
+  assert.deepEqual(parseAddress("agent-jarvis", "aimindset"), {
+    org: "aimindset",
+    agentId: "agent-jarvis",
+  });
+});
+
+test("parseAddress: org/agentId splits on the single slash", () => {
+  assert.deepEqual(parseAddress("partner/agent-bob", "aimindset"), {
+    org: "partner",
+    agentId: "agent-bob",
+  });
+});
+
+test("parseAddress: rejects nested slash + empty", () => {
+  assert.throws(() => parseAddress("a/b/c", "local"), /nested slash/);
+  assert.throws(() => parseAddress("", "local"), /empty address/);
+});
+
+test("formatAddress + isLocal round-trip", () => {
+  const addr = parseAddress("partner/agent-bob", "aimindset");
+  assert.equal(formatAddress(addr), "partner/agent-bob");
+  assert.equal(isLocal(addr, "aimindset"), false);
+  assert.equal(isLocal(parseAddress("agent-jarvis", "aimindset"), "aimindset"), true);
+});
+
+// ─── Signed roster ───
+
+async function buildRoster(org = "aimindset") {
+  const sign = await createSigningKeyPair(); // Ed25519 directory-signing key
+  const jarvisEnc = await createKeyPair(); // X25519
+  const jarvisSig = await createSigningKeyPair(); // Ed25519 (verify)
+  const body = {
+    org,
+    version: 1,
+    issuedAt: "2026-06-21T18:00:00.000Z",
+    agents: {
+      "agent-jarvis": {
+        encryptPublicKey: jarvisEnc.publicKey,
+        verifyPublicKey: jarvisSig.publicKey,
+      },
+    },
+  };
+  const roster = await signRoster(body, sign.privateKey, sign.publicKey);
+  return { roster, sign, jarvisEnc, jarvisSig };
+}
+
+test("signRoster -> verifyRoster round-trips", async () => {
+  const { roster } = await buildRoster();
+  assert.ok(roster.signature.length > 0);
+  assert.equal(await verifyRoster(roster), true);
+});
+
+test("verifyRoster fails on tampered keys (sig covers the body)", async () => {
+  const { roster } = await buildRoster();
+  const forged = await createKeyPair();
+  const tampered = {
+    ...roster,
+    agents: {
+      "agent-jarvis": {
+        ...roster.agents["agent-jarvis"],
+        encryptPublicKey: forged.publicKey, // swap in an attacker key
+      },
+    },
+  };
+  assert.equal(await verifyRoster(tampered), false);
+});
+
+test("verifyRoster fails when signed by a different org key", async () => {
+  const { roster } = await buildRoster();
+  const attacker = await createSigningKeyPair();
+  assert.equal(await verifyRoster({ ...roster, signingPublicKey: attacker.publicKey }), false);
+});
+
+test("canonicalRoster is insertion-order independent", () => {
+  const a = { org: "o", version: 1, issuedAt: "t", agents: { b: { encryptPublicKey: "1", verifyPublicKey: "2" }, a: { encryptPublicKey: "3", verifyPublicKey: "4" } } };
+  const b = { org: "o", version: 1, issuedAt: "t", agents: { a: { encryptPublicKey: "3", verifyPublicKey: "4" }, b: { encryptPublicKey: "1", verifyPublicKey: "2" } } };
+  assert.equal(canonicalRoster(a), canonicalRoster(b));
+});
+
+test("lookupAgentKeys returns keys / throws on miss", async () => {
+  const { roster, jarvisEnc } = await buildRoster();
+  assert.equal(lookupAgentKeys(roster, "agent-jarvis").encryptPublicKey, jarvisEnc.publicKey);
+  assert.throws(() => lookupAgentKeys(roster, "ghost"), /not in roster/);
+});
+
+test("signRoster rejects non-positive version", async () => {
+  const sign = await createSigningKeyPair();
+  await assert.rejects(
+    () => signRoster({ org: "o", version: 0, issuedAt: "t", agents: {} }, sign.privateKey, sign.publicKey),
+    /version must be a positive integer/,
+  );
+});

--- a/packages/federation/tsconfig.json
+++ b/packages/federation/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "composite": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@murmurv2/security": ["../security/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "../security" }]
+}


### PR DESCRIPTION
## What

JARVIS's half of the **federation #14** split (PRD E4) — new `@murmurv2/federation` package:

- **Addressing API:** `parseAddress` / `formatAddress` / `isLocal`. Format is `org/agentId`;
  a **bare `agentId` resolves to the local org** — the joint back-compat invariant so the
  current single-org mesh keeps working untouched. Exactly one slash; token validation.
- **Signed key directory (roster):** per-org **Ed25519-signed roster** mapping
  `agentId -> { encryptPublicKey (X25519), verifyPublicKey (Ed25519) }`.
  `signRoster` / `verifyRoster` / `lookupAgentKeys`. `canonicalRoster` sorts agents so the
  signing input is insertion-order independent (same discipline as `stableEnvelopePayload`).
  This is the only net-new crypto surface federation adds (PRD E4 line 126); `bridge-murmur`
  will fetch + verify a partner org's roster before any cross-org encrypt/verify.

## Tests

`node:test` **10/10 pass** with real keys (`@murmurv2/security`):
bare→local, org/agent split, nested-slash/empty reject, format+isLocal round-trip,
sign→verify round-trip, **tamper detection** (swapped key ⇒ verify false), wrong-signer reject,
canonical order-independence, lookup hit/miss, version validation.

## Interlock (with CODEX-VOLT)

This is the **addressing + key-directory** half. CODEX-VOLT owns the **NATS leaf-node /
per-org account `fed.*` subject contract** + smoke harness. The address `org/agentId` selects
his transport subject; the roster (here) is fetched+verified before cross-org send.
Joint gate: **E2E invariant** (payload ciphertext opaque to broker/federation) +
**back-compat** (bare agentId ⇒ local org).

## Scope / boundaries

- ✅ addressing + roster sign/verify/lookup — pure + unit-tested.
- ⏭️ **integration gate:** live cross-org fetch/transport over Codex's leaf-node contract.
- 🔒 opt-in package — not in root `tsc -b` graph yet (same posture as `bridge-a2a`).
  Build/test: `npm -w @murmurv2/federation run build && (cd packages/federation && node --test)`.

Review requested: **API boundaries + E2E invariant** (CODEX-VOLT).