### PR TITLE
test(federation): live two-org interop — roster verify + cross-org sealed envelope over NATS accounts (#14)

### DIFF
--- a/packages/federation-nats/integration/federation.live.mjs
+++ b/packages/federation-nats/integration/federation.live.mjs
@@ -1,0 +1,135 @@
+// LIVE federation interop test (JARVIS half of #14, isolated two-org).
+// Proves the full cross-org path over REAL NATS account isolation:
+//   1. Each org publishes an Ed25519-signed roster of its agents.
+//   2. The partner verifies that roster against a PINNED org key (and rejects a
+//      wrong pinned key + a tampered roster) — the only net-new crypto surface.
+//   3. org A seals+signs an EnvelopeV1 to org B's agent (keys taken from B's
+//      verified roster) and publishes it on the fed.* subject; NATS routes it
+//      across accounts (A imports B's `fed.partner.>` service); B verifies A's
+//      agent signature (key from A's verified roster) and decrypts.
+// Account config is generated from buildFederationAccountContract (gen-accounts-conf.mjs)
+// so the server config can't drift from the contract. Run via run-fed-live.sh
+// (boots an isolated local nats-server with the accounts config — NOT the prod broker).
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import { randomUUID } from "node:crypto";
+import { connect, StringCodec } from "nats";
+import {
+  createKeyPair,
+  createSigningKeyPair,
+  encryptPayload,
+  decryptPayload,
+  signEnvelope,
+  verifyEnvelopeSignature,
+} from "../../security/dist/src/index.js";
+import { signRoster, verifyRoster, lookupAgentKeys } from "../../federation/dist/src/index.js";
+import { federationMessageSubject } from "../dist/src/index.js";
+
+const PORT = process.env.FED_NATS_PORT || "14333";
+const NATS_URL = `nats://127.0.0.1:${PORT}`;
+const sc = StringCodec();
+
+// Mesh-canonical signing input (byte-identical to daemon / mcp-server / bridge-a2a).
+function stableEnvelopePayload(e) {
+  return JSON.stringify({
+    schemaVersion: e.schemaVersion,
+    msgId: e.msgId,
+    conversationId: e.conversationId,
+    senderAgentId: e.senderAgentId,
+    recipients: [...e.recipients],
+    createdAt: e.createdAt,
+    payloadCiphertext: e.payloadCiphertext,
+    payloadNonce: e.payloadNonce,
+  });
+}
+
+function natsReachable(url) {
+  const { hostname, port } = new URL(url);
+  return new Promise((resolve) => {
+    const s = net.connect({ host: hostname, port: Number(port) }, () => { s.destroy(); resolve(true); });
+    s.on("error", () => resolve(false));
+    s.setTimeout(1500, () => { s.destroy(); resolve(false); });
+  });
+}
+
+test("LIVE federation: roster sign/verify + cross-org sealed+signed envelope over isolated NATS accounts", async (t) => {
+  if (!(await natsReachable(NATS_URL))) {
+    t.skip(`no accounts nats-server at ${NATS_URL}; run via integration/run-fed-live.sh`);
+    return;
+  }
+
+  // org-level directory signing keypairs + per-agent keypairs
+  const aOrgSign = await createSigningKeyPair();
+  const bOrgSign = await createSigningKeyPair();
+  const aAgentEnc = await createKeyPair();
+  const aAgentSign = await createSigningKeyPair();
+  const bAgentEnc = await createKeyPair();
+  const bAgentSign = await createSigningKeyPair();
+
+  const rosterA = await signRoster(
+    { org: "aimindset", version: 1, issuedAt: "2026-06-21T00:00:00Z",
+      agents: { "agent-jarvis": { encryptPublicKey: aAgentEnc.publicKey, verifyPublicKey: aAgentSign.publicKey } } },
+    aOrgSign.privateKey, aOrgSign.publicKey,
+  );
+  const rosterB = await signRoster(
+    { org: "partner", version: 1, issuedAt: "2026-06-21T00:00:00Z",
+      agents: { "agent-codex": { encryptPublicKey: bAgentEnc.publicKey, verifyPublicKey: bAgentSign.publicKey } } },
+    bOrgSign.privateKey, bOrgSign.publicKey,
+  );
+
+  // roster trust: pinned key verifies; wrong pinned key + tampered roster are rejected
+  assert.equal(await verifyRoster(rosterA, aOrgSign.publicKey), true, "valid roster verifies with pinned org key");
+  assert.equal(await verifyRoster(rosterA, bOrgSign.publicKey), false, "wrong pinned key rejected");
+  const tampered = {
+    ...rosterA,
+    agents: { "agent-jarvis": { encryptPublicKey: bAgentEnc.publicKey, verifyPublicKey: aAgentSign.publicKey } },
+  };
+  assert.equal(await verifyRoster(tampered, aOrgSign.publicKey), false, "tampered roster rejected");
+
+  const aKeys = lookupAgentKeys(rosterA, "agent-jarvis"); // B's view of A's agent
+  const bKeys = lookupAgentKeys(rosterB, "agent-codex");  // A's view of B's agent
+
+  // live cross-org over isolated accounts
+  const a = await connect({ servers: NATS_URL, user: "aimindset", pass: "pw_aimindset", name: "orgA" });
+  const b = await connect({ servers: NATS_URL, user: "partner", pass: "pw_partner", name: "orgB" });
+  t.after(async () => { await a.drain(); await b.drain(); });
+
+  const subject = federationMessageSubject("partner/agent-codex", "aimindset"); // fed.partner.msg.agent-codex
+  const sub = b.subscribe(subject);
+  let received = null;
+  const waiter = (async () => { for await (const m of sub) { received = JSON.parse(sc.decode(m.data)); break; } })();
+
+  // A seals to B's agent (B's enc key from verified roster) + signs with A's agent key
+  const plaintext = JSON.stringify({ intent: "task", text: "cross-org hello from aimindset/agent-jarvis" });
+  const enc = await encryptPayload(plaintext, bKeys.encryptPublicKey, aAgentEnc.privateKey);
+  const unsigned = {
+    schemaVersion: "1.0",
+    msgId: randomUUID(),
+    conversationId: "fed-conv-1",
+    senderAgentId: "aimindset/agent-jarvis",
+    recipients: ["partner/agent-codex"],
+    createdAt: new Date().toISOString(),
+    payloadCiphertext: enc.ciphertext,
+    payloadNonce: enc.nonce,
+  };
+  const envelope = { ...unsigned, signature: await signEnvelope(stableEnvelopePayload(unsigned), aAgentSign.privateKey) };
+
+  await new Promise((r) => setTimeout(r, 250)); // sub propagation across accounts
+  a.publish(subject, sc.encode(JSON.stringify(envelope)));
+  await Promise.race([waiter, new Promise((r) => setTimeout(r, 1500))]);
+
+  assert.ok(received, "B received the cross-org envelope");
+  assert.equal(received.senderAgentId, "aimindset/agent-jarvis", "sender preserved");
+  // B verifies A's agent signature via the key from A's verified roster
+  assert.equal(
+    await verifyEnvelopeSignature(stableEnvelopePayload(received), received.signature, aKeys.verifyPublicKey),
+    true, "A's agent signature verifies via roster key",
+  );
+  // B decrypts with its agent key + A's agent enc key (from verified roster)
+  const opened = await decryptPayload(
+    { ciphertext: received.payloadCiphertext, nonce: received.payloadNonce, senderPublicKey: aKeys.encryptPublicKey },
+    bAgentEnc.privateKey,
+  );
+  assert.equal(JSON.parse(opened).text, "cross-org hello from aimindset/agent-jarvis", "payload decrypts intact");
+});

--- a/packages/federation-nats/integration/gen-accounts-conf.mjs
+++ b/packages/federation-nats/integration/gen-accounts-conf.mjs
@@ -1,0 +1,26 @@
+// Generate a nats-server accounts config from the federation account contract,
+// so the LIVE two-org test runs against the SAME exports/imports the contract
+// describes (no hand-divergence between contract and the server config).
+// Maps each org's contract to NATS service export/import (cross-account one-way
+// publish: an importing account may publish into the exporter's service subject).
+import { buildFederationAccountContract } from "../dist/src/index.js";
+
+const ORGS = (process.env.FED_ORGS || "aimindset,partner").split(",");
+const PORT = process.env.FED_NATS_PORT || "14333";
+
+const lines = [`port: ${PORT}`, "accounts {"];
+for (const org of ORGS) {
+  const partners = ORGS.filter((o) => o !== org);
+  const c = buildFederationAccountContract(org, partners);
+  lines.push(`  ${c.localAccount} {`);
+  lines.push(`    users: [{ user: "${org}", password: "pw_${org}" }]`);
+  lines.push(`    exports: [`);
+  for (const ex of c.exports) lines.push(`      { service: "${ex}" }`);
+  lines.push(`    ]`);
+  lines.push(`    imports: [`);
+  for (const im of c.imports) lines.push(`      { service: { account: "${im.account}", subject: "${im.subject}" } }`);
+  lines.push(`    ]`);
+  lines.push(`  }`);
+}
+lines.push("}");
+process.stdout.write(lines.join("\n") + "\n");

--- a/packages/federation-nats/integration/run-fed-live.sh
+++ b/packages/federation-nats/integration/run-fed-live.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Boot an isolated local nats-server with a 2-org accounts config generated from the
+# federation account contract, run the LIVE federation interop test, tear down.
+# Hard-fails if the broker does not come up (no silent skip-to-green).
+set -euo pipefail
+PORT="${FED_NATS_PORT:-14333}"
+NATS_BIN="${NATS_BIN:-$(command -v nats-server || echo /tmp/nats-server-test)}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"   # package root
+
+if [ ! -x "$NATS_BIN" ]; then
+  echo "SKIP: no nats-server binary ($NATS_BIN). Install nats-server or set NATS_BIN." >&2
+  exit 0
+fi
+
+cd "$HERE"
+CONF="$(mktemp "${TMPDIR:-/tmp}/fed-accounts.XXXXXX.conf")"
+LOG="$(mktemp "${TMPDIR:-/tmp}/fed-nats.XXXXXX.log")"
+FED_NATS_PORT="$PORT" node integration/gen-accounts-conf.mjs > "$CONF"
+
+"$NATS_BIN" -c "$CONF" >"$LOG" 2>&1 &
+NPID=$!
+cleanup() { kill "$NPID" 2>/dev/null || true; rm -f "$CONF" "$LOG"; }
+trap cleanup EXIT
+
+reachable=""
+for _ in $(seq 1 30); do
+  if ! kill -0 "$NPID" 2>/dev/null; then
+    echo "FAIL: nats-server exited during boot. Conf:" >&2; cat "$CONF" >&2; echo "Log:" >&2; cat "$LOG" >&2; exit 1
+  fi
+  if (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null; then exec 3>&- 3<&-; reachable=1; break; fi
+  sleep 0.2
+done
+if [ -z "$reachable" ]; then
+  echo "FAIL: nats-server port $PORT not reachable. Log:" >&2; cat "$LOG" >&2; exit 1
+fi
+
+FED_NATS_PORT="$PORT" node --test integration/federation.live.mjs

--- a/packages/federation-nats/package.json
+++ b/packages/federation-nats/package.json
@@ -7,10 +7,15 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node --test test/*.test.mjs"
+    "test": "npm run build && node --test test/*.test.mjs",
+    "test:fed-live": "npm run build && bash integration/run-fed-live.sh"
   },
   "dependencies": {
     "@murmurv2/core": "file:../core",
     "@murmurv2/federation": "file:../federation"
+  },
+  "devDependencies": {
+    "@murmurv2/security": "file:../security",
+    "nats": "^2.28.2"
   }
 }


### PR DESCRIPTION
## What
JARVIS half of #14: proves the federation primitives work **end-to-end over real NATS account isolation**, not just unit tests. Pairs with CODEX's real-deployment leaf-node/account half.

## Live proof (`integration/federation.live.mjs` + `run-fed-live.sh`)
1. **Account config from the contract:** `gen-accounts-conf.mjs` derives the nats-server accounts config straight from `buildFederationAccountContract` → server config can't drift from #36's contract.
2. **Roster trust:** each org publishes an Ed25519-signed roster; partner `verifyRoster` against a **pinned** org key — accepts valid, **rejects wrong pinned key + tampered roster**.
3. **Cross-org sealed+signed envelope:** org A seals to B's agent (enc key from B's verified roster) + signs with A's agent key → publishes `fed.partner.msg.agent-codex` → NATS routes **across accounts** (A imports B's `fed.partner.>` service) → B verifies A's agent signature (key from A's verified roster) + decrypts intact.

## Empirical finding for the real-deployment half (#14, CODEX)
`buildFederationAccountContract` maps **1:1 to NATS service export/import**; one-way cross-org publish works out of the box in standalone accounts mode (`exports:[{service:"fed.<self>.>"}]`, `imports:[{service:{account:"ORG_<partner>", subject:"fed.<partner>.>"}}]`). No contract wording change needed. (Verify response-permissions for reply-less pub on leaf-node/operator mode.)

## CI-safe
`integration/` is outside `node --test` default discovery; the package `test` globs `test/*.test.mjs` only. `run-fed-live.sh` **hard-fails** if the broker doesn't boot (no silent skip-to-green, same discipline as #41). Self-skips without NATS.

## Verify
- `npm --workspace @murmurv2/federation-nats test` → 6/6 (no regression)
- `npm --workspace @murmurv2/federation test` → 11/11
- `npm --workspace @murmurv2/federation-nats run test:fed-live` → 1/1 live (nats-server on PATH or /tmp/nats-server-test); `NATS_BIN=/bin/false` → exit 1

## Review ask (CODEX-VOLT)
Cross-review: (1) account-config generation vs your intended leaf-node/operator wiring, (2) whether the service export/import finding changes your #14 real-deployment plan, (3) roster pinned-key trust model in the test vs how orgs exchange pinned keys in production.