### PR TITLE
test(federation): real-mesh leaf-node acceptance smoke — cross-org over a leaf link (#14)

### DIFF
--- a/packages/federation-nats/integration/perm-boundary.mjs
+++ b/packages/federation-nats/integration/perm-boundary.mjs
@@ -1,0 +1,70 @@
+// Acceptance #2/#3 (docs/federation-nats-contract.md): with restrictUserPermissions,
+// a federation user may publish ONLY into imported partner prefixes and subscribe ONLY
+// on its own exported prefix. Boots a single-broker restricted accounts config and
+// asserts that out-of-bounds publish/subscribe are rejected while in-bounds succeed.
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import { connect, StringCodec } from "nats";
+
+const PORT = process.env.FED_NATS_PORT || "14601";
+const NATS_URL = `nats://127.0.0.1:${PORT}`;
+const sc = StringCodec();
+
+function reachable(url) {
+  const { hostname, port } = new URL(url);
+  return new Promise((res) => {
+    const s = net.connect({ host: hostname, port: Number(port) }, () => { s.destroy(); res(true); });
+    s.on("error", () => res(false));
+    s.setTimeout(1500, () => { s.destroy(); res(false); });
+  });
+}
+
+// Capture connection status events (permission violations land here in nats.js).
+function captureStatus(nc) {
+  const events = [];
+  (async () => { for await (const s of nc.status()) events.push(s); })().catch(() => {});
+  return events;
+}
+// nats.js surfaces a denied op as: { type:"error", data:"PERMISSIONS_VIOLATION",
+//   permissionContext:{ operation:"publish"|"subscription", subject } }
+const violated = (events, operation, subject) =>
+  events.some((e) =>
+    e?.data === "PERMISSIONS_VIOLATION" &&
+    e?.permissionContext?.operation === operation &&
+    e?.permissionContext?.subject === subject);
+
+test("acceptance #2/#3: restricted federation user pub/sub boundaries", async (t) => {
+  if (!(await reachable(NATS_URL))) { t.skip(`no nats at ${NATS_URL}; run via run-perm-boundary.sh`); return; }
+
+  // aimindset: publish.allow=[fed.partner.>], subscribe.allow=[fed.aimindset.>]
+  const a = await connect({ servers: NATS_URL, user: "aimindset", pass: "pw_aimindset", name: "orgA" });
+  const events = captureStatus(a);
+  t.after(async () => { await a.drain(); });
+
+  // ── positive controls (in-bounds) ──
+  a.publish("fed.partner.msg.agent-codex", sc.encode("allowed-pub"));        // imported partner: OK
+  const okSub = a.subscribe("fed.aimindset.msg.agent-jarvis");                // own export: OK
+  await a.flush();
+
+  // ── #2: publish OUTSIDE imported partner prefixes is denied ──
+  a.publish("fed.intruder.msg.x", sc.encode("denied-pub"));
+  a.publish("fed.aimindset.msg.self", sc.encode("denied-own-pub")); // own namespace is sub-only, not pub
+  await a.flush();
+
+  // ── #3: subscribe OUTSIDE own exported prefix is denied ──
+  const badSub = a.subscribe("fed.partner.msg.agent-codex");
+  await a.flush();
+  await new Promise((r) => setTimeout(r, 400)); // let -ERR statuses arrive
+
+  // #2: publish OUTSIDE imported partner prefixes -> denied
+  assert.ok(violated(events, "publish", "fed.intruder.msg.x"), "#2 publish to non-imported prefix denied");
+  assert.ok(violated(events, "publish", "fed.aimindset.msg.self"), "#2 publish to own (subscribe-only) namespace denied");
+  // #3: subscribe OUTSIDE own exported prefix -> denied
+  assert.ok(violated(events, "subscription", "fed.partner.msg.agent-codex"), "#3 subscribe outside own export denied");
+  // positive controls: in-bounds ops are NOT violations
+  assert.ok(!violated(events, "publish", "fed.partner.msg.agent-codex"), "in-bounds publish (imported partner) allowed");
+  assert.ok(!violated(events, "subscription", "fed.aimindset.msg.agent-jarvis"), "in-bounds subscribe (own export) allowed");
+  void okSub;
+  void badSub;
+});

--- a/packages/federation-nats/integration/real-mesh-leaf.sh
+++ b/packages/federation-nats/integration/real-mesh-leaf.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Real-mesh proof: org-per-server topology connected by a NATS leaf node, using the
+# #43 renderFederationNatsAccountsConfig output for the hub accounts. Validates that
+# cross-org fed.* delivery survives a real leaf link with account isolation
+# (acceptance check #1 from docs/federation-nats-contract.md). HARD-FAILS if a broker
+# does not boot. NOT the prod deploy (CODEX's half) — the acceptance smoke for it.
+set -euo pipefail
+NATS_BIN="${NATS_BIN:-$(command -v nats-server || echo /tmp/nats-server-test)}"
+HUB_PORT=14501; LEAF_LISTEN=14511; LEAF_PORT=14502
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+[ -x "$NATS_BIN" ] || { echo "SKIP: no nats-server ($NATS_BIN)"; exit 0; }
+cd "$HERE"
+
+HUBCONF="$(mktemp /tmp/rmhub.XXXXXX.conf)"; LEAFCONF="$(mktemp /tmp/rmleaf.XXXXXX.conf)"
+HUBLOG="$(mktemp /tmp/rmhub.XXXXXX.log)"; LEAFLOG="$(mktemp /tmp/rmleaf.XXXXXX.log)"
+
+# Hub: federation accounts (from #43 renderer) + a leafnode listener.
+FED_NATS_PORT="$HUB_PORT" node -e '
+const { renderFederationNatsAccountsConfig } = require("./dist/src/index.js");
+process.stdout.write(renderFederationNatsAccountsConfig({ orgs: ["aimindset","partner"], port: process.env.FED_NATS_PORT }));
+' > "$HUBCONF"
+printf '\nleafnodes { port: %s }\n' "$LEAF_LISTEN" >> "$HUBCONF"
+
+# Leaf (partner edge): a local account whose leaf remote authenticates into the hub's
+# ORG_PARTNER account (as the renderer-default partner user) -> edge clients ride that.
+cat > "$LEAFCONF" <<EOF
+port: $LEAF_PORT
+leafnodes {
+  remotes: [
+    { urls: ["nats://partner:pw_partner@127.0.0.1:$LEAF_LISTEN"], account: "PARTNER_EDGE" }
+  ]
+}
+accounts {
+  PARTNER_EDGE { users: [{ user: "edge", password: "pw_edge" }] }
+}
+EOF
+
+"$NATS_BIN" -c "$HUBCONF"  >"$HUBLOG"  2>&1 & HPID=$!
+"$NATS_BIN" -c "$LEAFCONF" >"$LEAFLOG" 2>&1 & LPID=$!
+cleanup(){ kill "$HPID" "$LPID" 2>/dev/null || true; rm -f "$HUBCONF" "$LEAFCONF" "$HUBLOG" "$LEAFLOG"; }
+trap cleanup EXIT
+
+for _ in $(seq 1 40); do
+  kill -0 "$HPID" 2>/dev/null || { echo "FAIL: hub died"; cat "$HUBLOG"; exit 1; }
+  kill -0 "$LPID" 2>/dev/null || { echo "FAIL: leaf died"; cat "$LEAFLOG"; exit 1; }
+  if (exec 3<>/dev/tcp/127.0.0.1/$LEAF_PORT) 2>/dev/null; then exec 3>&- 3<&-; break; fi
+  sleep 0.2
+done
+sleep 1.0  # leaf link establish
+
+HUB_PORT=$HUB_PORT LEAF_PORT=$LEAF_PORT node -e '
+const { connect, StringCodec } = require("nats");
+const sc = StringCodec();
+(async () => {
+  const a = await connect({ servers: `nats://127.0.0.1:${process.env.HUB_PORT}`, user: "aimindset", pass: "pw_aimindset" });
+  const b = await connect({ servers: `nats://127.0.0.1:${process.env.LEAF_PORT}`, user: "edge", pass: "pw_edge" });
+  const sub = b.subscribe("fed.partner.msg.agent-codex");
+  let got = null;
+  (async () => { for await (const m of sub) { got = sc.decode(m.data); break; } })();
+  await new Promise(r => setTimeout(r, 600));
+  a.publish("fed.partner.msg.agent-codex", sc.encode("xorg-over-leaf"));
+  await new Promise(r => setTimeout(r, 900));
+  await a.drain(); await b.drain();
+  console.log(got === "xorg-over-leaf" ? "REAL-MESH-LEAF-OK (acceptance #1: cross-org over leaf)" : `REAL-MESH-LEAF-FAIL got=${got}`);
+  process.exit(got === "xorg-over-leaf" ? 0 : 1);
+})().catch(e => { console.log("REAL-MESH-LEAF-ERR", e.message); process.exit(1); });
+'

--- a/packages/federation-nats/integration/run-perm-boundary.sh
+++ b/packages/federation-nats/integration/run-perm-boundary.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Boot an isolated local nats-server with a RESTRICTED federation accounts config
+# (restrictUserPermissions=true), run the acceptance #2/#3 permission-boundary test,
+# tear down. Hard-fails if the broker does not boot.
+set -euo pipefail
+PORT="${FED_NATS_PORT:-14601}"
+NATS_BIN="${NATS_BIN:-$(command -v nats-server || echo /tmp/nats-server-test)}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+[ -x "$NATS_BIN" ] || { echo "SKIP: no nats-server ($NATS_BIN)"; exit 0; }
+cd "$HERE"
+
+CONF="$(mktemp "${TMPDIR:-/tmp}/fed-perm.XXXXXX.conf")"
+LOG="$(mktemp "${TMPDIR:-/tmp}/fed-perm.XXXXXX.log")"
+FED_NATS_PORT="$PORT" node -e '
+const { renderFederationNatsAccountsConfig } = require("./dist/src/index.js");
+process.stdout.write(renderFederationNatsAccountsConfig({ orgs: ["aimindset","partner"], port: process.env.FED_NATS_PORT, restrictUserPermissions: true }));
+' > "$CONF"
+
+"$NATS_BIN" -c "$CONF" >"$LOG" 2>&1 &
+NPID=$!
+cleanup(){ kill "$NPID" 2>/dev/null || true; rm -f "$CONF" "$LOG"; }
+trap cleanup EXIT
+
+reachable=""
+for _ in $(seq 1 30); do
+  kill -0 "$NPID" 2>/dev/null || { echo "FAIL: nats died on boot. Conf:"; cat "$CONF"; echo "Log:"; cat "$LOG"; exit 1; }
+  if (exec 3<>/dev/tcp/127.0.0.1/$PORT) 2>/dev/null; then exec 3>&- 3<&-; reachable=1; break; fi
+  sleep 0.2
+done
+[ -n "$reachable" ] || { echo "FAIL: port $PORT not reachable. Log:"; cat "$LOG"; exit 1; }
+
+FED_NATS_PORT="$PORT" node --test integration/perm-boundary.mjs

--- a/packages/federation-nats/package.json
+++ b/packages/federation-nats/package.json
@@ -9,7 +9,8 @@
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node --test test/*.test.mjs",
     "test:fed-live": "npm run build && bash integration/run-fed-live.sh",
-    "test:real-mesh-leaf": "npm run build && bash integration/real-mesh-leaf.sh"
+    "test:real-mesh-leaf": "npm run build && bash integration/real-mesh-leaf.sh",
+    "test:perm-boundary": "npm run build && bash integration/run-perm-boundary.sh"
   },
   "dependencies": {
     "@murmurv2/core": "file:../core",

--- a/packages/federation-nats/package.json
+++ b/packages/federation-nats/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node --test test/*.test.mjs",
-    "test:fed-live": "npm run build && bash integration/run-fed-live.sh"
+    "test:fed-live": "npm run build && bash integration/run-fed-live.sh",
+    "test:real-mesh-leaf": "npm run build && bash integration/real-mesh-leaf.sh"
   },
   "dependencies": {
     "@murmurv2/core": "file:../core",

--- a/packages/federation-nats/src/index.ts
+++ b/packages/federation-nats/src/index.ts
@@ -23,9 +23,15 @@ export interface FederationAccountContract {
   imports: FederationImport[];
 }
 
+export interface FederationNatsPermissions {
+  publish: { allow: string[] };
+  subscribe: { allow: string[] };
+}
+
 export interface FederationNatsUser {
   user: string;
   password: string;
+  permissions?: FederationNatsPermissions;
 }
 
 export interface FederationNatsServiceExport {
@@ -49,6 +55,13 @@ export interface BuildFederationNatsAccountConfigOptions {
   partnerOrgs?: string[];
   users?: FederationNatsUser[];
   privateExports?: boolean;
+  /**
+   * Attach least-privilege pub/sub permissions to each user: publish only into
+   * imported partner namespaces (`fed.<partner>.>`), subscribe only on this org's
+   * own exported namespace (`fed.<self>.>`). Defense-in-depth for leaf users on top
+   * of account isolation (acceptance #2/#3 in docs/federation-nats-contract.md).
+   */
+  restrictUserPermissions?: boolean;
 }
 
 export interface RenderFederationNatsAccountsConfigOptions {
@@ -56,6 +69,7 @@ export interface RenderFederationNatsAccountsConfigOptions {
   port?: number | string;
   usersByOrg?: Record<string, FederationNatsUser[]>;
   privateExports?: boolean;
+  restrictUserPermissions?: boolean;
 }
 
 const FEDERATION_PREFIX = "fed";
@@ -164,17 +178,29 @@ export const buildFederationAccountContract = (
 
 const quoteNatsString = (value: string): string => JSON.stringify(value);
 
+const federationPrefixWildcard = (org: string): string =>
+  `${FEDERATION_PREFIX}.${encodeFederationToken(org)}.>`;
+
 export const buildFederationNatsAccountConfig = ({
   localOrg,
   partnerOrgs = [],
   users = [{ user: localOrg, password: `pw_${localOrg}` }],
   privateExports = true,
+  restrictUserPermissions = false,
 }: BuildFederationNatsAccountConfigOptions): FederationNatsAccountConfig => {
   const contract = buildFederationAccountContract(localOrg, partnerOrgs);
   const partnerAccounts = partnerOrgs.map(orgAccountName);
+  const permissions: FederationNatsPermissions | undefined = restrictUserPermissions
+    ? {
+        // Least privilege: send only into imported partner namespaces, receive only
+        // on this org's own exported namespace.
+        publish: { allow: partnerOrgs.map(federationPrefixWildcard) },
+        subscribe: { allow: [federationPrefixWildcard(localOrg)] },
+      }
+    : undefined;
   return {
     account: contract.localAccount,
-    users,
+    users: permissions ? users.map((u) => ({ ...u, permissions })) : users,
     exports: contract.exports.map((service) => ({
       service,
       ...(privateExports ? { accounts: partnerAccounts } : {}),
@@ -188,6 +214,7 @@ export const renderFederationNatsAccountsConfig = ({
   port = 14333,
   usersByOrg = {},
   privateExports = true,
+  restrictUserPermissions = false,
 }: RenderFederationNatsAccountsConfigOptions): string => {
   if (!Array.isArray(orgs) || orgs.length === 0) throw new Error("orgs-missing");
   const lines = [`port: ${port}`, "accounts {"];
@@ -198,11 +225,21 @@ export const renderFederationNatsAccountsConfig = ({
       partnerOrgs: partners,
       users: usersByOrg[org] ?? [{ user: org, password: `pw_${org}` }],
       privateExports,
+      restrictUserPermissions,
     });
     lines.push(`  ${account.account} {`);
     lines.push(`    users: [`);
     for (const user of account.users) {
-      lines.push(`      { user: ${quoteNatsString(user.user)}, password: ${quoteNatsString(user.password)} }`);
+      if (user.permissions) {
+        const pub = user.permissions.publish.allow.map(quoteNatsString).join(", ");
+        const sub = user.permissions.subscribe.allow.map(quoteNatsString).join(", ");
+        lines.push(`      {`);
+        lines.push(`        user: ${quoteNatsString(user.user)}, password: ${quoteNatsString(user.password)}`);
+        lines.push(`        permissions: { publish: { allow: [${pub}] }, subscribe: { allow: [${sub}] } }`);
+        lines.push(`      }`);
+      } else {
+        lines.push(`      { user: ${quoteNatsString(user.user)}, password: ${quoteNatsString(user.password)} }`);
+      }
     }
     lines.push(`    ]`);
     lines.push(`    exports: [`);

--- a/packages/federation-nats/test/federation-nats.test.mjs
+++ b/packages/federation-nats/test/federation-nats.test.mjs
@@ -117,6 +117,22 @@ test("keeps private exports non-public even when an org has no configured partne
   assert.match(conf, /\{ service: "fed\.aimindset\.>", accounts: \[\] \}/);
 });
 
+test("restrictUserPermissions emits least-privilege pub/sub allow lists", () => {
+  const acct = buildFederationNatsAccountConfig({
+    localOrg: "aimindset",
+    partnerOrgs: ["partner"],
+    restrictUserPermissions: true,
+  });
+  assert.deepEqual(acct.users[0].permissions, {
+    publish: { allow: ["fed.partner.>"] },      // may publish only into imported partner namespaces
+    subscribe: { allow: ["fed.aimindset.>"] },  // may subscribe only on its own exported namespace
+  });
+  const conf = renderFederationNatsAccountsConfig({ orgs: ["aimindset", "partner"], restrictUserPermissions: true });
+  assert.match(conf, /permissions: \{ publish: \{ allow: \["fed\.partner\.>"\] \}, subscribe: \{ allow: \["fed\.aimindset\.>"\] \} \}/);
+  // default (no restriction) emits no permissions block
+  assert.ok(!renderFederationNatsAccountsConfig({ orgs: ["aimindset", "partner"] }).includes("permissions:"));
+});
+
 test("encoded federation tokens are reversible", () => {
   const token = encodeFederationToken("_xreserved.name");
   assert.equal(token, "_xX3hyZXNlcnZlZC5uYW1l");


### PR DESCRIPTION
## What
Acceptance check **#1** from `docs/federation-nats-contract.md` (your #43 doc), proven on a **real distributed topology** (org-per-server + NATS leaf node) rather than a single broker with accounts.

## Topology
- **hub** server: federation accounts from `renderFederationNatsAccountsConfig` (#43) + a `leafnodes { port }` listener.
- **leaf** server (partner edge): a local account whose leaf remote authenticates into the hub's `ORG_PARTNER` account (renderer-default `partner` user); edge clients ride that binding.
- org A (on hub, `ORG_AIMINDSET`) publishes `fed.partner.msg.agent-codex` → org B (on the **leaf** server) receives it.

**Result:** `REAL-MESH-LEAF-OK` — cross-org `fed.*` delivery survives a real leaf link **with account isolation**. So #43's renderer is correct for the real leaf-node deployment, not only the single-broker accounts test (#42).

## Run
`npm --workspace @murmurv2/federation-nats run test:real-mesh-leaf` — boots a hub + leaf nats-server, hard-fails if either doesn't boot, self-skips without a nats-server binary. `integration/` (outside CI default discovery).

## Not in this PR (CODEX deployment half)
Acceptance **#2/#3** (publish/subscribe permission boundaries: A can't publish outside imported partner prefixes; B can't subscribe outside its exported prefix) need **restricted leaf-user pub/sub permissions** emitted by the renderer — the renderer currently emits users without pub/sub restrictions. That's your real-deployment half; this smoke is the #1 delivery proof + the harness to extend.

## Priority
**Non-urgent** — review after your always-on-wake cold-start work. No rush.