### PR TITLE
fix(bridge-a2a): advertise JSONRPC transport in Agent Card + live interop test (#31)

### DIFF
--- a/packages/bridge-a2a/integration/bridge-a2a.live.mjs
+++ b/packages/bridge-a2a/integration/bridge-a2a.live.mjs
@@ -1,0 +1,128 @@
+// LIVE integration test for @murmurv2/bridge-a2a.
+// Proves the full round-trip over REAL transports (no mocks of the hard parts):
+//   A2A client --HTTP/JSON-RPC--> bridge --seal+NATS--> mock internal Murmur agent
+//   --reply env on ack.<bridge>--> bridge --decrypt+correlate--> A2A reply to client.
+// Requires a real nats-server (run via run-live.sh, default nats://127.0.0.1:14222).
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { connect, StringCodec } from "nats";
+import {
+  createKeyPair,
+  createSigningKeyPair,
+  decryptPayload,
+  encryptPayload,
+  signEnvelope,
+} from "../../security/dist/src/index.js";
+import { A2AMurmurBridge, extractText, stableEnvelopePayload } from "../dist/src/index.js";
+import { ClientFactory } from "@a2a-js/sdk/client";
+import { Role } from "@a2a-js/sdk";
+import net from "node:net";
+
+const NATS_URL = process.env.TEST_NATS_URL || "nats://127.0.0.1:14222";
+const sc = StringCodec();
+const ANSWER = "internal-agent-reply-42";
+
+// Self-skip when no nats-server is reachable (file lives in integration/, outside
+// node --test default discovery, but guard anyway so it never hard-fails in CI).
+function natsReachable(url) {
+  const { hostname, port } = new URL(url);
+  return new Promise((resolve) => {
+    const s = net.connect({ host: hostname, port: Number(port) }, () => { s.destroy(); resolve(true); });
+    s.on("error", () => resolve(false));
+    s.setTimeout(1500, () => { s.destroy(); resolve(false); });
+  });
+}
+
+test("LIVE: A2A client -> bridge -> NATS mesh -> mock agent -> reply", async (t) => {
+  if (!(await natsReachable(NATS_URL))) {
+    t.skip(`no nats-server at ${NATS_URL}; run via integration/run-live.sh`);
+    return;
+  }
+  const bridgeEnc = await createKeyPair();
+  const bridgeSign = await createSigningKeyPair();
+  const agentEnc = await createKeyPair();
+  const agentSign = await createSigningKeyPair();
+
+  const target = "agent-jarvis";
+  const a2aPort = 14310;
+
+  const cfg = {
+    natsUrl: NATS_URL,
+    agentId: "a2a-bridge",
+    defaultTargetAgentId: target,
+    a2aPort,
+    signingPrivateKey: bridgeSign.privateKey,
+    encryptionPrivateKey: bridgeEnc.privateKey,
+    recipientPublicKeys: { [target]: agentEnc.publicKey },
+    allowedExternalAgents: ["ext-1"],
+    replyTimeoutMs: 10_000,
+  };
+
+  // ── mock internal Murmur agent over real NATS ──
+  const nc = await connect({ servers: NATS_URL });
+  const sub = nc.subscribe(`msg.${target}`);
+  let receivedTaskText = null;
+  const agentLoop = (async () => {
+    for await (const m of sub) {
+      const env = JSON.parse(sc.decode(m.data));
+      // open the sealed task (proves bridge seal -> agent open works end-to-end)
+      const plain = await decryptPayload(
+        { ciphertext: env.payloadCiphertext, nonce: env.payloadNonce, senderPublicKey: bridgeEnc.publicKey },
+        agentEnc.privateKey,
+      );
+      const task = JSON.parse(plain);
+      receivedTaskText = task.text;
+      // reply sealed back to the bridge, parentMsgId correlates to the original
+      const replyEnc = await encryptPayload(
+        JSON.stringify({ reply: ANSWER, echo: task.text }),
+        bridgeEnc.publicKey,
+        agentEnc.privateKey,
+      );
+      const unsigned = {
+        schemaVersion: "1.0",
+        msgId: randomUUID(),
+        parentMsgId: env.msgId,
+        conversationId: env.conversationId,
+        senderAgentId: target,
+        recipients: [env.senderAgentId],
+        createdAt: new Date().toISOString(),
+        payloadCiphertext: replyEnc.ciphertext,
+        payloadNonce: replyEnc.nonce,
+      };
+      const signature = await signEnvelope(stableEnvelopePayload({ ...unsigned, signature: "" }), agentSign.privateKey);
+      nc.publish(`ack.${cfg.agentId}`, sc.encode(JSON.stringify({ ...unsigned, signature })));
+    }
+  })();
+
+  const bridge = new A2AMurmurBridge(cfg);
+  await bridge.start();
+
+  t.after(async () => {
+    await bridge.stop();
+    sub.unsubscribe();
+    await agentLoop.catch(() => {});
+    await nc.drain();
+  });
+
+  // ── real A2A client over HTTP ──
+  const factory = new ClientFactory();
+  const client = await factory.createFromUrl(`http://127.0.0.1:${a2aPort}`);
+
+  const message = {
+    messageId: randomUUID(),
+    contextId: randomUUID(),
+    taskId: "",
+    role: Role.ROLE_USER,
+    parts: [{ content: { $case: "text", value: "please do the thing" }, metadata: undefined, filename: "", mediaType: "text/plain" }],
+    metadata: { externalAgentId: "ext-1" },
+    extensions: [],
+    referenceTaskIds: [],
+  };
+
+  const result = await client.sendMessage({ message });
+
+  const replyText = extractText(result);
+  assert.ok(receivedTaskText && receivedTaskText.includes("please do the thing"), `mock agent saw task text, got: ${receivedTaskText}`);
+  assert.ok(replyText.includes(ANSWER), `A2A reply should carry internal answer, got: ${JSON.stringify(replyText)}`);
+});

--- a/packages/bridge-a2a/integration/run-live.sh
+++ b/packages/bridge-a2a/integration/run-live.sh
@@ -1,27 +1,42 @@
 #!/usr/bin/env bash
 # Boot an isolated local nats-server, run the live A2A integration test, tear down.
-# Uses /tmp/nats-server-test (downloaded binary), port 14222 — NOT the prod broker.
-set -uo pipefail
+# Uses a nats-server on PATH (or the downloaded /tmp/nats-server-test), port 14222 —
+# NOT the prod broker.
+#
+# Unlike a bare `node --test`, this wrapper HARD-FAILS if the broker does not come up,
+# so `test:live` can NEVER report green without exercising the real NATS/HTTP/crypto
+# path. (CODEX review of PR #41: a fixed /tmp log owned by another user + no `set -e`
+# let a failed broker boot fall through to the JS self-skip and still exit 0.)
+set -euo pipefail
 PORT="${TEST_NATS_PORT:-14222}"
 NATS_BIN="${NATS_BIN:-$(command -v nats-server || echo /tmp/nats-server-test)}"
 HERE="$(cd "$(dirname "$0")/.." && pwd)"   # package root
 
+# Genuine no-infra skip (no binary at all) — distinct from a FAILED boot below.
 if [ ! -x "$NATS_BIN" ]; then
-  echo "SKIP: no nats-server binary ($NATS_BIN). Install nats-server or set NATS_BIN." >&2
+  echo "SKIP: no nats-server binary ($NATS_BIN). Install nats-server or set NATS_BIN to run the live proof." >&2
   exit 0
 fi
 
-"$NATS_BIN" -p "$PORT" -a 127.0.0.1 >/tmp/nats-test.log 2>&1 &
+LOG="$(mktemp "${TMPDIR:-/tmp}/nats-live.XXXXXX.log")"
+"$NATS_BIN" -p "$PORT" -a 127.0.0.1 >"$LOG" 2>&1 &
 NPID=$!
-trap 'kill "$NPID" 2>/dev/null' EXIT
+cleanup() { kill "$NPID" 2>/dev/null || true; rm -f "$LOG"; }
+trap cleanup EXIT
 
-# wait for nats to accept connections
-for i in $(seq 1 30); do
-  if (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then exec 3>&- 3<&-; break; fi
+# Once we have selected + started a broker, a failed boot is a HARD FAILURE, never a skip.
+reachable=""
+for _ in $(seq 1 30); do
+  if ! kill -0 "$NPID" 2>/dev/null; then
+    echo "FAIL: nats-server exited during boot. Log:" >&2; cat "$LOG" >&2; exit 1
+  fi
+  if (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then exec 3>&- 3<&-; reachable=1; break; fi
   sleep 0.2
 done
+if [ -z "$reachable" ]; then
+  echo "FAIL: nats-server port $PORT not reachable after wait. Log:" >&2; cat "$LOG" >&2; exit 1
+fi
 
 cd "$HERE"
+# `set -e` propagates a real test failure as a non-zero exit.
 TEST_NATS_URL="nats://127.0.0.1:$PORT" node --test integration/bridge-a2a.live.mjs
-RC=$?
-exit $RC

--- a/packages/bridge-a2a/integration/run-live.sh
+++ b/packages/bridge-a2a/integration/run-live.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Boot an isolated local nats-server, run the live A2A integration test, tear down.
+# Uses /tmp/nats-server-test (downloaded binary), port 14222 — NOT the prod broker.
+set -uo pipefail
+PORT="${TEST_NATS_PORT:-14222}"
+NATS_BIN="${NATS_BIN:-$(command -v nats-server || echo /tmp/nats-server-test)}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"   # package root
+
+if [ ! -x "$NATS_BIN" ]; then
+  echo "SKIP: no nats-server binary ($NATS_BIN). Install nats-server or set NATS_BIN." >&2
+  exit 0
+fi
+
+"$NATS_BIN" -p "$PORT" -a 127.0.0.1 >/tmp/nats-test.log 2>&1 &
+NPID=$!
+trap 'kill "$NPID" 2>/dev/null' EXIT
+
+# wait for nats to accept connections
+for i in $(seq 1 30); do
+  if (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then exec 3>&- 3<&-; break; fi
+  sleep 0.2
+done
+
+cd "$HERE"
+TEST_NATS_URL="nats://127.0.0.1:$PORT" node --test integration/bridge-a2a.live.mjs
+RC=$?
+exit $RC

--- a/packages/bridge-a2a/package.json
+++ b/packages/bridge-a2a/package.json
@@ -7,7 +7,8 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node --test"
+    "test": "npm run build && node --test",
+    "test:live": "npm run build && bash integration/run-live.sh"
   },
   "dependencies": {
     "@a2a-js/sdk": "1.0.0-alpha.0",

--- a/packages/bridge-a2a/src/index.ts
+++ b/packages/bridge-a2a/src/index.ts
@@ -249,7 +249,6 @@ export class A2AMurmurBridge {
       // .createFromUrl / .createFromAgentCard) can discover where to reach us.
       // jsonRpcHandler is mounted at the server root, so the endpoint == baseUrl.
       url: baseUrl,
-      preferredTransport: "JSONRPC",
       supportedInterfaces: [
         { url: baseUrl, protocolBinding: "JSONRPC", tenant: "", protocolVersion: "1.0" },
       ],

--- a/packages/bridge-a2a/src/index.ts
+++ b/packages/bridge-a2a/src/index.ts
@@ -54,6 +54,14 @@ export interface BridgeA2AConfig {
   defaultTargetAgentId: string;
   /** HTTP port the A2A server listens on. */
   a2aPort: number;
+  /**
+   * Absolute base URL where this bridge's A2A JSON-RPC endpoint is reachable by
+   * external clients (e.g. "https://a2a.example.com"). Advertised in the Agent
+   * Card's supportedInterfaces so standard A2A clients can discover the transport.
+   * Defaults to http://127.0.0.1:<a2aPort> (local/dev). MUST be set to the public
+   * HTTPS URL in production.
+   */
+  publicUrl?: string;
   /** Ed25519 private key the bridge signs internal envelopes with. */
   signingPrivateKey: string;
   /** X25519 private key the bridge seals outbound / opens inbound replies with. */
@@ -232,10 +240,19 @@ export class A2AMurmurBridge {
   agentCard(): AgentCard {
     // fromJSON fills the protobuf required defaults (supportedInterfaces, security*,
     // signatures, provider) so we only declare the fields we actually populate.
+    const baseUrl = this.config.publicUrl ?? `http://127.0.0.1:${this.config.a2aPort}`;
     return AgentCard.fromJSON({
       name: `murmur-bridge:${this.config.defaultTargetAgentId}`,
       description: "A2A bridge into a private Murmur (E2E/NATS) agent mesh.",
       version: "0.1.0",
+      // Advertise the JSON-RPC transport so standard A2A clients (ClientFactory
+      // .createFromUrl / .createFromAgentCard) can discover where to reach us.
+      // jsonRpcHandler is mounted at the server root, so the endpoint == baseUrl.
+      url: baseUrl,
+      preferredTransport: "JSONRPC",
+      supportedInterfaces: [
+        { url: baseUrl, protocolBinding: "JSONRPC", tenant: "", protocolVersion: "1.0" },
+      ],
       capabilities: { streaming: false }, // TODO(phase2): SSE streaming
       defaultInputModes: ["text/plain"],
       defaultOutputModes: ["text/plain"],


### PR DESCRIPTION
## What
Closes the live-interop gate for `@murmurv2/bridge-a2a` (#31) and fixes a real discovery bug.

**Bug:** the bridge served an Agent Card with no `supportedInterfaces`, so a standard A2A client (`ClientFactory.createFromUrl`/`createFromAgentCard`) could not select a transport → `No compatible transport found, available transports: JSONRPC,HTTP+JSON`. No external A2A agent could actually reach the bridge.

**Fix:** add `publicUrl` config and declare the JSONRPC interface in the card (`url` + `protocolBinding: "JSONRPC"`, `preferredTransport`). Defaults to `http://127.0.0.1:<a2aPort>` for local/dev; set to the public HTTPS URL in prod.

## Live proof
New `integration/bridge-a2a.live.mjs` + `integration/run-live.sh` prove the FULL round-trip over real transports (no mocks of the hard parts):

`A2A client --HTTP/JSON-RPC--> bridge --seal+NATS--> mock internal Murmur agent --reply env on ack.<bridge>--> bridge --decrypt+correlate(parentMsgId)--> A2A reply`

- Boots an **isolated local nats-server** (port 14222), NOT the prod broker (R-OPS-006).
- Kept **out of `node --test` default discovery** (`integration/` dir) + **self-skips** when no NATS reachable → core CI stays green without external infra.

## Verify
- `npm --workspace @murmurv2/bridge-a2a test` → 6/6 unit pass (no regression).
- `npm --workspace @murmurv2/bridge-a2a run test:live` → 1/1 live pass (with nats-server on PATH or `/tmp/nats-server-test`).

## Review ask (CODEX-VOLT)
Cross-review please: (1) card interface fields vs A2A spec (protocolBinding/url/protocolVersion), (2) the live harness teardown (bridge.stop + nats drain), (3) whether `publicUrl` belongs in the federation #14 key-directory story later. Opt-in package, not in root `tsc -b`/core CI.