### PR TITLE
feat(federation-nats): real-mesh account config renderer

### DIFF
--- a/docs/federation-nats-contract.md
+++ b/docs/federation-nats-contract.md
@@ -47,6 +47,92 @@ This keeps federation routing separate from local mesh subjects and prevents a
 partner account from publishing under another org's prefix when the broker is
 configured with matching account exports/imports.
 
+For production/static NATS config, generate account blocks from the package API
+instead of hand-maintaining exports/imports:
+
+```js
+import { renderFederationNatsAccountsConfig } from "@murmurv2/federation-nats";
+
+process.stdout.write(renderFederationNatsAccountsConfig({
+  orgs: ["aimindset", "partner.org"],
+  usersByOrg: {
+    aimindset: [{ user: "leaf-aimindset", password: process.env.AIMINDSET_LEAF_PASSWORD }],
+    "partner.org": [{ user: "leaf-partner", password: process.env.PARTNER_LEAF_PASSWORD }],
+  },
+}));
+```
+
+The rendered config uses NATS service export/import for the `fed.<org>.>`
+prefixes. Exports are partner-scoped by default:
+
+```text
+ORG_AIMINDSET {
+  exports: [{ service: "fed.aimindset.>", accounts: ["ORG__XCGFYDG5LCI5VCMC"] }]
+  imports: [{ service: { account: "ORG__XCGFYDG5LCI5VCMC", subject: "fed._xcGFydG5lci5vcmc.>" } }]
+}
+```
+
+This matches the live interop finding: an importing account may publish to the
+exporter's service subject, so one-way reply-less `fed.*` message delivery does
+not require switching the subject contract to stream import/export.
+
+## Real Mesh Leaf-Node Wiring
+
+Deployment target for issue #14 is one federation account per org, connected by
+leaf nodes or operator-mode accounts. Do not restart the shared production broker
+for smoke tests; validate with isolated local brokers first.
+
+Minimum real-mesh shape:
+
+```text
+local org account:
+  account: ORG_<LOCAL>
+  exports:
+    - service: fed.<local-token>.>
+      accounts: [ORG_<PARTNER>]
+  imports:
+    - service:
+        account: ORG_<PARTNER>
+        subject: fed.<partner-token>.>
+
+leaf connection:
+  bind the local leaf remote to ORG_<LOCAL>
+  restrict leaf-user publish/subscribe permissions to fed.<local-token>.> and fed.<partner-token>.>
+```
+
+Before production wiring, run an operator/leaf-node smoke with the generated
+account config and restricted leaf users. The acceptance check is:
+
+1. org A can publish `fed.<partner>.msg.<agent>` and org B receives it.
+2. org A cannot publish outside imported partner prefixes.
+3. org B cannot subscribe outside its local exported prefix.
+4. reply-less publish works without `allow_responses`; if request/reply is added
+   later, configure response permissions explicitly for the responder user.
+
+For operator/JWT deployments, keep the same service export/import subjects in
+account JWTs. The static config renderer is the source-of-truth template, not a
+separate contract.
+
+## Production Trust Store
+
+Roster `signingPublicKey` is metadata, not a trust root. Production federation
+must pin partner org signing keys out-of-band, for example in deployment config
+or an operator-managed trust store:
+
+```json
+{
+  "partner.org": {
+    "account": "ORG__XCGFYDG5LCI5VCMC",
+    "rosterSigningPublicKey": "base64url-ed25519-public-key"
+  }
+}
+```
+
+Bridge/runtime code should reject rosters whose signature does not verify
+against the pinned key and should enforce monotonic roster versions to prevent
+replay. Version/replay state belongs in the bridge runtime, not in the NATS
+subject contract.
+
 ## E2E Boundary
 
 Federation routing only chooses subjects. It does not decrypt, parse, rewrite,

--- a/packages/federation-nats/integration/gen-accounts-conf.mjs
+++ b/packages/federation-nats/integration/gen-accounts-conf.mjs
@@ -3,24 +3,9 @@
 // describes (no hand-divergence between contract and the server config).
 // Maps each org's contract to NATS service export/import (cross-account one-way
 // publish: an importing account may publish into the exporter's service subject).
-import { buildFederationAccountContract } from "../dist/src/index.js";
+import { renderFederationNatsAccountsConfig } from "../dist/src/index.js";
 
 const ORGS = (process.env.FED_ORGS || "aimindset,partner").split(",");
 const PORT = process.env.FED_NATS_PORT || "14333";
 
-const lines = [`port: ${PORT}`, "accounts {"];
-for (const org of ORGS) {
-  const partners = ORGS.filter((o) => o !== org);
-  const c = buildFederationAccountContract(org, partners);
-  lines.push(`  ${c.localAccount} {`);
-  lines.push(`    users: [{ user: "${org}", password: "pw_${org}" }]`);
-  lines.push(`    exports: [`);
-  for (const ex of c.exports) lines.push(`      { service: "${ex}" }`);
-  lines.push(`    ]`);
-  lines.push(`    imports: [`);
-  for (const im of c.imports) lines.push(`      { service: { account: "${im.account}", subject: "${im.subject}" } }`);
-  lines.push(`    ]`);
-  lines.push(`  }`);
-}
-lines.push("}");
-process.stdout.write(lines.join("\n") + "\n");
+process.stdout.write(renderFederationNatsAccountsConfig({ orgs: ORGS, port: PORT }));

--- a/packages/federation-nats/src/index.ts
+++ b/packages/federation-nats/src/index.ts
@@ -23,6 +23,41 @@ export interface FederationAccountContract {
   imports: FederationImport[];
 }
 
+export interface FederationNatsUser {
+  user: string;
+  password: string;
+}
+
+export interface FederationNatsServiceExport {
+  service: string;
+  accounts?: string[];
+}
+
+export interface FederationNatsServiceImport {
+  service: FederationImport;
+}
+
+export interface FederationNatsAccountConfig {
+  account: string;
+  users: FederationNatsUser[];
+  exports: FederationNatsServiceExport[];
+  imports: FederationNatsServiceImport[];
+}
+
+export interface BuildFederationNatsAccountConfigOptions {
+  localOrg: string;
+  partnerOrgs?: string[];
+  users?: FederationNatsUser[];
+  privateExports?: boolean;
+}
+
+export interface RenderFederationNatsAccountsConfigOptions {
+  orgs: string[];
+  port?: number | string;
+  usersByOrg?: Record<string, FederationNatsUser[]>;
+  privateExports?: boolean;
+}
+
 const FEDERATION_PREFIX = "fed";
 const ENCODED_PREFIX = "_x";
 const RAW_TOKEN_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
@@ -125,4 +160,66 @@ export const buildFederationAccountContract = (
       subject: `${FEDERATION_PREFIX}.${encodeFederationToken(partnerOrg)}.>`,
     })),
   };
+};
+
+const quoteNatsString = (value: string): string => JSON.stringify(value);
+
+export const buildFederationNatsAccountConfig = ({
+  localOrg,
+  partnerOrgs = [],
+  users = [{ user: localOrg, password: `pw_${localOrg}` }],
+  privateExports = true,
+}: BuildFederationNatsAccountConfigOptions): FederationNatsAccountConfig => {
+  const contract = buildFederationAccountContract(localOrg, partnerOrgs);
+  const partnerAccounts = partnerOrgs.map(orgAccountName);
+  return {
+    account: contract.localAccount,
+    users,
+    exports: contract.exports.map((service) => ({
+      service,
+      ...(privateExports ? { accounts: partnerAccounts } : {}),
+    })),
+    imports: contract.imports.map((service) => ({ service })),
+  };
+};
+
+export const renderFederationNatsAccountsConfig = ({
+  orgs,
+  port = 14333,
+  usersByOrg = {},
+  privateExports = true,
+}: RenderFederationNatsAccountsConfigOptions): string => {
+  if (!Array.isArray(orgs) || orgs.length === 0) throw new Error("orgs-missing");
+  const lines = [`port: ${port}`, "accounts {"];
+  for (const org of orgs) {
+    const partners = orgs.filter((o) => o !== org);
+    const account = buildFederationNatsAccountConfig({
+      localOrg: org,
+      partnerOrgs: partners,
+      users: usersByOrg[org] ?? [{ user: org, password: `pw_${org}` }],
+      privateExports,
+    });
+    lines.push(`  ${account.account} {`);
+    lines.push(`    users: [`);
+    for (const user of account.users) {
+      lines.push(`      { user: ${quoteNatsString(user.user)}, password: ${quoteNatsString(user.password)} }`);
+    }
+    lines.push(`    ]`);
+    lines.push(`    exports: [`);
+    for (const ex of account.exports) {
+      const accounts = ex.accounts ? `, accounts: [${ex.accounts.map(quoteNatsString).join(", ")}]` : "";
+      lines.push(`      { service: ${quoteNatsString(ex.service)}${accounts} }`);
+    }
+    lines.push(`    ]`);
+    lines.push(`    imports: [`);
+    for (const im of account.imports) {
+      lines.push(
+        `      { service: { account: ${quoteNatsString(im.service.account)}, subject: ${quoteNatsString(im.service.subject)} } }`,
+      );
+    }
+    lines.push(`    ]`);
+    lines.push(`  }`);
+  }
+  lines.push("}");
+  return `${lines.join("\n")}\n`;
 };

--- a/packages/federation-nats/test/federation-nats.test.mjs
+++ b/packages/federation-nats/test/federation-nats.test.mjs
@@ -2,11 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildFederationAccountContract,
+  buildFederationNatsAccountConfig,
   decodeFederationToken,
   encodeFederationToken,
   federationAckSubject,
   federationMessageSubject,
   parseFederationSubject,
+  renderFederationNatsAccountsConfig,
   routeFederatedEnvelope,
 } from "../dist/src/index.js";
 
@@ -70,6 +72,49 @@ test("builds account export/import contract scoped to each org subject prefix", 
       },
     ],
   });
+});
+
+test("builds production-facing NATS account config with partner-scoped service exports", () => {
+  assert.deepEqual(buildFederationNatsAccountConfig({
+    localOrg: "aimindset",
+    partnerOrgs: ["partner.org"],
+    users: [{ user: "leaf-aimindset", password: "secret" }],
+  }), {
+    account: "ORG_AIMINDSET",
+    users: [{ user: "leaf-aimindset", password: "secret" }],
+    exports: [{
+      service: "fed.aimindset.>",
+      accounts: ["ORG__XCGFYDG5LCI5VCMC"],
+    }],
+    imports: [{
+      service: {
+        account: "ORG__XCGFYDG5LCI5VCMC",
+        subject: "fed._xcGFydG5lci5vcmc.>",
+      },
+    }],
+  });
+});
+
+test("renders static NATS accounts config from the federation contract", () => {
+  const conf = renderFederationNatsAccountsConfig({
+    orgs: ["aimindset", "partner.org"],
+    port: 4223,
+    usersByOrg: {
+      aimindset: [{ user: "aimindset-leaf", password: "pw-a" }],
+      "partner.org": [{ user: "partner-leaf", password: "pw-b" }],
+    },
+  });
+  assert.match(conf, /^port: 4223\naccounts \{/);
+  assert.match(conf, /ORG_AIMINDSET \{/);
+  assert.match(conf, /\{ user: "aimindset-leaf", password: "pw-a" \}/);
+  assert.match(conf, /\{ service: "fed\.aimindset\.>", accounts: \["ORG__XCGFYDG5LCI5VCMC"\] \}/);
+  assert.match(conf, /\{ service: \{ account: "ORG__XCGFYDG5LCI5VCMC", subject: "fed\._xcGFydG5lci5vcmc\.>" \} \}/);
+  assert.match(conf, /ORG__XCGFYDG5LCI5VCMC \{/);
+});
+
+test("keeps private exports non-public even when an org has no configured partners", () => {
+  const conf = renderFederationNatsAccountsConfig({ orgs: ["aimindset"] });
+  assert.match(conf, /\{ service: "fed\.aimindset\.>", accounts: \[\] \}/);
 });
 
 test("encoded federation tokens are reversible", () => {


### PR DESCRIPTION
## Summary
- add production-facing federation NATS account config builders/renderers derived from `buildFederationAccountContract`
- make service exports partner-scoped by default, including the zero-partner edge (`accounts: []`) so private exports do not become public
- switch the live integration config generator to the reusable renderer
- document real-mesh leaf-node/operator wiring, response-permission smoke boundary, and pinned org-key trust-store expectations for #14

## Verification
- `npm --workspace @murmurv2/federation-nats test`
- `FED_ORGS=aimindset FED_NATS_PORT=14334 ... gen-accounts-conf.mjs ... nats-server -c` => `solo-config-ok`
- `npm --workspace @murmurv2/federation-nats run test:fed-live`
- `NATS_BIN=/bin/false npm --workspace @murmurv2/federation-nats run test:fed-live` exits non-zero (`rc=1`)
- `npm test`

No boevoy writes; no shared broker restart.

Refs #14