### PR TITLE
fix(broker): route JetStream advisories to DLQ

### DIFF
--- a/packages/broker-nats/dist/src/index.d.ts
+++ b/packages/broker-nats/dist/src/index.d.ts
@@ -68,6 +68,12 @@ export declare class NatsBroker {
         consumerId?: string;
     }): Promise<BrokerSubscription>;
     private processAckFrame;
+    startJetStreamAdvisoryDlq(params: {
+        outbox: OutboxStore;
+    }): Promise<BrokerSubscription>;
+    private processJetStreamAdvisoryFrame;
+    private jetStreamAdvisoryKind;
+    private jetStreamAdvisoryReason;
     /**
      * Basic outbox worker:
      * - picks due records

--- a/packages/broker-nats/dist/src/index.js
+++ b/packages/broker-nats/dist/src/index.js
@@ -320,6 +320,82 @@ export class NatsBroker {
             });
         }
     }
+    async startJetStreamAdvisoryDlq(params) {
+        await this.connect();
+        if (!this.nc)
+            throw new Error("nats-connection-unavailable");
+        if (!this.jsm)
+            throw new Error("jetstream-manager-unavailable");
+        const stream = this.streamName();
+        const subjects = [
+            `$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.${stream}.*`,
+            `$JS.EVENT.ADVISORY.CONSUMER.MSG_TERMINATED.${stream}.*`,
+        ];
+        const subs = subjects.map((subject) => this.nc.subscribe(subject));
+        for (const sub of subs) {
+            (async () => {
+                for await (const m of sub) {
+                    await this.processJetStreamAdvisoryFrame(m.data, params.outbox);
+                }
+            })().catch((err) => {
+                const e = err instanceof Error ? err : new Error(String(err));
+                console.error("[NatsBroker.startJetStreamAdvisoryDlq] loop crashed", {
+                    message: e.message,
+                    stack: e.stack,
+                });
+            });
+        }
+        return {
+            unsubscribe: () => {
+                for (const sub of subs)
+                    sub.unsubscribe();
+            },
+        };
+    }
+    async processJetStreamAdvisoryFrame(data, outbox) {
+        if (!this.jsm)
+            throw new Error("jetstream-manager-unavailable");
+        try {
+            const advisory = JSON.parse(this.sc.decode(data));
+            const advisoryKind = this.jetStreamAdvisoryKind(advisory);
+            if (!advisoryKind)
+                return;
+            if (advisory.stream !== this.streamName())
+                return;
+            const streamSeqRaw = advisory.stream_seq;
+            if (typeof streamSeqRaw !== "number" || !Number.isFinite(streamSeqRaw) || streamSeqRaw <= 0)
+                return;
+            const streamSeq = Math.trunc(streamSeqRaw);
+            const stored = await this.jsm.streams.getMessage(advisory.stream, { seq: streamSeq });
+            const envelope = JSON.parse(this.sc.decode(stored.data));
+            if (!isEnvelopeV1(envelope))
+                return;
+            await outbox.markDlq(envelope.msgId, this.jetStreamAdvisoryReason(advisoryKind, advisory, streamSeq));
+        }
+        catch (err) {
+            const e = err instanceof Error ? err : new Error(String(err));
+            console.error("[NatsBroker.startJetStreamAdvisoryDlq] malformed advisory frame", {
+                message: e.message,
+                stack: e.stack,
+                raw: this.sc.decode(data),
+            });
+        }
+    }
+    jetStreamAdvisoryKind(advisory) {
+        if (advisory.type === "io.nats.jetstream.advisory.v1.max_deliver")
+            return "max_deliver";
+        if (advisory.type === "io.nats.jetstream.advisory.v1.terminated")
+            return "terminated";
+        return undefined;
+    }
+    jetStreamAdvisoryReason(kind, advisory, streamSeq) {
+        const consumer = advisory.consumer ?? "unknown-consumer";
+        const deliveriesRaw = advisory.deliveries;
+        const deliveries = typeof deliveriesRaw === "number" && Number.isFinite(deliveriesRaw)
+            ? `:deliveries=${Math.trunc(deliveriesRaw)}`
+            : "";
+        return `jetstream-advisory:${kind}:${consumer}${deliveries}:stream_seq=${streamSeq}`;
+    }
     /**
      * Basic outbox worker:
      * - picks due records

--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -51,6 +51,14 @@ export interface BrokerStatusEvent {
   reconnects: number;
 }
 
+interface JetStreamConsumerAdvisory {
+  type?: string;
+  stream?: string;
+  consumer?: string;
+  stream_seq?: number;
+  deliveries?: number;
+}
+
 export const buildNatsConnectionOptions = (config: BrokerConfig): ConnectionOptions => ({
   servers: config.url,
   token: config.token,
@@ -419,6 +427,87 @@ export class NatsBroker {
         raw: this.sc.decode(data),
       });
     }
+  }
+
+  async startJetStreamAdvisoryDlq(params: {
+    outbox: OutboxStore;
+  }): Promise<BrokerSubscription> {
+    await this.connect();
+    if (!this.nc) throw new Error("nats-connection-unavailable");
+    if (!this.jsm) throw new Error("jetstream-manager-unavailable");
+
+    const stream = this.streamName();
+    const subjects = [
+      `$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.${stream}.*`,
+      `$JS.EVENT.ADVISORY.CONSUMER.MSG_TERMINATED.${stream}.*`,
+    ];
+    const subs = subjects.map((subject) => this.nc!.subscribe(subject));
+
+    for (const sub of subs) {
+      (async () => {
+        for await (const m of sub) {
+          await this.processJetStreamAdvisoryFrame(m.data, params.outbox);
+        }
+      })().catch((err) => {
+        const e = err instanceof Error ? err : new Error(String(err));
+        console.error("[NatsBroker.startJetStreamAdvisoryDlq] loop crashed", {
+          message: e.message,
+          stack: e.stack,
+        });
+      });
+    }
+
+    return {
+      unsubscribe: () => {
+        for (const sub of subs) sub.unsubscribe();
+      },
+    };
+  }
+
+  private async processJetStreamAdvisoryFrame(data: Uint8Array, outbox: OutboxStore): Promise<void> {
+    if (!this.jsm) throw new Error("jetstream-manager-unavailable");
+
+    try {
+      const advisory = JSON.parse(this.sc.decode(data)) as JetStreamConsumerAdvisory;
+      const advisoryKind = this.jetStreamAdvisoryKind(advisory);
+      if (!advisoryKind) return;
+      if (advisory.stream !== this.streamName()) return;
+      const streamSeqRaw = advisory.stream_seq;
+      if (typeof streamSeqRaw !== "number" || !Number.isFinite(streamSeqRaw) || streamSeqRaw <= 0) return;
+
+      const streamSeq = Math.trunc(streamSeqRaw);
+      const stored = await this.jsm.streams.getMessage(advisory.stream, { seq: streamSeq });
+      const envelope = JSON.parse(this.sc.decode(stored.data));
+      if (!isEnvelopeV1(envelope)) return;
+
+      await outbox.markDlq(envelope.msgId, this.jetStreamAdvisoryReason(advisoryKind, advisory, streamSeq));
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      console.error("[NatsBroker.startJetStreamAdvisoryDlq] malformed advisory frame", {
+        message: e.message,
+        stack: e.stack,
+        raw: this.sc.decode(data),
+      });
+    }
+  }
+
+  private jetStreamAdvisoryKind(advisory: JetStreamConsumerAdvisory): "max_deliver" | "terminated" | undefined {
+    if (advisory.type === "io.nats.jetstream.advisory.v1.max_deliver") return "max_deliver";
+    if (advisory.type === "io.nats.jetstream.advisory.v1.terminated") return "terminated";
+    return undefined;
+  }
+
+  private jetStreamAdvisoryReason(
+    kind: "max_deliver" | "terminated",
+    advisory: JetStreamConsumerAdvisory,
+    streamSeq: number,
+  ): string {
+    const consumer = advisory.consumer ?? "unknown-consumer";
+    const deliveriesRaw = advisory.deliveries;
+    const deliveries = typeof deliveriesRaw === "number" && Number.isFinite(deliveriesRaw)
+      ? `:deliveries=${Math.trunc(deliveriesRaw)}`
+      : "";
+    return `jetstream-advisory:${kind}:${consumer}${deliveries}:stream_seq=${streamSeq}`;
   }
 
   /**

--- a/tests/broker-jetstream.test.mjs
+++ b/tests/broker-jetstream.test.mjs
@@ -18,13 +18,22 @@ const envelope = {
   signature: "sig",
 };
 
-const makeJetStreamBroker = ({ streamInfoThrows = true, consumerInfo, messages = [], brokerConfig = {} } = {}) => {
+const makeJetStreamBroker = ({
+  streamInfoThrows = true,
+  consumerInfo,
+  messages = [],
+  advisoryMessages = {},
+  storedMessages = new Map(),
+  brokerConfig = {},
+} = {}) => {
   const streamsAdded = [];
   const consumersAdded = [];
   const consumersUpdated = [];
   const published = [];
   const acked = [];
   const nacked = [];
+  const subscribed = [];
+  const getMessageQueries = [];
 
   const fakeMessages = {
     async *[Symbol.asyncIterator]() {
@@ -54,6 +63,12 @@ const makeJetStreamBroker = ({ streamInfoThrows = true, consumerInfo, messages =
       },
       async update(_stream, config) {
         streamsAdded.push(config);
+      },
+      async getMessage(stream, query) {
+        getMessageQueries.push({ stream, query });
+        const msg = storedMessages.get(`${stream}:${query.seq}`);
+        if (!msg) throw new Error("message-missing");
+        return msg;
       },
     },
     consumers: {
@@ -94,6 +109,18 @@ const makeJetStreamBroker = ({ streamInfoThrows = true, consumerInfo, messages =
     jetstream() {
       return fakeJs;
     },
+    subscribe(subject) {
+      subscribed.push(subject);
+      const frames = advisoryMessages[subject] ?? [];
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const data of frames) {
+            yield { data };
+          }
+        },
+        unsubscribe() {},
+      };
+    },
     async drain() {},
   };
 
@@ -106,7 +133,7 @@ const makeJetStreamBroker = ({ streamInfoThrows = true, consumerInfo, messages =
   });
   broker.nc = fakeNc;
 
-  return { broker, streamsAdded, consumersAdded, consumersUpdated, published, acked, nacked };
+  return { broker, streamsAdded, consumersAdded, consumersUpdated, published, acked, nacked, subscribed, getMessageQueries };
 };
 
 test("JetStream publish ensures stream and uses envelope msgId as dedupe id", async () => {
@@ -310,4 +337,42 @@ test("JetStream ACK correlation consumes durable ack subject and updates outbox"
   assert.equal(consumersAdded[0].config.filter_subject, "ack.agent-sender");
   assert.deepEqual(marked, [["acked", envelope.msgId]]);
   assert.equal(acked.length, 1);
+});
+
+test("JetStream DLQ advisory resolves stream sequence and marks original outbox row DLQ", async () => {
+  const advisorySubject = "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.MURMUR.*";
+  const advisory = {
+    type: "io.nats.jetstream.advisory.v1.max_deliver",
+    id: "advisory-1",
+    timestamp: "2026-06-21T18:00:00.000Z",
+    stream: "MURMUR",
+    consumer: "agent-receiver",
+    stream_seq: 42,
+    deliveries: 5,
+  };
+  const { broker, subscribed, getMessageQueries } = makeJetStreamBroker({
+    streamInfoThrows: false,
+    advisoryMessages: {
+      [advisorySubject]: [sc.encode(JSON.stringify(advisory))],
+    },
+    storedMessages: new Map([
+      ["MURMUR:42", { data: sc.encode(JSON.stringify(envelope)) }],
+    ]),
+  });
+  const marked = [];
+  const outbox = {
+    async markDlq(msgId, reason) {
+      marked.push([msgId, reason]);
+    },
+  };
+
+  await broker.startJetStreamAdvisoryDlq({ outbox });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.deepEqual(subscribed, [
+    "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.MURMUR.*",
+    "$JS.EVENT.ADVISORY.CONSUMER.MSG_TERMINATED.MURMUR.*",
+  ]);
+  assert.deepEqual(getMessageQueries, [{ stream: "MURMUR", query: { seq: 42 } }]);
+  assert.deepEqual(marked, [[envelope.msgId, "jetstream-advisory:max_deliver:agent-receiver:deliveries=5:stream_seq=42"]]);
 });


### PR DESCRIPTION
## Summary
- add NatsBroker.startJetStreamAdvisoryDlq(outbox) for JetStream MAX_DELIVERIES and MSG_TERMINATED advisory subjects
- resolve advisory stream_seq back to the original stored EnvelopeV1 via streams.getMessage(stream, { seq })
- mark the original sender-side outbox row DLQ with a reason containing advisory kind, consumer, deliveries, and stream_seq
- ignore unrelated/malformed advisories without changing JetStream default-off publish/subscribe behavior

## TDD evidence
- Added regression test first; it failed with: broker.startJetStreamAdvisoryDlq is not a function
- Implemented the minimal broker handler and reran tests

## Verification
- npm run build && node --test tests/broker-jetstream.test.mjs
  - broker JetStream tests 9/9 pass
- npm test
  - root build PASS
  - unit tests 55/55 PASS
  - notify smoke PASS

## Ops note
- No production broker restart, no boevoy write, fake JetStream/advisory inputs only.