### PR TITLE
feat(federation): add NATS subject contract smoke

### DIFF
--- a/docs/federation-nats-contract.md
+++ b/docs/federation-nats-contract.md
@@ -1,0 +1,68 @@
+# Murmur Federation NATS Subject Contract
+
+This document defines the first NATS-facing contract for issue #14. It is an
+application-level contract and does not require restarting the shared broker for
+unit smoke.
+
+## Addressing
+
+Federated recipients use `org/agentId`. Bare `agentId` addresses resolve to the
+local org before routing.
+
+Message subjects:
+
+```text
+fed.<org-token>.msg.<agent-token>
+```
+
+ACK subjects:
+
+```text
+fed.<org-token>.ack.<agent-token>
+```
+
+`org-token` and `agent-token` are subject-safe encodings of the address parts.
+Plain `[A-Za-z0-9_-]+` values are emitted unchanged. Values containing `.`, a
+reserved `_x` prefix, or other non-token characters are encoded as
+`_x<base64url(utf8)>`. Address parts containing NATS wildcards, spaces, or `/`
+are rejected before subject construction.
+
+Examples:
+
+```text
+aimindset/agent-codex  -> fed.aimindset.msg.agent-codex
+partner.org/agent.v1   -> fed._xcGFydG5lci5vcmc.msg._xYWdlbnQudjE
+```
+
+## Account Boundary
+
+Each org account exports only its own prefix and imports partner prefixes:
+
+```text
+ORG_AIMINDSET exports fed.aimindset.>
+ORG_AIMINDSET imports fed._xcGFydG5lci5vcmc.> from ORG__XCGFYDG5LCI5VCMC
+```
+
+This keeps federation routing separate from local mesh subjects and prevents a
+partner account from publishing under another org's prefix when the broker is
+configured with matching account exports/imports.
+
+## E2E Boundary
+
+Federation routing only chooses subjects. It does not decrypt, parse, rewrite,
+or re-sign `EnvelopeV1.payloadCiphertext`, `payloadNonce`, or `signature`.
+Roster/auth code must validate organization identity before a live bridge
+accepts partner traffic.
+
+## Smoke Harness
+
+`@murmurv2/federation-nats` includes a pure smoke test that verifies:
+
+- deterministic local and remote subject mapping;
+- dotted org/agent IDs round-trip through subject-safe tokens;
+- wildcard and slash injection are rejected;
+- envelopes keep ciphertext fields unchanged through routing;
+- account export/import prefixes match the subject contract.
+
+Live NATS smoke should use this contract with isolated accounts or a dedicated
+broker. Do not restart the shared production broker for this issue's smoke.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,10 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@murmurv2/federation-nats": {
+      "resolved": "packages/federation-nats",
+      "link": true
+    },
     "node_modules/@murmurv2/mcp-server": {
       "resolved": "packages/mcp-server",
       "link": true
@@ -830,6 +834,13 @@
       "version": "0.1.0",
       "dependencies": {
         "pg": "^8.16.3"
+      }
+    },
+    "packages/federation-nats": {
+      "name": "@murmurv2/federation-nats",
+      "version": "0.1.0",
+      "dependencies": {
+        "@murmurv2/core": "file:../core"
       }
     },
     "packages/mcp-server": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:unit": "node --test tests/*.test.mjs",
     "test:integration": "node scripts/run-integration.mjs",
     "test:notify-smoke": "node scripts/notify-smoke.mjs",
-    "test": "npm run build && npm run test:unit && npm run test:notify-smoke"
+    "test:federation-nats": "npm --workspace @murmurv2/federation-nats test",
+    "test": "npm run build && npm run test:unit && npm run test:notify-smoke && npm run test:federation-nats"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/federation-nats/package.json
+++ b/packages/federation-nats/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@murmurv2/federation-nats",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test test/*.test.mjs"
+  },
+  "dependencies": {
+    "@murmurv2/core": "file:../core"
+  }
+}

--- a/packages/federation-nats/src/index.ts
+++ b/packages/federation-nats/src/index.ts
@@ -1,0 +1,142 @@
+import type { EnvelopeV1 } from "@murmurv2/core";
+
+export type FederationSubjectKind = "msg" | "ack";
+
+export interface FederationAddress {
+  org: string;
+  agentId: string;
+}
+
+export interface FederatedRoute<TEnvelope extends EnvelopeV1 = EnvelopeV1> {
+  subject: string;
+  address: FederationAddress;
+  envelope: TEnvelope;
+}
+
+export interface FederationImport {
+  account: string;
+  subject: string;
+}
+
+export interface FederationAccountContract {
+  localOrg: string;
+  localAccount: string;
+  exports: string[];
+  imports: FederationImport[];
+}
+
+const FEDERATION_PREFIX = "fed";
+const ENCODED_PREFIX = "_x";
+const RAW_TOKEN_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+const ENCODED_TOKEN_RE = /^_x[A-Za-z0-9_-]+$/;
+const FORBIDDEN_ADDRESS_CHARS_RE = /[\s/*>]/;
+
+const assertAddressPart = (name: string, value: string): string => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${name}-missing`);
+  }
+  if (FORBIDDEN_ADDRESS_CHARS_RE.test(value)) {
+    throw new Error(`${name}-contains-nats-wildcard-or-separator`);
+  }
+  return value;
+};
+
+export const encodeFederationToken = (value: string): string => {
+  assertAddressPart("federation-token", value);
+  if (RAW_TOKEN_RE.test(value) && !value.startsWith(ENCODED_PREFIX)) return value;
+  return `${ENCODED_PREFIX}${Buffer.from(value, "utf8").toString("base64url")}`;
+};
+
+export const decodeFederationToken = (token: string): string => {
+  if (RAW_TOKEN_RE.test(token) && !token.startsWith(ENCODED_PREFIX)) return token;
+  if (!ENCODED_TOKEN_RE.test(token)) throw new Error("federation-token-invalid");
+  const decoded = Buffer.from(token.slice(ENCODED_PREFIX.length), "base64url").toString("utf8");
+  return assertAddressPart("federation-token", decoded);
+};
+
+export const parseFederationAddress = (raw: string, localOrg: string): FederationAddress => {
+  assertAddressPart("local-org", localOrg);
+  const parts = raw.split("/");
+  if (parts.length === 1) {
+    return {
+      org: localOrg,
+      agentId: assertAddressPart("agent-id", parts[0] ?? ""),
+    };
+  }
+  if (parts.length !== 2) throw new Error("federation-address-invalid");
+  return {
+    org: assertAddressPart("org", parts[0] ?? ""),
+    agentId: assertAddressPart("agent-id", parts[1] ?? ""),
+  };
+};
+
+export const formatFederationAddress = (address: FederationAddress): string => {
+  const org = assertAddressPart("org", address.org);
+  const agentId = assertAddressPart("agent-id", address.agentId);
+  return `${org}/${agentId}`;
+};
+
+export const federationSubject = (kind: FederationSubjectKind, address: FederationAddress): string => {
+  if (kind !== "msg" && kind !== "ack") throw new Error("federation-subject-kind-invalid");
+  const org = encodeFederationToken(address.org);
+  const agentId = encodeFederationToken(address.agentId);
+  return `${FEDERATION_PREFIX}.${org}.${kind}.${agentId}`;
+};
+
+export const parseFederationSubject = (subject: string): { kind: FederationSubjectKind; address: FederationAddress } => {
+  const parts = subject.split(".");
+  if (parts.length !== 4 || parts[0] !== FEDERATION_PREFIX) throw new Error("federation-subject-invalid");
+  const kind = parts[2];
+  if (kind !== "msg" && kind !== "ack") throw new Error("federation-subject-kind-invalid");
+  return {
+    kind,
+    address: {
+      org: decodeFederationToken(parts[1] ?? ""),
+      agentId: decodeFederationToken(parts[3] ?? ""),
+    },
+  };
+};
+
+export const federationMessageSubject = (recipient: string | FederationAddress, localOrg: string): string => {
+  const address = typeof recipient === "string" ? parseFederationAddress(recipient, localOrg) : recipient;
+  return federationSubject("msg", address);
+};
+
+export const federationAckSubject = (recipient: string | FederationAddress, localOrg: string): string => {
+  const address = typeof recipient === "string" ? parseFederationAddress(recipient, localOrg) : recipient;
+  return federationSubject("ack", address);
+};
+
+export const routeFederatedEnvelope = <TEnvelope extends EnvelopeV1>(
+  envelope: TEnvelope,
+  recipient: string | FederationAddress,
+  localOrg: string,
+): FederatedRoute<TEnvelope> => {
+  const address = typeof recipient === "string" ? parseFederationAddress(recipient, localOrg) : recipient;
+  return {
+    subject: federationSubject("msg", address),
+    address,
+    envelope,
+  };
+};
+
+export const orgAccountName = (org: string): string => {
+  const encodedOrg = encodeFederationToken(org);
+  return `ORG_${encodedOrg.toUpperCase().replaceAll("-", "_")}`;
+};
+
+export const buildFederationAccountContract = (
+  localOrg: string,
+  partnerOrgs: string[] = [],
+): FederationAccountContract => {
+  const localOrgToken = encodeFederationToken(localOrg);
+  return {
+    localOrg,
+    localAccount: orgAccountName(localOrg),
+    exports: [`${FEDERATION_PREFIX}.${localOrgToken}.>`],
+    imports: partnerOrgs.map((partnerOrg) => ({
+      account: orgAccountName(partnerOrg),
+      subject: `${FEDERATION_PREFIX}.${encodeFederationToken(partnerOrg)}.>`,
+    })),
+  };
+};

--- a/packages/federation-nats/test/federation-nats.test.mjs
+++ b/packages/federation-nats/test/federation-nats.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildFederationAccountContract,
+  decodeFederationToken,
+  encodeFederationToken,
+  federationAckSubject,
+  federationMessageSubject,
+  parseFederationSubject,
+  routeFederatedEnvelope,
+} from "../dist/src/index.js";
+
+const envelope = Object.freeze({
+  schemaVersion: "1.0",
+  msgId: "msg-fed-1",
+  conversationId: "conv-fed",
+  senderAgentId: "agent-jarvis",
+  recipients: ["partner.org/agent.codex"],
+  createdAt: "2026-06-21T18:30:00.000Z",
+  payloadCiphertext: "opaque-ciphertext",
+  payloadNonce: "opaque-nonce",
+  signature: "opaque-signature",
+});
+
+test("maps local and remote addresses to deterministic federation subjects", () => {
+  assert.equal(federationMessageSubject("agent-codex", "aimindset"), "fed.aimindset.msg.agent-codex");
+  assert.equal(federationAckSubject("partner/agent-jarvis", "aimindset"), "fed.partner.ack.agent-jarvis");
+});
+
+test("round-trips dotted address parts without subject-token ambiguity", () => {
+  const subject = federationMessageSubject("partner.org/agent.codex", "aimindset");
+  assert.equal(subject, "fed._xcGFydG5lci5vcmc.msg._xYWdlbnQuY29kZXg");
+  assert.deepEqual(parseFederationSubject(subject), {
+    kind: "msg",
+    address: {
+      org: "partner.org",
+      agentId: "agent.codex",
+    },
+  });
+});
+
+test("rejects wildcard and separator injection in address parts", () => {
+  assert.throws(() => federationMessageSubject("partner/agent.*", "aimindset"), /wildcard-or-separator/);
+  assert.throws(() => federationMessageSubject("partner>/agent", "aimindset"), /wildcard-or-separator/);
+  assert.throws(() => federationMessageSubject("partner/agent/sub", "aimindset"), /federation-address-invalid/);
+});
+
+test("routes envelopes without inspecting or mutating ciphertext fields", () => {
+  const route = routeFederatedEnvelope(envelope, "partner.org/agent.codex", "aimindset");
+  assert.equal(route.subject, "fed._xcGFydG5lci5vcmc.msg._xYWdlbnQuY29kZXg");
+  assert.equal(route.envelope, envelope);
+  assert.equal(route.envelope.payloadCiphertext, "opaque-ciphertext");
+  assert.equal(route.envelope.payloadNonce, "opaque-nonce");
+  assert.equal(route.envelope.signature, "opaque-signature");
+});
+
+test("builds account export/import contract scoped to each org subject prefix", () => {
+  assert.deepEqual(buildFederationAccountContract("aimindset", ["partner.org", "lab-2"]), {
+    localOrg: "aimindset",
+    localAccount: "ORG_AIMINDSET",
+    exports: ["fed.aimindset.>"],
+    imports: [
+      {
+        account: "ORG__XCGFYDG5LCI5VCMC",
+        subject: "fed._xcGFydG5lci5vcmc.>",
+      },
+      {
+        account: "ORG_LAB_2",
+        subject: "fed.lab-2.>",
+      },
+    ],
+  });
+});
+
+test("encoded federation tokens are reversible", () => {
+  const token = encodeFederationToken("_xreserved.name");
+  assert.equal(token, "_xX3hyZXNlcnZlZC5uYW1l");
+  assert.equal(decodeFederationToken(token), "_xreserved.name");
+});

--- a/packages/federation-nats/tsconfig.json
+++ b/packages/federation-nats/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "composite": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
## Summary
- add @murmurv2/federation-nats opt-in package for issue #14 NATS subject/account contract
- map org/agentId recipients to fed.<org-token>.msg.<agent-token> and ACKs to fed.<org-token>.ack.<agent-token>
- encode dotted/reserved address parts to subject-safe tokens, reject wildcard/slash injection, and keep EnvelopeV1 ciphertext opaque through routing
- document account export/import boundaries and shared-broker-safe smoke scope
- include federation package smoke in root npm test

## Verification
- npm test
  - root build OK
  - unit tests 54/54 pass
  - notify smoke PASS
  - federation-nats workspace smoke 6/6 pass

## Ops note
- No boevoy write, no shared broker restart, no live NATS mutation. This is dev-clone -> PR for JARVIS review/merge.