### PR TITLE
feat(ws5): add send-boundary worker client

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "test:integration": "node scripts/run-integration.mjs",
     "test:notify-smoke": "node scripts/notify-smoke.mjs",
     "test:ws4-acp": "python3 tests/ws4-acp-boundary.test.py && python3 scripts/murmur-to-acp-producer.py --self-test && python3 scripts/murmur-send-service.py --self-test && python3 -m py_compile scripts/murmur-to-acp-producer.py scripts/murmur-send-service.py tests/ws4-acp-boundary.test.py",
+    "test:ws5-boundary": "python3 tests/ws5-send-boundary.test.py && python3 scripts/murmur-send-boundary.py --self-test && python3 -m py_compile scripts/murmur-send-boundary.py tests/ws5-send-boundary.test.py",
     "test:a2a": "npm --workspace @murmurv2/bridge-a2a test",
     "test:federation": "npm --workspace @murmurv2/federation test",
     "test:federation-nats": "npm --workspace @murmurv2/federation-nats test",
-    "test": "npm run build && npm run test:unit && npm run test:notify-smoke && npm run test:ws4-acp && npm run test:a2a && npm run test:federation && npm run test:federation-nats"
+    "test": "npm run build && npm run test:unit && npm run test:notify-smoke && npm run test:ws4-acp && npm run test:ws5-boundary && npm run test:a2a && npm run test:federation && npm run test:federation-nats"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/scripts/murmur-send-boundary.py
+++ b/scripts/murmur-send-boundary.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import socket
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+DEFAULT_SOCKET_PATH = Path(os.environ.get("MURMUR_SEND_SOCKET", "/run/murmur-send-service/codex-volt.sock"))
+DEFAULT_PROJECT = os.environ.get("MURMUR_SEND_PROJECT", "/opt/lifecoach/vault")
+DEFAULT_SOURCE = os.environ.get("MURMUR_SEND_SOURCE", "codex-acp-worker")
+PEERS = {"agent-jarvis", "agent-codex-mac-kovalyaevo"}
+KINDS = {"ack", "progress", "final", "blocked", "error"}
+MAX_BODY_BYTES = 14 * 1024
+CONVERSATION_RE = re.compile(r"^[a-zA-Z0-9:_./-]{1,160}$")
+SECRET_RE = re.compile(
+    r"BEGIN PRIVATE KEY|OPENAI_API_KEY=|auth\.json|ghp_|github_pat_|AKIA[0-9A-Z]{16}|xox[abp]-|sk-[A-Za-z0-9_-]{20,}|-----BEGIN",
+    re.IGNORECASE,
+)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_body(args: argparse.Namespace) -> str:
+    if args.text is not None:
+        return args.text
+    return sys.stdin.read()
+
+
+def build_message(*, kind: str, summary: str, body: str, source_task_id: str, project: str, source: str) -> str:
+    lines = [
+        "[CODEX->AGENT]",
+        f"source={source}",
+        f"project={project}",
+        f"ts={utc_now()}",
+        f"intent={kind}",
+        f"summary={summary}",
+    ]
+    if source_task_id:
+        lines.append(f"source_task_id={source_task_id}")
+    lines.extend(["", "payload:", body.rstrip()])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_payload(args: argparse.Namespace) -> dict:
+    body = read_body(args)
+    if not body.strip():
+        raise ValueError("empty-body")
+    if len(body.encode("utf-8")) > MAX_BODY_BYTES:
+        raise ValueError("body-too-large")
+    if SECRET_RE.search(body):
+        raise ValueError("secret-marker")
+    if args.to not in PEERS:
+        raise ValueError("bad-peer")
+    if args.kind not in KINDS:
+        raise ValueError("bad-kind")
+    if not CONVERSATION_RE.fullmatch(args.conversation_id):
+        raise ValueError("bad-conversation-id")
+    if not args.summary.strip():
+        raise ValueError("empty-summary")
+    text = build_message(
+        kind=args.kind,
+        summary=args.summary.strip(),
+        body=body,
+        source_task_id=args.source_task_id or "",
+        project=args.project,
+        source=args.source,
+    )
+    return {
+        "to": args.to,
+        "conversation_id": args.conversation_id,
+        "kind": args.kind,
+        "source_task_id": args.source_task_id,
+        "text": text,
+    }
+
+
+def send_to_socket(payload: dict, socket_path: Path, timeout_seconds: float) -> dict:
+    line = (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(timeout_seconds)
+        client.connect(str(socket_path))
+        client.sendall(line)
+        chunks = []
+        while True:
+            chunk = client.recv(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            if b"\n" in chunk:
+                break
+    raw = b"".join(chunks).decode("utf-8")
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"send-boundary-non-json-response:{raw[-500:]}") from exc
+    if not result.get("ok"):
+        raise RuntimeError(f"send-boundary-failed:{json.dumps(result, ensure_ascii=False, sort_keys=True)}")
+    return result
+
+
+def run_self_test() -> int:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "--to",
+            "agent-jarvis",
+            "--conversation-id",
+            "codex:task:test",
+            "--kind",
+            "final",
+            "--source-task-id",
+            "123",
+            "--summary",
+            "done",
+            "--text",
+            "proof-pack v0",
+            "--dry-run",
+        ]
+    )
+    payload = build_payload(args)
+    if payload["to"] != "agent-jarvis" or payload["kind"] != "final":
+        return 1
+    if "source=codex-acp-worker" not in payload["text"]:
+        return 1
+    if "payload:\nproof-pack v0" not in payload["text"]:
+        return 1
+    print("WS5 send-boundary client self-test passed")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Send ACP worker replies through the Murmur send boundary.")
+    parser.add_argument("--to", default="")
+    parser.add_argument("--conversation-id", default="")
+    parser.add_argument("--kind", choices=sorted(KINDS))
+    parser.add_argument("--source-task-id", default="")
+    parser.add_argument("--summary", default="")
+    parser.add_argument("--text")
+    parser.add_argument("--socket", type=Path, default=DEFAULT_SOCKET_PATH)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--project", default=DEFAULT_PROJECT)
+    parser.add_argument("--source", default=DEFAULT_SOURCE)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.self_test:
+        return run_self_test()
+    try:
+        payload = build_payload(args)
+        if args.dry_run:
+            print(json.dumps({"ok": True, "dry_run": True, "payload": payload}, ensure_ascii=False, indent=2))
+            return 0
+        result = send_to_socket(payload, args.socket, args.timeout)
+        print(json.dumps(result, ensure_ascii=False))
+        return 0
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/murmur-to-acp-producer.py
+++ b/scripts/murmur-to-acp-producer.py
@@ -75,6 +75,12 @@ def task_body(sender: str, conversation_id: str, msg_id: str, rowid: str, create
             "to": sender,
             "conversation_id": conversation_id,
             "send_boundary": "murmur-send-service",
+            "client": "murmur-send-boundary.py",
+            "command": (
+                "python3 /opt/lifecoach/mur-mur-v2/scripts/murmur-send-boundary.py "
+                f"--to {sender} --conversation-id {conversation_id} "
+                "--kind final --source-task-id <ACP_TASK_ID> --summary '<summary>'"
+            ),
         },
         "prompt": text,
         "requirements": ["create_or_get_task", "write_result", "write_proof_pack", "reply_via_send_boundary"],

--- a/tests/ws4-acp-boundary.test.py
+++ b/tests/ws4-acp-boundary.test.py
@@ -57,6 +57,8 @@ def test_task_packet_contract() -> None:
     assert_eq(packet["source"], "murmur", "packet source")
     assert_eq(packet["murmur"]["msg_id"], "msg-123", "packet msg_id")
     assert_eq(packet["reply"]["send_boundary"], "murmur-send-service", "send boundary")
+    assert_eq(packet["reply"]["client"], "murmur-send-boundary.py", "send boundary client")
+    assert "murmur-send-boundary.py" in packet["reply"]["command"]
     assert "write_proof_pack" in packet["requirements"]
     assert "reply_via_send_boundary" in packet["coverage"]
 

--- a/tests/ws5-send-boundary.test.py
+++ b/tests/ws5-send-boundary.test.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import contextlib
+import io
+import json
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+client = load("send_boundary", ROOT / "scripts" / "murmur-send-boundary.py")
+
+
+def parser_args(*extra: str):
+    parser = client.build_parser()
+    return parser.parse_args(
+        [
+            "--to",
+            "agent-jarvis",
+            "--conversation-id",
+            "codex:task:ws5",
+            "--kind",
+            "final",
+            "--source-task-id",
+            "321",
+            "--summary",
+            "ws5 done",
+            "--text",
+            "proof-pack v0",
+            *extra,
+        ]
+    )
+
+
+def assert_in(needle: str, haystack: str, label: str) -> None:
+    if needle not in haystack:
+        raise AssertionError(f"{label}: missing {needle!r}")
+
+
+def test_payload_envelope() -> None:
+    payload = client.build_payload(parser_args())
+    assert payload["to"] == "agent-jarvis"
+    assert payload["kind"] == "final"
+    assert payload["source_task_id"] == "321"
+    assert_in("[CODEX->AGENT]", payload["text"], "envelope")
+    assert_in("source=codex-acp-worker", payload["text"], "source")
+    assert_in("project=/opt/lifecoach/vault", payload["text"], "project")
+    assert_in("intent=final", payload["text"], "intent")
+    assert_in("summary=ws5 done", payload["text"], "summary")
+    assert_in("payload:\nproof-pack v0", payload["text"], "body")
+
+
+def test_client_validation() -> None:
+    for extra, expected in [
+        (("--to", "agent-evil"), "bad-peer"),
+        (("--kind", "other"), None),
+        (("--conversation-id", "bad conv"), "bad-conversation-id"),
+        (("--summary", " "), "empty-summary"),
+        (("--text", " "), "empty-body"),
+        (("--text", "OPENAI_API_KEY=secret"), "secret-marker"),
+    ]:
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                args = parser_args(*extra)
+            client.build_payload(args)
+        except SystemExit:
+            if expected is None:
+                continue
+            raise
+        except ValueError as exc:
+            if expected is None or str(exc) != expected:
+                raise AssertionError(f"expected {expected}, got {exc}") from exc
+        else:
+            raise AssertionError(f"expected validation failure {expected}")
+
+
+def test_socket_roundtrip() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        sock_path = Path(tmp) / "boundary.sock"
+        received: list[dict] = []
+
+        def server() -> None:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as srv:
+                srv.bind(str(sock_path))
+                srv.listen(1)
+                conn, _ = srv.accept()
+                with conn:
+                    data = b""
+                    while not data.endswith(b"\n"):
+                        data += conn.recv(65536)
+                    received.append(json.loads(data.decode("utf-8")))
+                    conn.sendall(json.dumps({"ok": True, "send": {"msgId": "msg-ws5"}}).encode("utf-8") + b"\n")
+
+        thread = threading.Thread(target=server, daemon=True)
+        thread.start()
+        deadline = time.time() + 2
+        while not sock_path.exists() and time.time() < deadline:
+            time.sleep(0.01)
+        if not sock_path.exists():
+            raise AssertionError("socket server did not bind")
+        result = client.send_to_socket(client.build_payload(parser_args()), sock_path, 2)
+        thread.join(timeout=2)
+
+        if thread.is_alive():
+            raise AssertionError("socket server did not exit")
+        if result["send"]["msgId"] != "msg-ws5":
+            raise AssertionError(f"bad result {result}")
+        if received[0]["conversation_id"] != "codex:task:ws5":
+            raise AssertionError(f"bad request {received[0]}")
+
+
+def main() -> int:
+    test_payload_envelope()
+    test_client_validation()
+    test_socket_roundtrip()
+    print("WS5 send-boundary tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the WS5 worker-facing side of the Murmur send boundary:

- `scripts/murmur-send-boundary.py`: executable CLI for ACP workers to send replies through the audited Unix-socket `murmur-send-service`.
- Builds a stable `[CODEX->AGENT]` metadata envelope (`source`, `project`, `ts`, `intent`, `summary`, optional `source_task_id`) before crossing the socket boundary.
- Performs client-side validation for peer/kind/conversation/body size/secret markers before calling the live service.
- Extends the Murmur->ACP task packet with the concrete reply client + command hint.
- Adds WS5 tests covering envelope contract, validation, and Unix-socket roundtrip with a temp socket.

## Boundaries

- No boevoy writes.
- No ACP live edits.
- No daemon restart or shared broker restart.
- This is source-only for JARVIS review/merge/deploy.

## Verification

- `npm run test:ws4-acp`
- `npm run test:ws5-boundary`
- `npm test`
- `git diff --check`

All passed locally.