### PR TITLE
feat(federation): add roster-backed auth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ This enables **fully autonomous overnight work** — launch 2-3 agents, they col
 
 ### Security
 - **Security Policies** — sender→recipient allow-lists, max payload size
+- **Roster-backed Auth Tokens** — signed audience/scope tokens verified against the latest accepted federation roster (model/helper layer; transport/bridge enforcement pending)
 - **MLS Scaffold** — group encryption interface ready (RFC 9420)
 - **No Plaintext** — messages are always encrypted on the wire
 
@@ -433,6 +434,7 @@ See [protocol-v1.md](docs/protocol-v1.md) for the full specification.
 - [ ] **Federation (v2.1)** — addressing + Ed25519 signed key directory + `fed.*` contract + account-config renderer + `RosterStore` (pinned-key trust + monotonic-version replay guard) are **live-proven against a real local NATS mesh**: cross-org sealed+signed delivery on isolated accounts, the same over a **leaf-node topology** (org-per-server), and least-privilege pub/sub permission boundaries (`integration/` smokes, cross-verified). Remaining gate: **not yet wired to a second real partner org**
 - [ ] **A2A interop bridge (v2.1)** — a **real `@a2a-js/sdk` client → bridge → NATS → reply round-trip is proven** over HTTP (against a mock internal agent), and Agent-Card transport discovery is fixed. Remaining gate: **not yet connected to a real remote A2A agent**
 - [ ] **Always-on wake (dead session) (v2.1)** — a cold-start spawn-on-inbound sidecar (fresh `codex exec` per batch, exactly-once, linger-enabled systemd user service) exists in the **reference Codex deployment, outside this repo**; a repo-shipped version and the strict no-live-session proof remain pending
+- [ ] **Auth/authz token model** — roster-backed signed tokens with audience/scope/time verification are coded and unit-tested; remaining gate: wire token enforcement into live transports/bridges
 - [x] Prometheus metrics exporter — outbox depth, delivery latency, error rates
 - [ ] npm package publishing — `@murmurv2/*` on npm registry
 - [ ] NATS native request-reply — replace polling with ephemeral inbox subjects
@@ -442,7 +444,6 @@ See [protocol-v1.md](docs/protocol-v1.md) for the full specification.
 - [ ] Message streaming — large payload chunking with backpressure
 - [ ] Agent discovery protocol — find peers without manual invite exchange
 - [ ] Reference deployment examples — docker-compose, Kubernetes manifests
-- [ ] Auth/authz model — token-based peer authentication (federation roster is the identity layer)
 - [ ] Conformance test suite — integration tests for third-party implementations
 - [ ] Versioned protocol spec — machine-readable schema + compatibility matrix
 

--- a/packages/federation/src/index.ts
+++ b/packages/federation/src/index.ts
@@ -234,3 +234,210 @@ export class RosterStore {
     return lookupAgentKeys(roster, agentId);
   }
 }
+
+// ──────────────────── Auth token (roster-backed authn/authz) ────────────────────
+
+export interface AuthTokenClaims {
+  /** Agent that signs the token; its Ed25519 verify key MUST come from RosterStore. */
+  issuer: AgentAddress;
+  /** Intended recipient/service of the token. */
+  audience: AgentAddress;
+  /** Permission strings such as `murmur:send` or `murmur:reply`. */
+  scopes: string[];
+  /** ISO timestamp. Tokens are not accepted before this time. */
+  issuedAt: string;
+  /** ISO timestamp. Tokens expire at or after this time. */
+  expiresAt: string;
+  /** Optional caller-provided nonce/jti for replay caches outside this pure helper. */
+  nonce?: string;
+}
+
+export interface SignedAuthToken extends AuthTokenClaims {
+  /** Ed25519 signature over canonicalAuthTokenClaims(claims). */
+  signature: string;
+}
+
+export type AuthTokenRejectReason =
+  | "malformed"
+  | "issuer-not-found"
+  | "signature-invalid"
+  | "not-yet-valid"
+  | "expired"
+  | "audience-mismatch"
+  | "scope-missing";
+
+export interface AuthTokenVerifyOptions {
+  now?: Date | string | number;
+  audience?: AgentAddress;
+  requiredScopes?: string[];
+}
+
+export interface AuthTokenVerifyResult {
+  accepted: boolean;
+  reason?: AuthTokenRejectReason;
+}
+
+export const AUTH_TOKEN_PREFIX = "MURMUR-AUTH:";
+
+const SCOPE_RE = /^[A-Za-z0-9:._/-]+$/;
+
+function validDateMs(value: string, label: string): number {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`federation: invalid ${label}`);
+  }
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) throw new Error(`federation: invalid ${label}`);
+  return ms;
+}
+
+function normalizeScopes(scopes: string[]): string[] {
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    throw new Error("federation: auth token must carry at least one scope");
+  }
+  const uniq = new Set<string>();
+  for (const scope of scopes) {
+    if (typeof scope !== "string" || !SCOPE_RE.test(scope)) {
+      throw new Error(`federation: invalid auth scope: ${JSON.stringify(scope)}`);
+    }
+    uniq.add(scope);
+  }
+  return [...uniq].sort();
+}
+
+function normalizeAuthClaims(claims: AuthTokenClaims): AuthTokenClaims {
+  if (!claims || typeof claims !== "object") throw new Error("federation: invalid auth token claims");
+  const issuedAtMs = validDateMs(claims.issuedAt, "issuedAt");
+  const expiresAtMs = validDateMs(claims.expiresAt, "expiresAt");
+  if (expiresAtMs <= issuedAtMs) throw new Error("federation: expiresAt must be after issuedAt");
+  const nonce = claims.nonce;
+  if (nonce !== undefined && (typeof nonce !== "string" || nonce.length === 0)) {
+    throw new Error("federation: invalid nonce");
+  }
+  return {
+    issuer: parseAddress(formatAddress(claims.issuer), claims.issuer.org),
+    audience: parseAddress(formatAddress(claims.audience), claims.audience.org),
+    scopes: normalizeScopes(claims.scopes),
+    issuedAt: claims.issuedAt,
+    expiresAt: claims.expiresAt,
+    ...(nonce !== undefined ? { nonce } : {}),
+  };
+}
+
+/**
+ * Canonical auth-token signing input. Scopes are sorted/deduped so permission order
+ * does not affect signatures; issuer/audience are canonical `org/agentId` strings.
+ */
+export function canonicalAuthTokenClaims(claims: AuthTokenClaims): string {
+  const normalized = normalizeAuthClaims(claims);
+  return JSON.stringify({
+    issuer: formatAddress(normalized.issuer),
+    audience: formatAddress(normalized.audience),
+    scopes: normalized.scopes,
+    issuedAt: normalized.issuedAt,
+    expiresAt: normalized.expiresAt,
+    ...(normalized.nonce !== undefined ? { nonce: normalized.nonce } : {}),
+  });
+}
+
+/** Sign an auth token with the issuer agent's Ed25519 private key. */
+export async function signAuthToken(
+  claims: AuthTokenClaims,
+  issuerSigningPrivateKey: string,
+): Promise<SignedAuthToken> {
+  const normalized = normalizeAuthClaims(claims);
+  const signature = await signEnvelope(canonicalAuthTokenClaims(normalized), issuerSigningPrivateKey);
+  return { ...normalized, signature };
+}
+
+function normalizeSignedAuthToken(token: SignedAuthToken): SignedAuthToken {
+  const normalized = normalizeAuthClaims(token);
+  if (typeof token.signature !== "string" || token.signature.length === 0) {
+    throw new Error("federation: invalid auth token signature");
+  }
+  return { ...normalized, signature: token.signature };
+}
+
+/** Encode a signed auth token as a bearer-safe string. */
+export function encodeAuthToken(token: SignedAuthToken): string {
+  const normalized = normalizeSignedAuthToken(token);
+  return `${AUTH_TOKEN_PREFIX}${Buffer.from(JSON.stringify(normalized), "utf8").toString("base64url")}`;
+}
+
+/** Decode a bearer-safe auth token string. Signature validity is checked by verifyAuthToken(). */
+export function decodeAuthToken(encoded: string): SignedAuthToken {
+  if (typeof encoded !== "string" || !encoded.startsWith(AUTH_TOKEN_PREFIX)) {
+    throw new Error("federation: invalid auth token");
+  }
+  try {
+    const raw = Buffer.from(encoded.slice(AUTH_TOKEN_PREFIX.length), "base64url").toString("utf8");
+    return normalizeSignedAuthToken(JSON.parse(raw));
+  } catch (err) {
+    throw new Error("federation: invalid auth token", { cause: err });
+  }
+}
+
+function optionTimeMs(now: Date | string | number | undefined): number {
+  if (now === undefined) return Date.now();
+  if (now instanceof Date) return now.getTime();
+  if (typeof now === "number") return now;
+  const ms = Date.parse(now);
+  if (!Number.isFinite(ms)) throw new Error("federation: invalid now");
+  return ms;
+}
+
+/**
+ * Verify a signed auth token against RosterStore. The token contains no trust root:
+ * the issuer's verify key is resolved from the latest accepted roster.
+ */
+export async function verifyAuthToken(
+  token: SignedAuthToken,
+  rosters: RosterStore,
+  options: AuthTokenVerifyOptions = {},
+): Promise<AuthTokenVerifyResult> {
+  let normalized: AuthTokenClaims;
+  let issuedAtMs: number;
+  let expiresAtMs: number;
+  let nowMs: number;
+  try {
+    normalized = normalizeAuthClaims(token);
+    issuedAtMs = validDateMs(normalized.issuedAt, "issuedAt");
+    expiresAtMs = validDateMs(normalized.expiresAt, "expiresAt");
+    nowMs = optionTimeMs(options.now);
+  } catch {
+    return { accepted: false, reason: "malformed" };
+  }
+
+  let verifyPublicKey: string;
+  try {
+    verifyPublicKey = rosters.agentKeys(normalized.issuer.org, normalized.issuer.agentId).verifyPublicKey;
+  } catch {
+    return { accepted: false, reason: "issuer-not-found" };
+  }
+
+  let signatureOk = false;
+  try {
+    signatureOk =
+      typeof token.signature === "string" &&
+      (await verifyEnvelopeSignature(canonicalAuthTokenClaims(normalized), token.signature, verifyPublicKey));
+  } catch {
+    signatureOk = false;
+  }
+  if (!signatureOk) {
+    return { accepted: false, reason: "signature-invalid" };
+  }
+  if (nowMs < issuedAtMs) return { accepted: false, reason: "not-yet-valid" };
+  if (nowMs >= expiresAtMs) return { accepted: false, reason: "expired" };
+
+  if (options.audience && formatAddress(options.audience) !== formatAddress(normalized.audience)) {
+    return { accepted: false, reason: "audience-mismatch" };
+  }
+
+  if (options.requiredScopes?.length) {
+    const granted = new Set(normalized.scopes);
+    for (const scope of normalizeScopes(options.requiredScopes)) {
+      if (!granted.has(scope)) return { accepted: false, reason: "scope-missing" };
+    }
+  }
+
+  return { accepted: true };
+}

--- a/packages/federation/test/federation.test.mjs
+++ b/packages/federation/test/federation.test.mjs
@@ -2,13 +2,18 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createKeyPair, createSigningKeyPair, signEnvelope } from "../../security/dist/src/index.js";
 import {
+  canonicalAuthTokenClaims,
   canonicalRoster,
+  decodeAuthToken,
+  encodeAuthToken,
   formatAddress,
   isLocal,
   lookupAgentKeys,
   parseAddress,
   RosterStore,
+  signAuthToken,
   signRoster,
+  verifyAuthToken,
   verifyRoster,
 } from "../dist/src/index.js";
 
@@ -237,4 +242,119 @@ test("RosterStore: re-pinning the same key preserves accepted state", async () =
   store.pin("partner", sign.publicKey); // same key -> no epoch reset
   assert.equal(store.current("partner").version, 5);
   assert.deepEqual(await store.offer(await makeRoster("partner", 5, sign, ak)), { accepted: false, reason: "stale-or-replay" });
+});
+
+// ─── Auth token (roster-backed identity + authz) ───
+
+async function authStoreWithIssuer() {
+  const orgSign = await createSigningKeyPair();
+  const issuerEnc = await createKeyPair();
+  const issuerSig = await createSigningKeyPair();
+  const roster = await signRoster(
+    {
+      org: "aimindset",
+      version: 1,
+      issuedAt: "2026-06-21T00:00:00Z",
+      agents: {
+        "agent-jarvis": {
+          encryptPublicKey: issuerEnc.publicKey,
+          verifyPublicKey: issuerSig.publicKey,
+        },
+      },
+    },
+    orgSign.privateKey,
+    orgSign.publicKey,
+  );
+  const store = new RosterStore({ aimindset: orgSign.publicKey });
+  assert.deepEqual(await store.offer(roster), { accepted: true });
+  return { store, issuerSig };
+}
+
+function authClaims(overrides = {}) {
+  return {
+    issuer: { org: "aimindset", agentId: "agent-jarvis" },
+    audience: { org: "partner", agentId: "agent-codex" },
+    scopes: ["murmur:send", "murmur:reply"],
+    issuedAt: "2026-06-21T10:00:00.000Z",
+    expiresAt: "2026-06-21T11:00:00.000Z",
+    nonce: "nonce-1",
+    ...overrides,
+  };
+}
+
+test("AuthToken: signs and verifies against issuer key from accepted roster", async () => {
+  const { store, issuerSig } = await authStoreWithIssuer();
+  const token = await signAuthToken(authClaims(), issuerSig.privateKey);
+  assert.deepEqual(
+    await verifyAuthToken(token, store, {
+      now: "2026-06-21T10:30:00.000Z",
+      audience: { org: "partner", agentId: "agent-codex" },
+      requiredScopes: ["murmur:send"],
+    }),
+    { accepted: true },
+  );
+});
+
+test("AuthToken: encodes/decodes a bearer token string", async () => {
+  const { store, issuerSig } = await authStoreWithIssuer();
+  const token = await signAuthToken(authClaims(), issuerSig.privateKey);
+  const encoded = encodeAuthToken(token);
+  assert.match(encoded, /^MURMUR-AUTH:/);
+  const decoded = decodeAuthToken(encoded);
+  assert.deepEqual(decoded, token);
+  assert.deepEqual(await verifyAuthToken(decoded, store, { now: "2026-06-21T10:30:00.000Z" }), {
+    accepted: true,
+  });
+  assert.throws(() => decodeAuthToken("not-a-token"), /invalid auth token/);
+});
+
+test("AuthToken: canonical claims are scope-order independent", () => {
+  assert.equal(
+    canonicalAuthTokenClaims(authClaims({ scopes: ["murmur:reply", "murmur:send"] })),
+    canonicalAuthTokenClaims(authClaims({ scopes: ["murmur:send", "murmur:reply"] })),
+  );
+});
+
+test("AuthToken: rejects tampered claims, unknown issuer, audience mismatch, missing scope, and expiry", async () => {
+  const { store, issuerSig } = await authStoreWithIssuer();
+  const token = await signAuthToken(authClaims(), issuerSig.privateKey);
+  assert.deepEqual(
+    await verifyAuthToken({ ...token, scopes: ["murmur:admin"] }, store, { now: "2026-06-21T10:30:00.000Z" }),
+    { accepted: false, reason: "signature-invalid" },
+  );
+  assert.deepEqual(
+    await verifyAuthToken({ ...token, signature: "not-base64" }, store, { now: "2026-06-21T10:30:00.000Z" }),
+    { accepted: false, reason: "signature-invalid" },
+  );
+  assert.deepEqual(
+    await verifyAuthToken({ ...token, issuer: { org: "aimindset", agentId: "ghost" } }, store, { now: "2026-06-21T10:30:00.000Z" }),
+    { accepted: false, reason: "issuer-not-found" },
+  );
+  assert.deepEqual(
+    await verifyAuthToken(token, store, {
+      now: "2026-06-21T10:30:00.000Z",
+      audience: { org: "other", agentId: "agent-codex" },
+    }),
+    { accepted: false, reason: "audience-mismatch" },
+  );
+  assert.deepEqual(
+    await verifyAuthToken(token, store, { now: "2026-06-21T10:30:00.000Z", requiredScopes: ["murmur:admin"] }),
+    { accepted: false, reason: "scope-missing" },
+  );
+  assert.deepEqual(
+    await verifyAuthToken(token, store, { now: "2026-06-21T11:00:01.000Z" }),
+    { accepted: false, reason: "expired" },
+  );
+});
+
+test("AuthToken: rejects malformed token timestamps and empty scopes before signing", async () => {
+  const { issuerSig } = await authStoreWithIssuer();
+  await assert.rejects(
+    () => signAuthToken(authClaims({ scopes: [] }), issuerSig.privateKey),
+    /at least one scope/,
+  );
+  await assert.rejects(
+    () => signAuthToken(authClaims({ expiresAt: "not-a-date" }), issuerSig.privateKey),
+    /invalid expiresAt/,
+  );
 });


### PR DESCRIPTION
## Summary
- add roster-backed signed auth tokens to `@murmurv2/federation`
- token issuer/audience use existing `org/agentId` addresses
- issuer verification key is resolved only from the latest accepted `RosterStore` roster
- support audience/scope/time verification and bearer-safe `MURMUR-AUTH:` encode/decode
- document the honest boundary: model/helper layer is coded+tested; live transport/bridge enforcement remains pending

## Why
Roadmap item: auth/authz model — token-based peer authentication where the federation roster is the identity layer. This PR keeps auth trust rooted in the already-merged `RosterStore` instead of adding a second key directory.

## Verification
- TDD red first: `@murmurv2/federation` test failed on missing auth-token exports
- `npm --workspace @murmurv2/federation test` PASS (24/24)
- `npm test` PASS

## Boundaries
- No live transport/bridge enforcement yet
- No replay cache yet; `nonce`/jti is included for a future bridge/runtime replay store
