### PR TITLE
feat(federation): RosterStore — pinned-key trust + monotonic-version replay guard (#14)

### DIFF
--- a/packages/federation/src/index.ts
+++ b/packages/federation/src/index.ts
@@ -157,7 +157,11 @@ export function lookupAgentKeys(roster: SignedRoster, agentId: string): AgentKey
 
 // ──────────────────── Roster store (runtime trust + replay guard) ────────────────────
 
-export type RosterRejectReason = "org-not-pinned" | "signature-invalid" | "stale-or-replay";
+export type RosterRejectReason =
+  | "org-not-pinned"
+  | "signature-invalid"
+  | "invalid-version"
+  | "stale-or-replay";
 
 export interface RosterOfferResult {
   accepted: boolean;
@@ -182,19 +186,34 @@ export class RosterStore {
       pinnedOrgKeys instanceof Map ? new Map(pinnedOrgKeys) : new Map(Object.entries(pinnedOrgKeys));
   }
 
-  /** Pin (or re-pin) an org's directory-signing public key (out-of-band trust input). */
+  /**
+   * Pin (or re-pin) an org's directory-signing public key (out-of-band trust input).
+   * Rotating to a DIFFERENT key starts a fresh trust epoch: the org's previously
+   * accepted roster (signed under the old key) is dropped, so a new roster under the
+   * new key is accepted from any version rather than being blocked as stale-or-replay.
+   * Re-pinning the same key is a no-op.
+   */
   pin(org: string, signingPublicKey: string): void {
+    const previous = this.pinned.get(org);
     this.pinned.set(org, signingPublicKey);
+    if (previous !== undefined && previous !== signingPublicKey) {
+      this.latest.delete(org);
+    }
   }
 
   /**
-   * Offer a signed roster. Accepted only when it verifies against the pinned org key
-   * and is strictly newer than the last accepted version (monotonic ⇒ no replay).
+   * Offer a signed roster. Accepted only when it (1) verifies against the pinned org
+   * key, (2) carries a structurally valid version (positive integer — enforced here,
+   * not trusted from the signer, since the store is the wire/runtime boundary), and
+   * (3) is strictly newer than the last accepted version (monotonic ⇒ no replay).
    */
   async offer(roster: SignedRoster): Promise<RosterOfferResult> {
     const pin = this.pinned.get(roster.org);
     if (!pin) return { accepted: false, reason: "org-not-pinned" };
     if (!(await verifyRoster(roster, pin))) return { accepted: false, reason: "signature-invalid" };
+    if (!Number.isInteger(roster.version) || roster.version < 1) {
+      return { accepted: false, reason: "invalid-version" };
+    }
     const current = this.latest.get(roster.org);
     if (current && roster.version <= current.version) {
       return { accepted: false, reason: "stale-or-replay" };

--- a/packages/federation/src/index.ts
+++ b/packages/federation/src/index.ts
@@ -154,3 +154,64 @@ export function lookupAgentKeys(roster: SignedRoster, agentId: string): AgentKey
   if (!keys) throw new Error(`federation: agent not in roster ${roster.org}: ${agentId}`);
   return keys;
 }
+
+// ──────────────────── Roster store (runtime trust + replay guard) ────────────────────
+
+export type RosterRejectReason = "org-not-pinned" | "signature-invalid" | "stale-or-replay";
+
+export interface RosterOfferResult {
+  accepted: boolean;
+  reason?: RosterRejectReason;
+}
+
+/**
+ * Holds the latest verified roster per org and enforces the production trust model
+ * (the runtime/bridge-layer concern, deliberately NOT in the NATS subject contract):
+ *   - org directory-signing keys are PINNED out-of-band; an embedded
+ *     `signingPublicKey` is never the trust root.
+ *   - a roster is accepted only if it verifies against the pinned key AND its version
+ *     strictly exceeds the last accepted version for that org — so a replayed or
+ *     downgraded roster (lower/equal version) is rejected.
+ */
+export class RosterStore {
+  private readonly pinned: Map<string, string>;
+  private readonly latest = new Map<string, SignedRoster>();
+
+  constructor(pinnedOrgKeys: Record<string, string> | Map<string, string> = {}) {
+    this.pinned =
+      pinnedOrgKeys instanceof Map ? new Map(pinnedOrgKeys) : new Map(Object.entries(pinnedOrgKeys));
+  }
+
+  /** Pin (or re-pin) an org's directory-signing public key (out-of-band trust input). */
+  pin(org: string, signingPublicKey: string): void {
+    this.pinned.set(org, signingPublicKey);
+  }
+
+  /**
+   * Offer a signed roster. Accepted only when it verifies against the pinned org key
+   * and is strictly newer than the last accepted version (monotonic ⇒ no replay).
+   */
+  async offer(roster: SignedRoster): Promise<RosterOfferResult> {
+    const pin = this.pinned.get(roster.org);
+    if (!pin) return { accepted: false, reason: "org-not-pinned" };
+    if (!(await verifyRoster(roster, pin))) return { accepted: false, reason: "signature-invalid" };
+    const current = this.latest.get(roster.org);
+    if (current && roster.version <= current.version) {
+      return { accepted: false, reason: "stale-or-replay" };
+    }
+    this.latest.set(roster.org, roster);
+    return { accepted: true };
+  }
+
+  /** The latest accepted roster for an org, if any. */
+  current(org: string): SignedRoster | undefined {
+    return this.latest.get(org);
+  }
+
+  /** Look up an agent's keys from the latest accepted roster. Throws if none accepted. */
+  agentKeys(org: string, agentId: string): AgentKeys {
+    const roster = this.latest.get(org);
+    if (!roster) throw new Error(`federation: no accepted roster for org ${org}`);
+    return lookupAgentKeys(roster, agentId);
+  }
+}

--- a/packages/federation/test/federation.test.mjs
+++ b/packages/federation/test/federation.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createKeyPair, createSigningKeyPair } from "../../security/dist/src/index.js";
+import { createKeyPair, createSigningKeyPair, signEnvelope } from "../../security/dist/src/index.js";
 import {
   canonicalRoster,
   formatAddress,
@@ -194,4 +194,47 @@ test("RosterStore: pin() can add trust after construction", async () => {
   assert.equal((await store.offer(await makeRoster("partner", 1, sign, ak))).reason, "org-not-pinned");
   store.pin("partner", sign.publicKey);
   assert.deepEqual(await store.offer(await makeRoster("partner", 1, sign, ak)), { accepted: true });
+});
+
+// Forge a correctly-signed SignedRoster directly (bypassing signRoster's validation),
+// to prove offer() enforces version validity itself at the wire/runtime boundary.
+async function forgeSignedRoster(org, version, sign, agentKeys) {
+  const body = { org, version, issuedAt: "2026-06-21T00:00:00Z", agents: { "agent-1": agentKeys } };
+  const signature = await signEnvelope(canonicalRoster(body), sign.privateKey);
+  return { ...body, signature, signingPublicKey: sign.publicKey };
+}
+
+test("RosterStore: rejects an authentic roster with an invalid version", async () => {
+  const sign = await createSigningKeyPair();
+  const ak = await agentKeyPair();
+  const store = new RosterStore({ partner: sign.publicKey });
+  for (const v of [0, -1, 1.5]) {
+    const forged = await forgeSignedRoster("partner", v, sign, ak);
+    assert.deepEqual(await store.offer(forged), { accepted: false, reason: "invalid-version" }, `version ${v}`);
+  }
+  assert.deepEqual(await store.offer(await forgeSignedRoster("partner", 1, sign, ak)), { accepted: true });
+});
+
+test("RosterStore: re-pinning a new key rotates the trust epoch", async () => {
+  const keyA = await createSigningKeyPair();
+  const keyB = await createSigningKeyPair();
+  const akA = await agentKeyPair();
+  const akB = await agentKeyPair();
+  const store = new RosterStore({ partner: keyA.publicKey });
+  assert.deepEqual(await store.offer(await makeRoster("partner", 10, keyA, akA)), { accepted: true });
+  store.pin("partner", keyB.publicKey); // rotate trust root
+  assert.throws(() => store.agentKeys("partner", "agent-1"), /no accepted roster/); // old roster dropped
+  // fresh key-B roster at a low version is accepted (new epoch), not blocked as stale
+  assert.deepEqual(await store.offer(await makeRoster("partner", 1, keyB, akB)), { accepted: true });
+  assert.deepEqual(store.agentKeys("partner", "agent-1"), akB);
+});
+
+test("RosterStore: re-pinning the same key preserves accepted state", async () => {
+  const sign = await createSigningKeyPair();
+  const ak = await agentKeyPair();
+  const store = new RosterStore({ partner: sign.publicKey });
+  await store.offer(await makeRoster("partner", 5, sign, ak));
+  store.pin("partner", sign.publicKey); // same key -> no epoch reset
+  assert.equal(store.current("partner").version, 5);
+  assert.deepEqual(await store.offer(await makeRoster("partner", 5, sign, ak)), { accepted: false, reason: "stale-or-replay" });
 });

--- a/packages/federation/test/federation.test.mjs
+++ b/packages/federation/test/federation.test.mjs
@@ -7,6 +7,7 @@ import {
   isLocal,
   lookupAgentKeys,
   parseAddress,
+  RosterStore,
   signRoster,
   verifyRoster,
 } from "../dist/src/index.js";
@@ -127,4 +128,70 @@ test("signRoster rejects non-positive version", async () => {
     () => signRoster({ org: "o", version: 0, issuedAt: "t", agents: {} }, sign.privateKey, sign.publicKey),
     /version must be a positive integer/,
   );
+});
+
+// ─── RosterStore (runtime trust + replay guard) ───
+
+async function agentKeyPair() {
+  return {
+    encryptPublicKey: (await createKeyPair()).publicKey,
+    verifyPublicKey: (await createSigningKeyPair()).publicKey,
+  };
+}
+async function makeRoster(org, version, sign, agentKeys) {
+  return signRoster(
+    { org, version, issuedAt: "2026-06-21T00:00:00Z", agents: { "agent-1": agentKeys } },
+    sign.privateKey,
+    sign.publicKey,
+  );
+}
+
+test("RosterStore: rejects an unpinned org", async () => {
+  const sign = await createSigningKeyPair();
+  const store = new RosterStore();
+  const r = await makeRoster("partner", 1, sign, await agentKeyPair());
+  assert.deepEqual(await store.offer(r), { accepted: false, reason: "org-not-pinned" });
+});
+
+test("RosterStore: accepts pinned+valid, rejects a different signing key", async () => {
+  const sign = await createSigningKeyPair();
+  const other = await createSigningKeyPair();
+  const ak = await agentKeyPair();
+  const store = new RosterStore({ partner: sign.publicKey });
+  assert.deepEqual(await store.offer(await makeRoster("partner", 1, sign, ak)), { accepted: true });
+  // signed by a different key but claims org=partner -> pinned mismatch
+  assert.deepEqual(await store.offer(await makeRoster("partner", 2, other, ak)), {
+    accepted: false,
+    reason: "signature-invalid",
+  });
+});
+
+test("RosterStore: enforces monotonic version (replay + downgrade rejected)", async () => {
+  const sign = await createSigningKeyPair();
+  const ak = await agentKeyPair();
+  const store = new RosterStore({ partner: sign.publicKey });
+  assert.deepEqual(await store.offer(await makeRoster("partner", 2, sign, ak)), { accepted: true });
+  assert.deepEqual(await store.offer(await makeRoster("partner", 2, sign, ak)), { accepted: false, reason: "stale-or-replay" });
+  assert.deepEqual(await store.offer(await makeRoster("partner", 1, sign, ak)), { accepted: false, reason: "stale-or-replay" });
+  assert.deepEqual(await store.offer(await makeRoster("partner", 3, sign, ak)), { accepted: true });
+  assert.equal(store.current("partner").version, 3);
+});
+
+test("RosterStore: agentKeys reads the latest accepted roster; throws if none", async () => {
+  const sign = await createSigningKeyPair();
+  const ak = await agentKeyPair();
+  const store = new RosterStore({ partner: sign.publicKey });
+  assert.throws(() => store.agentKeys("partner", "agent-1"), /no accepted roster/);
+  await store.offer(await makeRoster("partner", 1, sign, ak));
+  assert.deepEqual(store.agentKeys("partner", "agent-1"), ak);
+  assert.throws(() => store.agentKeys("partner", "ghost"), /agent not in roster/);
+});
+
+test("RosterStore: pin() can add trust after construction", async () => {
+  const sign = await createSigningKeyPair();
+  const ak = await agentKeyPair();
+  const store = new RosterStore();
+  assert.equal((await store.offer(await makeRoster("partner", 1, sign, ak))).reason, "org-not-pinned");
+  store.pin("partner", sign.publicKey);
+  assert.deepEqual(await store.offer(await makeRoster("partner", 1, sign, ak)), { accepted: true });
 });


### PR DESCRIPTION
## What
The runtime/bridge-layer trust model your #42/#43 reviews called out: *roster version/replay enforcement belongs in the bridge runtime, not the NATS subject contract.* Adds `RosterStore` to `@murmurv2/federation`.

## Behavior
- **Pinned-key trust:** org directory-signing keys are pinned out-of-band; an embedded `signingPublicKey` is never the trust root (re-uses `verifyRoster`'s pinned-key check).
- **`offer(roster)`** accepts only if it (a) verifies against the pinned key and (b) version **strictly exceeds** the last accepted version for that org → replayed/downgraded rosters (lower-or-equal version) are rejected with `stale-or-replay`.
- **`pin(org,key)`**, **`current(org)`**, **`agentKeys(org,agentId)`** (reads latest accepted; throws if none / agent absent).

## Tests (federation 16/16)
unpinned org → `org-not-pinned`; different signing key → `signature-invalid`; replay (equal) + downgrade (lower) rejected, higher accepted; `agentKeys` from latest; late `pin()` enables acceptance.

## Priority
Non-urgent — pure addition to the federation package (no contract change). Review whenever; pairs with #44 (renderer/accounts) + your real-mesh deployment.