### PR TITLE
feat(ws4): add Murmur ACP producer boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "test:unit": "node --test tests/*.test.mjs",
     "test:integration": "node scripts/run-integration.mjs",
     "test:notify-smoke": "node scripts/notify-smoke.mjs",
+    "test:ws4-acp": "python3 tests/ws4-acp-boundary.test.py && python3 scripts/murmur-to-acp-producer.py --self-test && python3 scripts/murmur-send-service.py --self-test && python3 -m py_compile scripts/murmur-to-acp-producer.py scripts/murmur-send-service.py tests/ws4-acp-boundary.test.py",
     "test:a2a": "npm --workspace @murmurv2/bridge-a2a test",
     "test:federation": "npm --workspace @murmurv2/federation test",
     "test:federation-nats": "npm --workspace @murmurv2/federation-nats test",
-    "test": "npm run build && npm run test:unit && npm run test:notify-smoke && npm run test:a2a && npm run test:federation && npm run test:federation-nats"
+    "test": "npm run build && npm run test:unit && npm run test:notify-smoke && npm run test:ws4-acp && npm run test:a2a && npm run test:federation && npm run test:federation-nats"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/scripts/murmur-send-service.py
+++ b/scripts/murmur-send-service.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import grp
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+SOCKET_PATH = Path(os.environ.get("MURMUR_SEND_SOCKET", "/run/murmur-send-service/codex-volt.sock"))
+AUDIT_LOG = Path(os.environ.get("MURMUR_SEND_AUDIT", "/var/log/murmur-send-service.log"))
+DATA_DIR = os.environ.get("MURMUR_DATA_DIR", "/opt/lifecoach/mur-mur-v2/.data-codex-volt")
+SEND_SCRIPT = os.environ.get("MURMUR_SEND_SCRIPT", "/opt/lifecoach/mur-mur-v2/scripts/murmur-shell-send.mjs")
+MURMUR_CWD = os.environ.get("MURMUR_CWD", "/opt/lifecoach/mur-mur-v2")
+
+PEERS = {"agent-jarvis", "agent-codex-mac-kovalyaevo"}
+KINDS = {"ack", "progress", "final", "blocked", "error"}
+CONVERSATION_RE = re.compile(r"^[a-zA-Z0-9:_./-]{1,160}$")
+SECRET_RE = re.compile(
+    r"BEGIN PRIVATE KEY|OPENAI_API_KEY=|auth\.json|ghp_|github_pat_|AKIA[0-9A-Z]{16}|xox[abp]-|sk-[A-Za-z0-9_-]{20,}|-----BEGIN",
+    re.IGNORECASE,
+)
+SOCKET_GROUP = os.environ.get("MURMUR_SEND_SOCKET_GROUP", "acpworkers")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def audit(event: dict) -> None:
+    AUDIT_LOG.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"ts": utc_now(), **event}
+    with AUDIT_LOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def validate_request(payload: dict) -> tuple[bool, str]:
+    if not isinstance(payload, dict):
+        return False, "payload-not-object"
+    to = str(payload.get("to") or "")
+    conversation_id = str(payload.get("conversation_id") or "")
+    text = str(payload.get("text") or "")
+    kind = str(payload.get("kind") or "")
+    if to not in PEERS:
+        return False, "bad-peer"
+    if not CONVERSATION_RE.fullmatch(conversation_id):
+        return False, "bad-conversation-id"
+    if kind not in KINDS:
+        return False, "bad-kind"
+    encoded = text.encode("utf-8")
+    if not encoded or len(encoded) > 16 * 1024:
+        return False, "bad-text-size"
+    if SECRET_RE.search(text):
+        return False, "secret-marker"
+    return True, "ok"
+
+
+def send(payload: dict) -> dict:
+    ok, reason = validate_request(payload)
+    audit({"event": "request", "ok": ok, "reason": reason, "to": payload.get("to"), "kind": payload.get("kind"), "task_id": payload.get("source_task_id")})
+    if not ok:
+        return {"ok": False, "error": reason}
+
+    env = os.environ.copy()
+    env["DATA_DIR"] = DATA_DIR
+    proc = subprocess.run(
+        ["node", SEND_SCRIPT, "--to", payload["to"], "--conv", payload["conversation_id"], "--stdin"],
+        input=payload["text"],
+        text=True,
+        capture_output=True,
+        cwd=MURMUR_CWD,
+        env=env,
+        timeout=30,
+    )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        data = {"raw_stdout": proc.stdout[-1000:]}
+    result = {"ok": proc.returncode == 0, "returncode": proc.returncode, "send": data, "stderr": proc.stderr[-1000:]}
+    audit({"event": "result", "ok": result["ok"], "to": payload.get("to"), "kind": payload.get("kind"), "msg_id": data.get("msgId") if isinstance(data, dict) else None})
+    return result
+
+
+def handle_line(line: bytes) -> bytes:
+    try:
+        payload = json.loads(line.decode("utf-8"))
+        result = send(payload)
+    except Exception as exc:
+        result = {"ok": False, "error": str(exc)}
+    return (json.dumps(result, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def serve() -> None:
+    SOCKET_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if SOCKET_PATH.exists():
+        SOCKET_PATH.unlink()
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+        server.bind(str(SOCKET_PATH))
+        gid = grp.getgrnam(SOCKET_GROUP).gr_gid
+        os.chown(SOCKET_PATH, 0, gid)
+        os.chmod(SOCKET_PATH, 0o660)
+        server.listen(20)
+        audit({"event": "started", "socket": str(SOCKET_PATH)})
+        while True:
+            conn, _addr = server.accept()
+            with conn:
+                data = b""
+                while not data.endswith(b"\n"):
+                    chunk = conn.recv(65536)
+                    if not chunk:
+                        break
+                    data += chunk
+                    if len(data) > 20 * 1024:
+                        break
+                conn.sendall(handle_line(data))
+
+
+def run_self_test() -> int:
+    valid = {
+        "to": "agent-jarvis",
+        "conversation_id": "dm:agent-jarvis:agent-codex-volt",
+        "text": "[CODEX->AGENT]\nsource=codex-cli\nproject=/opt/lifecoach/vault\nts=2026-06-20T00:00:00Z\nintent=sync\nsummary=test",
+        "kind": "ack",
+        "source_task_id": 1,
+    }
+    cases = [
+        ("valid", valid, True),
+        ("bad-peer", {**valid, "to": "agent-evil"}, False),
+        ("bad-conv", {**valid, "conversation_id": "bad conv"}, False),
+        ("bad-kind", {**valid, "kind": "other"}, False),
+        ("secret", {**valid, "text": "OPENAI_API_KEY=secret"}, False),
+        ("auth-json", {**valid, "text": "auth.json"}, False),
+        ("too-large", {**valid, "text": "x" * (17 * 1024)}, False),
+    ]
+    for name, payload, expected in cases:
+        got, reason = validate_request(payload)
+        print(f"{name}: got={got} expected={expected} reason={reason}")
+        if got != expected:
+            return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        return run_self_test()
+    serve()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/murmur-shell-send.mjs
+++ b/scripts/murmur-shell-send.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Standalone Murmur V2 sender for shell scripts and send-boundary services.
+// Reads agent-config.json from DATA_DIR, encrypts/signs/enqueues an envelope.
+
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { SQLiteDedupeOutboxStore, SQLiteMessageStore } from "@murmurv2/core";
+import { encryptPayload, signEnvelope } from "@murmurv2/security";
+
+const args = process.argv.slice(2);
+const opt = {};
+for (let i = 0; i < args.length; i += 1) {
+  const a = args[i];
+  if (a === "--to") opt.to = args[++i];
+  else if (a === "--conv" || a === "--conversation") opt.conversationId = args[++i];
+  else if (a === "--text") opt.text = args[++i];
+  else if (a === "--text-file") opt.textFile = args[++i];
+  else if (a === "--stdin") opt.stdin = true;
+  else if (a === "--help" || a === "-h") opt.help = true;
+}
+
+if (opt.help || !opt.to || (!opt.text && !opt.textFile && !opt.stdin)) {
+  process.stderr.write(
+    "usage: murmur-shell-send.mjs --to <peer-id> (--text <txt> | --text-file <path> | --stdin) [--conv <id>]\n",
+  );
+  process.exit(1);
+}
+
+if (opt.textFile) {
+  opt.text = readFileSync(opt.textFile, "utf8");
+} else if (opt.stdin) {
+  opt.text = readFileSync(0, "utf8");
+}
+const text = String(opt.text ?? "").trim();
+if (!text) {
+  process.stderr.write("error: text is empty\n");
+  process.exit(1);
+}
+
+const dataDir = process.env.DATA_DIR || ".data";
+const configPath = path.join(dataDir, "agent-config.json");
+const dbPath = process.env.MURMUR_STORE_PATH ?? path.join(dataDir, "murmur.db");
+
+let cfg;
+try {
+  cfg = JSON.parse(readFileSync(configPath, "utf8"));
+} catch (err) {
+  process.stderr.write(`error: cannot read ${configPath}: ${err.message}\n`);
+  process.exit(2);
+}
+
+const peer = cfg.peers?.[opt.to];
+if (!peer) {
+  process.stderr.write(`error: unknown peer '${opt.to}' in ${configPath}\n`);
+  process.exit(2);
+}
+
+const conversationId = opt.conversationId || `dm:${cfg.agentId}:${opt.to}`;
+const msgId = randomUUID();
+const createdAt = new Date().toISOString();
+
+const stableEnvelopePayload = (e) =>
+  JSON.stringify({
+    schemaVersion: e.schemaVersion,
+    msgId: e.msgId,
+    conversationId: e.conversationId,
+    senderAgentId: e.senderAgentId,
+    recipients: [...e.recipients],
+    createdAt: e.createdAt,
+    payloadCiphertext: e.payloadCiphertext,
+    payloadNonce: e.payloadNonce,
+  });
+
+try {
+  const encrypted = await encryptPayload(
+    text,
+    peer.encryption.publicKey,
+    cfg.keys.encryption.privateKey,
+  );
+
+  const envelope = {
+    schemaVersion: "1.0",
+    msgId,
+    conversationId,
+    senderAgentId: cfg.agentId,
+    recipients: [opt.to],
+    createdAt,
+    payloadCiphertext: encrypted.ciphertext,
+    payloadNonce: encrypted.nonce,
+    signature: "",
+  };
+  envelope.signature = await signEnvelope(
+    stableEnvelopePayload(envelope),
+    cfg.keys.signing.privateKey,
+  );
+
+  const outbox = new SQLiteDedupeOutboxStore(dbPath);
+  outbox.db?.exec?.("PRAGMA busy_timeout=5000;");
+  await outbox.enqueue(peer.subject, envelope);
+
+  const store = new SQLiteMessageStore(dbPath);
+  store.db?.exec?.("PRAGMA busy_timeout=5000;");
+  await store.append({
+    conversationId,
+    msgId,
+    direction: "outbound",
+    sender: cfg.agentId,
+    text,
+    createdAt,
+    transport: "nats",
+  });
+
+  process.stdout.write(
+    `${JSON.stringify({ msgId, to: opt.to, conversationId, status: "queued" })}\n`,
+  );
+  process.exit(0);
+} catch (err) {
+  process.stderr.write(`error: enqueue failed: ${err.message}\n`);
+  process.exit(3);
+}

--- a/scripts/murmur-to-acp-producer.py
+++ b/scripts/murmur-to-acp-producer.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ACP = os.environ.get("ACP_BIN", "/opt/lifecoach/agent-control-plane/bin/acp")
+PROJECT = os.environ.get("ACP_PROJECT", "/opt/lifecoach/vault")
+STATE_ROOT = Path(os.environ.get("MURMUR_TO_ACP_STATE", "/var/lib/murmur-to-acp"))
+LOG_PATH = Path(os.environ.get("MURMUR_TO_ACP_LOG", "/opt/lifecoach/logs/murmur-to-acp-producer.log"))
+SELF_AGENT = os.environ.get("MURMUR_SELF_AGENT", "agent-codex-volt")
+ACP_TIMEOUT_SECONDS = float(os.environ.get("MURMUR_TO_ACP_TIMEOUT_SECONDS", "3"))
+
+TASK_INTENT_RE = re.compile(r"^\s*intent\s*=\s*task\s*$", re.IGNORECASE | re.MULTILINE)
+SYNC_INTENT_RE = re.compile(r"^\s*intent\s*=\s*sync\s*$", re.IGNORECASE | re.MULTILINE)
+ACP_PREFIX_RE = re.compile(r"^\s*#ACP(?:\s|$)", re.IGNORECASE)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def log(event: dict) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"ts": utc_now(), **event}
+    with LOG_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def should_process(sender: str, text: str) -> tuple[bool, str]:
+    if not sender or sender == SELF_AGENT:
+        return False, "self-or-empty-sender"
+    if "source=codex-cli" in text:
+        return False, "codex-cli-output"
+    if "source=codex-murmur-autopilot" in text:
+        return False, "autopilot-output"
+    if "[CODEX AUTOPILOT]" in text or "[CODEX->AGENT]" in text:
+        return False, "codex-output-marker"
+    if SYNC_INTENT_RE.search(text):
+        return False, "coord-sync"
+    if TASK_INTENT_RE.search(text) or ACP_PREFIX_RE.search(text):
+        return True, "explicit-task"
+    return False, "missing-task-intent"
+
+
+def one_line(text: str, limit: int = 100) -> str:
+    for line in (text or "").splitlines():
+        line = line.strip()
+        if line:
+            return line[:limit]
+    return "Murmur task"
+
+
+def task_body(sender: str, conversation_id: str, msg_id: str, rowid: str, created_at: str, text: str) -> str:
+    packet = {
+        "lane": "auto",
+        "task_type": "analysis",
+        "source": "murmur",
+        "murmur": {
+            "from": sender,
+            "conversation_id": conversation_id,
+            "msg_id": msg_id,
+            "rowid": rowid,
+            "created_at": created_at,
+        },
+        "reply": {
+            "to": sender,
+            "conversation_id": conversation_id,
+            "send_boundary": "murmur-send-service",
+        },
+        "prompt": text,
+        "requirements": ["create_or_get_task", "write_result", "write_proof_pack", "reply_via_send_boundary"],
+        "coverage": ["create_or_get_task", "write_result", "write_proof_pack", "reply_via_send_boundary"],
+    }
+    return json.dumps(packet, ensure_ascii=False, indent=2)
+
+
+def create_or_get_task(sender: str, conversation_id: str, msg_id: str, rowid: str, created_at: str, text: str) -> dict:
+    title = f"Murmur {sender} {msg_id[:8]}: {one_line(text)}"
+    body = task_body(sender, conversation_id, msg_id, rowid, created_at, text)
+    proc = subprocess.run(
+        [
+            ACP,
+            "create-or-get",
+            "--source",
+            "murmur",
+            "--external-key",
+            msg_id,
+            "--title",
+            title,
+            "--body",
+            body,
+            "--repo-path",
+            PROJECT,
+            "--worker-kind",
+            "codex-task",
+        ],
+        text=True,
+        capture_output=True,
+        timeout=ACP_TIMEOUT_SECONDS,
+    )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"acp create-or-get returned non-json rc={proc.returncode}: {proc.stdout[-500:]} {proc.stderr[-500:]}") from exc
+    data["_returncode"] = proc.returncode
+    if proc.returncode != 0 or not data.get("ok"):
+        raise RuntimeError(f"acp create-or-get failed: {data}")
+    return data
+
+
+def process_env() -> dict:
+    sender = os.environ.get("MURMUR_FROM", "")
+    text = os.environ.get("MURMUR_TEXT", "")
+    msg_id = os.environ.get("MURMUR_MSG_ID", "")
+    conversation_id = os.environ.get("MURMUR_CONVERSATION_ID", "")
+    rowid = os.environ.get("MURMUR_ROWID", "")
+    created_at = os.environ.get("MURMUR_CREATED_AT", utc_now())
+
+    if not msg_id:
+        result = {"ok": True, "status": "ignored", "reason": "missing-msg-id"}
+        log(result)
+        return result
+
+    allowed, reason = should_process(sender, text)
+    if not allowed:
+        result = {"ok": True, "status": "ignored", "reason": reason, "msg_id": msg_id, "sender": sender}
+        log(result)
+        return result
+
+    seen_dir = STATE_ROOT / "seen"
+    inbound_dir = STATE_ROOT / "inbound"
+    seen_dir.mkdir(parents=True, exist_ok=True)
+    inbound_dir.mkdir(parents=True, exist_ok=True)
+    marker = seen_dir / msg_id
+    try:
+        marker.mkdir()
+    except FileExistsError:
+        result = {"ok": True, "status": "duplicate", "msg_id": msg_id}
+        log(result)
+        return result
+
+    inbound = {
+        "sender": sender,
+        "conversation_id": conversation_id,
+        "msg_id": msg_id,
+        "rowid": rowid,
+        "created_at": created_at,
+        "text": text,
+    }
+    try:
+        (inbound_dir / f"{msg_id}.json").write_text(json.dumps(inbound, ensure_ascii=False, indent=2), encoding="utf-8")
+        task = create_or_get_task(sender, conversation_id, msg_id, rowid, created_at, text)
+    except Exception:
+        shutil.rmtree(marker, ignore_errors=True)
+        raise
+
+    result = {"ok": True, "status": "created" if task.get("created") else "existing", "msg_id": msg_id, "task_id": task["task_id"]}
+    log(result)
+    return result
+
+
+def run_self_test() -> int:
+    cases = [
+        ("sync", "agent-jarvis", "intent=sync\nhello", False),
+        ("codex", "agent-jarvis", "[CODEX->AGENT]\nintent=task", False),
+        ("self", SELF_AGENT, "intent=task\nhello", False),
+        ("coord", "agent-jarvis", "JARVIS -> CODEX hello", False),
+        ("coord-arrow", "agent-jarvis", "JARVIS → CODEX hello", False),
+        ("task", "agent-jarvis", "intent=task\nhello", True),
+        ("task-meta", "agent-jarvis", "JARVIS discusses intent=task token", False),
+        ("hash", "agent-jarvis", "#ACP\nhello", True),
+        ("hash-meta", "agent-jarvis", "JARVIS discusses #ACP token", False),
+    ]
+    for name, sender, text, expected in cases:
+        got, _reason = should_process(sender, text)
+        print(f"{name}: got={got} expected={expected}")
+        if got != expected:
+            return 1
+
+    body = task_body("agent-jarvis", "codex:task:test", "msg-1", "42", "2026-06-21T00:00:00Z", "intent=task\nhello")
+    packet = json.loads(body)
+    if packet["source"] != "murmur" or packet["murmur"]["msg_id"] != "msg-1":
+        return 1
+    if "reply_via_send_boundary" not in packet["requirements"]:
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        return run_self_test()
+    result = process_env()
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/murmur-to-acp-producer.sh
+++ b/scripts/murmur-to-acp-producer.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec /usr/bin/env python3 /opt/lifecoach/mur-mur-v2/scripts/murmur-to-acp-producer.py "$@"

--- a/tests/ws4-acp-boundary.test.py
+++ b/tests/ws4-acp-boundary.test.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+producer = load("producer", ROOT / "scripts" / "murmur-to-acp-producer.py")
+sender = load("sender", ROOT / "scripts" / "murmur-send-service.py")
+
+
+def assert_eq(got, expected, label: str) -> None:
+    if got != expected:
+        raise AssertionError(f"{label}: got={got!r} expected={expected!r}")
+
+
+def test_producer_filter() -> None:
+    cases = [
+        ("sync", "agent-jarvis", "intent=sync\nhello", False),
+        ("codex-output", "agent-jarvis", "[CODEX->AGENT]\nintent=task", False),
+        ("self", "agent-codex-volt", "intent=task\nhello", False),
+        ("coord", "agent-jarvis", "JARVIS -> CODEX hello", False),
+        ("coord-arrow", "agent-jarvis", "JARVIS → CODEX hello", False),
+        ("task", "agent-jarvis", "intent=task\nhello", True),
+        ("task-meta", "agent-jarvis", "JARVIS discusses intent=task token", False),
+        ("hash", "agent-jarvis", "#ACP\nhello", True),
+        ("hash-meta", "agent-jarvis", "JARVIS discusses #ACP token", False),
+    ]
+    for label, sender_name, text, expected in cases:
+        got, _reason = producer.should_process(sender_name, text)
+        assert_eq(got, expected, f"producer {label}")
+
+
+def test_task_packet_contract() -> None:
+    body = producer.task_body(
+        "agent-jarvis",
+        "codex:task:ws4",
+        "msg-123",
+        "899",
+        "2026-06-21T20:42:08Z",
+        "intent=task\nWrite result.",
+    )
+    packet = json.loads(body)
+    assert_eq(packet["source"], "murmur", "packet source")
+    assert_eq(packet["murmur"]["msg_id"], "msg-123", "packet msg_id")
+    assert_eq(packet["reply"]["send_boundary"], "murmur-send-service", "send boundary")
+    assert "write_proof_pack" in packet["requirements"]
+    assert "reply_via_send_boundary" in packet["coverage"]
+
+
+def test_marker_removed_when_acp_create_fails() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        producer.STATE_ROOT = Path(tmp)
+        producer.LOG_PATH = Path(tmp) / "producer.log"
+        original = producer.create_or_get_task
+        try:
+            producer.create_or_get_task = lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom"))
+            env = {
+                "MURMUR_FROM": "agent-jarvis",
+                "MURMUR_TEXT": "intent=task\nhello",
+                "MURMUR_MSG_ID": "msg-fail",
+                "MURMUR_CONVERSATION_ID": "codex:task:ws4",
+            }
+            import os
+
+            old = {key: os.environ.get(key) for key in env}
+            os.environ.update(env)
+            try:
+                try:
+                    producer.process_env()
+                except RuntimeError:
+                    pass
+                else:
+                    raise AssertionError("expected RuntimeError")
+            finally:
+                for key, value in old.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value
+        finally:
+            producer.create_or_get_task = original
+        assert not (Path(tmp) / "seen" / "msg-fail").exists()
+
+
+def test_send_service_validation() -> None:
+    valid = {
+        "to": "agent-jarvis",
+        "conversation_id": "dm:agent-jarvis:agent-codex-volt",
+        "text": "[CODEX->AGENT]\nsource=codex-cli\nproject=/opt/lifecoach/vault\nts=2026-06-20T00:00:00Z\nintent=sync\nsummary=test",
+        "kind": "ack",
+        "source_task_id": 1,
+    }
+    cases = [
+        ("valid", valid, True),
+        ("bad-peer", {**valid, "to": "agent-evil"}, False),
+        ("bad-conv", {**valid, "conversation_id": "bad conv"}, False),
+        ("bad-kind", {**valid, "kind": "other"}, False),
+        ("secret", {**valid, "text": "OPENAI_API_KEY=secret"}, False),
+        ("auth-json", {**valid, "text": "auth.json"}, False),
+        ("too-large", {**valid, "text": "x" * (17 * 1024)}, False),
+    ]
+    for label, payload, expected in cases:
+        got, _reason = sender.validate_request(payload)
+        assert_eq(got, expected, f"sender {label}")
+
+
+def main() -> int:
+    test_producer_filter()
+    test_task_packet_contract()
+    test_marker_removed_when_acp_create_fails()
+    test_send_service_validation()
+    print("WS4 ACP boundary tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds reviewable WS4/WS5 source for the Murmur -> ACP autonomy lane without touching live runtime:

- `scripts/murmur-to-acp-producer.py` and wrapper: explicit task-intake filter, local idempotency by `MURMUR_MSG_ID`, ACP `create-or-get` upsert, task packet with proof-pack and send-boundary requirements.
- `scripts/murmur-send-service.py`: Unix-socket send boundary validation for ACP replies, peer/kind/conversation allowlists, secret-marker reject, audited call into Murmur send CLI.
- `scripts/murmur-shell-send.mjs`: standalone encrypted/signed outbox enqueue helper used by send-service.
- `tests/ws4-acp-boundary.test.py` plus `npm run test:ws4-acp`, wired into full `npm test`.

## Boundaries

- No boevoy writes.
- No ACP live edits.
- No daemon restart or shared broker restart.
- This PR only makes the reviewed source available for JARVIS review/merge/deploy.

## Verification

- `npm run test:ws4-acp`
- `npm test`

Both passed locally.
