### PR TITLE
fix(ops): wire JetStream advisories and dedupe federation parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mur-mur-v2",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mur-mur-v2",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "workspaces": [
         "packages/*"
       ],
@@ -1828,7 +1828,8 @@
       "name": "@murmurv2/federation-nats",
       "version": "0.1.0",
       "dependencies": {
-        "@murmurv2/core": "file:../core"
+        "@murmurv2/core": "file:../core",
+        "@murmurv2/federation": "file:../federation"
       }
     },
     "packages/mcp-server": {

--- a/packages/federation-nats/package.json
+++ b/packages/federation-nats/package.json
@@ -10,6 +10,7 @@
     "test": "npm run build && node --test test/*.test.mjs"
   },
   "dependencies": {
-    "@murmurv2/core": "file:../core"
+    "@murmurv2/core": "file:../core",
+    "@murmurv2/federation": "file:../federation"
   }
 }

--- a/packages/federation-nats/src/index.ts
+++ b/packages/federation-nats/src/index.ts
@@ -1,11 +1,9 @@
 import type { EnvelopeV1 } from "@murmurv2/core";
+import { parseAddress, type AgentAddress } from "@murmurv2/federation";
 
 export type FederationSubjectKind = "msg" | "ack";
 
-export interface FederationAddress {
-  org: string;
-  agentId: string;
-}
+export type FederationAddress = AgentAddress;
 
 export interface FederatedRoute<TEnvelope extends EnvelopeV1 = EnvelopeV1> {
   subject: string;
@@ -55,19 +53,7 @@ export const decodeFederationToken = (token: string): string => {
 };
 
 export const parseFederationAddress = (raw: string, localOrg: string): FederationAddress => {
-  assertAddressPart("local-org", localOrg);
-  const parts = raw.split("/");
-  if (parts.length === 1) {
-    return {
-      org: localOrg,
-      agentId: assertAddressPart("agent-id", parts[0] ?? ""),
-    };
-  }
-  if (parts.length !== 2) throw new Error("federation-address-invalid");
-  return {
-    org: assertAddressPart("org", parts[0] ?? ""),
-    agentId: assertAddressPart("agent-id", parts[1] ?? ""),
-  };
+  return parseAddress(raw, localOrg);
 };
 
 export const formatFederationAddress = (address: FederationAddress): string => {

--- a/packages/federation-nats/test/federation-nats.test.mjs
+++ b/packages/federation-nats/test/federation-nats.test.mjs
@@ -40,9 +40,9 @@ test("round-trips dotted address parts without subject-token ambiguity", () => {
 });
 
 test("rejects wildcard and separator injection in address parts", () => {
-  assert.throws(() => federationMessageSubject("partner/agent.*", "aimindset"), /wildcard-or-separator/);
-  assert.throws(() => federationMessageSubject("partner>/agent", "aimindset"), /wildcard-or-separator/);
-  assert.throws(() => federationMessageSubject("partner/agent/sub", "aimindset"), /federation-address-invalid/);
+  assert.throws(() => federationMessageSubject("partner/agent.*", "aimindset"), /invalid agentId/);
+  assert.throws(() => federationMessageSubject("partner>/agent", "aimindset"), /invalid org/);
+  assert.throws(() => federationMessageSubject("partner/agent/sub", "aimindset"), /nested slash/);
 });
 
 test("routes envelopes without inspecting or mutating ciphertext fields", () => {

--- a/packages/federation-nats/tsconfig.json
+++ b/packages/federation-nats/tsconfig.json
@@ -9,11 +9,22 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@murmurv2/federation": [
+        "../federation/src/index.ts"
+      ]
+    },
     "types": [
       "node"
     ]
   },
   "include": [
     "src"
+  ],
+  "references": [
+    {
+      "path": "../federation"
+    }
   ]
 }

--- a/scripts/murmur-daemon.mjs
+++ b/scripts/murmur-daemon.mjs
@@ -11,6 +11,7 @@ import { SQLiteDedupeOutboxStore, SQLiteMessageStore } from "@murmurv2/core";
 import { decryptPayload, verifyEnvelopeSignature } from "@murmurv2/security";
 import { NotifyQueue, flushNotifyQueue, normalizeNotifyTargets } from "./notify-router.mjs";
 import { createCodexAppServerInjector } from "./codex-app-server-wake.mjs";
+import { startJetStreamAdvisoryDlqIfEnabled } from "./murmur-jetstream-advisory.mjs";
 import { WakeMonitor, createAuditShellHook, createShellHook, normalizeWakeConfig } from "./wake-monitor.mjs";
 // vault-guard: optional content policy hook (not included in OSS release)
 
@@ -281,6 +282,12 @@ try {
 
   await broker.startAckCorrelation({ outbox: store, ackSubject: `ack.${agentId}`, consumerId: `${agentId}-ack` });
   log("info", "ACK correlation started", { ackSubject: `ack.${agentId}` });
+  await startJetStreamAdvisoryDlqIfEnabled({
+    broker,
+    outbox: store,
+    jetstreamEnabled,
+    log,
+  });
 
   const pendingNotify = notifyQueue.pendingCount();
   if (pendingNotify > 0) {

--- a/scripts/murmur-jetstream-advisory.mjs
+++ b/scripts/murmur-jetstream-advisory.mjs
@@ -1,0 +1,11 @@
+export async function startJetStreamAdvisoryDlqIfEnabled({
+  broker,
+  outbox,
+  jetstreamEnabled,
+  log = () => {},
+}) {
+  if (!jetstreamEnabled) return undefined;
+  const subscription = await broker.startJetStreamAdvisoryDlq({ outbox });
+  log("info", "JetStream advisory DLQ correlation started");
+  return subscription;
+}

--- a/tests/murmur-jetstream-advisory.test.mjs
+++ b/tests/murmur-jetstream-advisory.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { startJetStreamAdvisoryDlqIfEnabled } from "../scripts/murmur-jetstream-advisory.mjs";
+
+test("startJetStreamAdvisoryDlqIfEnabled is dormant when JetStream is disabled", async () => {
+  let calls = 0;
+  const result = await startJetStreamAdvisoryDlqIfEnabled({
+    jetstreamEnabled: false,
+    outbox: {},
+    broker: {
+      async startJetStreamAdvisoryDlq() {
+        calls += 1;
+      },
+    },
+  });
+
+  assert.equal(result, undefined);
+  assert.equal(calls, 0);
+});
+
+test("startJetStreamAdvisoryDlqIfEnabled wires advisory DLQ when JetStream is enabled", async () => {
+  const outbox = {};
+  const subscription = { unsubscribe() {} };
+  const logs = [];
+  const calls = [];
+
+  const result = await startJetStreamAdvisoryDlqIfEnabled({
+    jetstreamEnabled: true,
+    outbox,
+    log: (level, msg) => logs.push({ level, msg }),
+    broker: {
+      async startJetStreamAdvisoryDlq(params) {
+        calls.push(params);
+        return subscription;
+      },
+    },
+  });
+
+  assert.equal(result, subscription);
+  assert.deepEqual(calls, [{ outbox }]);
+  assert.deepEqual(logs, [{ level: "info", msg: "JetStream advisory DLQ correlation started" }]);
+});


### PR DESCRIPTION
## Summary
- wire the dormant #37 JetStream advisory DLQ handler into murmur-daemon when JetStream is enabled
- add a focused helper test proving advisory wiring stays dormant when JetStream is off and calls broker.startJetStreamAdvisoryDlq({ outbox }) when on
- make @murmurv2/federation-nats reuse @murmurv2/federation parseAddress as the single addressing parser
- add federation-nats project reference/path to @murmurv2/federation
- sync package-lock root version to current 2.1.0 package.json

## Verification
- node --test tests/murmur-jetstream-advisory.test.mjs: 2/2 pass
- npm --workspace @murmurv2/federation-nats test: 6/6 pass
- npm test: root build PASS, unit 57/57 PASS, notify-smoke PASS, A2A 6/6 PASS, federation 11/11 PASS, federation-nats 6/6 PASS

## Ops note
- no boevoy write
- no shared broker restart
- daemon wiring activates only under existing jetstreamEnabled config