### PR TITLE
feat(broker-ws): add WebSocket transport adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ This enables **fully autonomous overnight work** — launch 2-3 agents, they col
 ### Operations
 - **SQLite WAL** — concurrent reads, write-ahead logging, optimistic locking
 - **Core NATS + SQLite outbox** — low-latency pub/sub with app-level at-least-once delivery, ACK correlation, DLQ, and unbounded dedupe
+- **WebSocket Transport Adapter** — local relay + broker client with envelope delivery, ACK correlation, dedupe, and invalid-envelope NACKs (browser deployment pending)
 - **Systemd Ready** — production service file included
 - **Docker Compose** — one-command NATS setup
 - **Observability Dashboard** — real-time message flow visualization
@@ -301,6 +302,7 @@ mur-mur-v2/
 ├── packages/
 │   ├── core/              # Envelope schema, SQLite stores, policy validation
 │   ├── broker-nats/       # core NATS pub/sub, outbox flush, ACK correlation
+│   ├── broker-ws/         # WebSocket relay/client transport adapter
 │   ├── security/          # NaCl crypto (X25519, XChaCha20, Ed25519), MLS scaffold
 │   ├── mcp-server/        # JSON-RPC MCP stdio server (7 tools)
 │   ├── bridge-telegram/   # Telegram bot adapter
@@ -435,12 +437,12 @@ See [protocol-v1.md](docs/protocol-v1.md) for the full specification.
 - [ ] **A2A interop bridge (v2.1)** — a **real `@a2a-js/sdk` client → bridge → NATS → reply round-trip is proven** over HTTP (against a mock internal agent), and Agent-Card transport discovery is fixed. Remaining gate: **not yet connected to a real remote A2A agent**
 - [ ] **Always-on wake (dead session) (v2.1)** — a cold-start spawn-on-inbound sidecar (fresh `codex exec` per batch, exactly-once, linger-enabled systemd user service) exists in the **reference Codex deployment, outside this repo**; a repo-shipped version and the strict no-live-session proof remain pending
 - [ ] **Auth/authz token model** — roster-backed signed tokens with audience/scope/time verification are coded and unit-tested; remaining gate: wire token enforcement into live transports/bridges
+- [ ] **WebSocket transport adapter** — relay + broker client are coded and unit-tested for envelope delivery, ACK correlation, dedupe, and invalid-envelope NACKs; remaining gate: browser/edge deployment examples and hardening
 - [x] Prometheus metrics exporter — outbox depth, delivery latency, error rates
 - [ ] npm package publishing — `@murmurv2/*` on npm registry
 - [ ] NATS native request-reply — replace polling with ephemeral inbox subjects
 
 ### Planned (next wave)
-- [ ] WebSocket transport adapter — browser-based agents
 - [ ] Message streaming — large payload chunking with backpressure
 - [ ] Agent discovery protocol — find peers without manual invite exchange
 - [ ] Reference deployment examples — docker-compose, Kubernetes manifests

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,10 @@
       "resolved": "packages/broker-nats",
       "link": true
     },
+    "node_modules/@murmurv2/broker-ws": {
+      "resolved": "packages/broker-ws",
+      "link": true
+    },
     "node_modules/@murmurv2/core": {
       "resolved": "packages/core",
       "link": true
@@ -1813,6 +1817,15 @@
       "dependencies": {
         "@murmurv2/core": "^0.1.0",
         "nats": "^2.28.2"
+      }
+    },
+    "packages/broker-ws": {
+      "name": "@murmurv2/broker-ws",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@murmurv2/core": "^0.1.0",
+        "ws": "^8.21.0"
       }
     },
     "packages/core": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
     "test:ws5-boundary": "python3 tests/ws5-send-boundary.test.py && python3 scripts/murmur-send-boundary.py --self-test && python3 -m py_compile scripts/murmur-send-boundary.py tests/ws5-send-boundary.test.py",
     "test:core": "npm --workspace @murmurv2/core test",
     "test:a2a": "npm --workspace @murmurv2/bridge-a2a test",
+    "test:broker-ws": "npm --workspace @murmurv2/broker-ws test",
     "test:federation": "npm --workspace @murmurv2/federation test",
     "test:federation-nats": "npm --workspace @murmurv2/federation-nats test",
-    "test": "npm run build && npm run test:unit && npm run test:core && npm run test:notify-smoke && npm run test:ws4-acp && npm run test:ws5-boundary && npm run test:a2a && npm run test:federation && npm run test:federation-nats"
+    "test": "npm run build && npm run test:unit && npm run test:core && npm run test:notify-smoke && npm run test:ws4-acp && npm run test:ws5-boundary && npm run test:a2a && npm run test:broker-ws && npm run test:federation && npm run test:federation-nats"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/broker-ws/LICENSE
+++ b/packages/broker-ws/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/broker-ws/package.json
+++ b/packages/broker-ws/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@murmurv2/broker-ws",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test",
+    "prepack": "npm run build"
+  },
+  "dependencies": {
+    "@murmurv2/core": "^0.1.0",
+    "ws": "^8.21.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/broker-ws"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist/src",
+    "LICENSE"
+  ],
+  "description": "Murmur V2 WebSocket broker adapter — local relay and browser/edge-friendly transport semantics."
+}

--- a/packages/broker-ws/src/index.ts
+++ b/packages/broker-ws/src/index.ts
@@ -1,0 +1,384 @@
+import { createRequire } from "node:module";
+import {
+  applyJitter,
+  computeBackoffMs,
+  createAck,
+  type AckV1,
+  type DedupeStore,
+  type EnvelopeV1,
+  isEnvelopeV1,
+  type OutboxStore,
+  type SecurityPolicy,
+  validateEnvelopePolicy,
+} from "@murmurv2/core";
+
+const require = createRequire(import.meta.url);
+const { WebSocket, WebSocketServer } = require("ws") as {
+  WebSocket: {
+    new(url: string): WsSocket;
+    OPEN: number;
+  };
+  WebSocketServer: new(options: { host?: string; port: number }) => WsServer;
+};
+
+interface WsSocket {
+  readyState: number;
+  send(data: string): void;
+  close(): void;
+  terminate?(): void;
+  on(event: "open" | "error" | "close", cb: (...args: unknown[]) => void): void;
+  on(event: "message", cb: (data: unknown) => void): void;
+}
+
+interface WsServer {
+  clients: Set<WsSocket>;
+  address(): { address: string; port: number } | string | null;
+  close(cb?: (err?: Error) => void): void;
+  on(event: "connection", cb: (socket: WsSocket) => void): void;
+  on(event: "listening", cb: () => void): void;
+  on(event: "error", cb: (err: Error) => void): void;
+}
+
+type WsFrame =
+  | { type: "subscribe"; subject: string }
+  | { type: "message"; subject: string; envelope: EnvelopeV1 | unknown }
+  | { type: "ack"; subject: string; ack: AckV1 };
+
+export interface WebSocketRelayConfig {
+  host?: string;
+  port: number;
+}
+
+export interface WebSocketRelayListenResult {
+  url: string;
+  port: number;
+}
+
+export interface WebSocketBrokerConfig {
+  url: string;
+}
+
+export type WebSocketMessageHandler = (envelope: EnvelopeV1) => Promise<void>;
+export type WebSocketBrokerSubscription = { unsubscribe(): void | Promise<void> };
+
+export function wsSubjectMatches(pattern: string, subject: string): boolean {
+  const p = pattern.split(".");
+  const s = subject.split(".");
+  for (let i = 0; i < p.length; i += 1) {
+    const token = p[i];
+    if (token === ">") return i === p.length - 1;
+    if (i >= s.length) return false;
+    if (token !== "*" && token !== s[i]) return false;
+  }
+  return p.length === s.length;
+}
+
+function parseFrame(data: unknown): WsFrame | undefined {
+  const text = Buffer.isBuffer(data) ? data.toString("utf8") : String(data);
+  const frame = JSON.parse(text) as WsFrame;
+  if (!frame || typeof frame !== "object") return undefined;
+  if (frame.type === "subscribe" && typeof frame.subject === "string") return frame;
+  if (frame.type === "message" && typeof frame.subject === "string") return frame;
+  if (frame.type === "ack" && typeof frame.subject === "string") return frame;
+  return undefined;
+}
+
+function sendJson(socket: WsSocket, frame: WsFrame): void {
+  if (socket.readyState !== WebSocket.OPEN) return;
+  socket.send(JSON.stringify(frame));
+}
+
+export class WebSocketRelay {
+  private server?: WsServer;
+  private readonly subscriptions = new Map<WsSocket, Set<string>>();
+
+  constructor(private readonly config: WebSocketRelayConfig) {}
+
+  async listen(): Promise<WebSocketRelayListenResult> {
+    if (this.server) return this.listenResult();
+    this.server = new WebSocketServer({ host: this.config.host, port: this.config.port });
+    this.server.on("connection", (socket) => this.addClient(socket));
+    await new Promise<void>((resolve, reject) => {
+      this.server!.on("listening", resolve);
+      this.server!.on("error", reject);
+    });
+    return this.listenResult();
+  }
+
+  async close(): Promise<void> {
+    if (!this.server) return;
+    for (const client of this.server.clients) client.terminate?.();
+    const server = this.server;
+    this.server = undefined;
+    this.subscriptions.clear();
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+
+  private listenResult(): WebSocketRelayListenResult {
+    if (!this.server) throw new Error("websocket-relay-not-listening");
+    const addr = this.server.address();
+    if (!addr || typeof addr === "string") throw new Error("websocket-relay-address-unavailable");
+    const host = this.config.host ?? (addr.address === "::" ? "127.0.0.1" : addr.address);
+    return { url: `ws://${host}:${addr.port}`, port: addr.port };
+  }
+
+  private addClient(socket: WsSocket): void {
+    this.subscriptions.set(socket, new Set());
+    socket.on("message", (data) => {
+      try {
+        const frame = parseFrame(data);
+        if (!frame) return;
+        if (frame.type === "subscribe") {
+          this.subscriptions.get(socket)?.add(frame.subject);
+          return;
+        }
+        this.broadcast(frame);
+      } catch {
+        // Malformed relay frames are dropped; subscribers NACK malformed envelopes.
+      }
+    });
+    socket.on("close", () => {
+      this.subscriptions.delete(socket);
+    });
+  }
+
+  private broadcast(frame: Extract<WsFrame, { type: "message" | "ack" }>): void {
+    for (const [client, subjects] of this.subscriptions.entries()) {
+      if ([...subjects].some((subject) => wsSubjectMatches(subject, frame.subject))) {
+        sendJson(client, frame);
+      }
+    }
+  }
+}
+
+interface MessageSubscription {
+  subject: string;
+  consumerId: string;
+  dedupe: DedupeStore;
+  onMessage: WebSocketMessageHandler;
+  maxPoisonAttempts?: number;
+  active: boolean;
+  queue: Promise<void>;
+}
+
+interface AckSubscription {
+  subject: string;
+  outbox: OutboxStore;
+  active: boolean;
+}
+
+export class WebSocketBroker {
+  private socket?: WsSocket;
+  private connectPromise?: Promise<void>;
+  private readonly messageSubscriptions = new Set<MessageSubscription>();
+  private readonly ackSubscriptions = new Set<AckSubscription>();
+  private readonly failedDeliveries = new Map<string, number>();
+
+  constructor(private readonly config: WebSocketBrokerConfig) {}
+
+  async connect(): Promise<void> {
+    if (this.socket?.readyState === WebSocket.OPEN) return;
+    if (this.connectPromise) return this.connectPromise;
+    this.connectPromise = new Promise<void>((resolve, reject) => {
+      const socket = new WebSocket(this.config.url);
+      this.socket = socket;
+      socket.on("open", () => resolve());
+      socket.on("error", (err) => reject(err instanceof Error ? err : new Error(String(err))));
+      socket.on("message", (data) => {
+        void this.onFrameData(data);
+      });
+      socket.on("close", () => {
+        this.socket = undefined;
+        this.connectPromise = undefined;
+      });
+    });
+    return this.connectPromise;
+  }
+
+  async close(): Promise<void> {
+    if (!this.socket) return;
+    const socket = this.socket;
+    this.socket = undefined;
+    socket.close();
+  }
+
+  private async send(frame: WsFrame): Promise<void> {
+    await this.connect();
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      throw new Error("websocket-not-open");
+    }
+    this.socket.send(JSON.stringify(frame));
+  }
+
+  async publish(subject: string, envelope: EnvelopeV1, policy?: SecurityPolicy): Promise<void> {
+    const violations = validateEnvelopePolicy(envelope, policy);
+    if (violations.length > 0) {
+      throw new Error(`policy-rejected:${violations.join("|")}`);
+    }
+    await this.send({ type: "message", subject, envelope });
+  }
+
+  async publishAck(subject: string, ack: AckV1): Promise<void> {
+    await this.send({ type: "ack", subject, ack });
+  }
+
+  async subscribeWithAck(params: {
+    subject: string;
+    consumerId: string;
+    dedupe: DedupeStore;
+    onMessage: WebSocketMessageHandler;
+    maxPoisonAttempts?: number;
+  }): Promise<WebSocketBrokerSubscription> {
+    await this.connect();
+    const sub: MessageSubscription = { ...params, active: true, queue: Promise.resolve() };
+    this.messageSubscriptions.add(sub);
+    await this.send({ type: "subscribe", subject: params.subject });
+    return {
+      unsubscribe: () => {
+        sub.active = false;
+        this.messageSubscriptions.delete(sub);
+      },
+    };
+  }
+
+  async startAckCorrelation(params: {
+    outbox: OutboxStore;
+    ackSubject: string;
+  }): Promise<WebSocketBrokerSubscription> {
+    await this.connect();
+    const sub: AckSubscription = { subject: params.ackSubject, outbox: params.outbox, active: true };
+    this.ackSubscriptions.add(sub);
+    await this.send({ type: "subscribe", subject: params.ackSubject });
+    return {
+      unsubscribe: () => {
+        sub.active = false;
+        this.ackSubscriptions.delete(sub);
+      },
+    };
+  }
+
+  private async onFrameData(data: unknown): Promise<void> {
+    let frame: WsFrame | undefined;
+    try {
+      frame = parseFrame(data);
+    } catch {
+      return;
+    }
+    if (!frame) return;
+    if (frame.type === "message") {
+      await Promise.all(
+        [...this.messageSubscriptions]
+          .filter((sub) => sub.active && wsSubjectMatches(sub.subject, frame!.subject))
+          .map((sub) => {
+            sub.queue = sub.queue
+              .then(() => this.processEnvelopeFrame(frame!.envelope, sub))
+              .catch((err) => {
+                const e = err instanceof Error ? err : new Error(String(err));
+                console.error("[WebSocketBroker.subscribeWithAck] loop crashed", { message: e.message, stack: e.stack });
+              });
+            return sub.queue;
+          }),
+      );
+      return;
+    }
+    if (frame.type === "ack") {
+      await Promise.all(
+        [...this.ackSubscriptions]
+          .filter((sub) => sub.active && wsSubjectMatches(sub.subject, frame!.subject))
+          .map((sub) => this.processAckFrame(frame!.ack, sub.outbox)),
+      );
+    }
+  }
+
+  private async processEnvelopeFrame(raw: unknown, params: MessageSubscription): Promise<void> {
+    if (!isEnvelopeV1(raw)) {
+      const sender = typeof raw === "object" && raw && typeof (raw as Record<string, unknown>).senderAgentId === "string"
+        ? String((raw as Record<string, unknown>).senderAgentId)
+        : params.consumerId;
+      await this.publishAck(`ack.${sender}`, createAck("unknown", params.consumerId, "nack", "invalid-envelope"));
+      return;
+    }
+
+    const envelope = raw;
+    const ackSubject = `ack.${envelope.senderAgentId}`;
+    const isDup = await params.dedupe.seen(envelope.msgId, params.consumerId);
+    if (isDup) {
+      await this.publishAck(ackSubject, createAck(envelope.msgId, params.consumerId, "ack", "duplicate-ignored"));
+      return;
+    }
+
+    try {
+      await params.onMessage(envelope);
+      await params.dedupe.markSeen(envelope.msgId, params.consumerId);
+      this.failedDeliveries.delete(`${params.consumerId}:${envelope.msgId}`);
+      await this.publishAck(ackSubject, createAck(envelope.msgId, params.consumerId, "ack"));
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : "handler-failed";
+      const maxPoisonAttempts = params.maxPoisonAttempts ?? 3;
+      const key = `${params.consumerId}:${envelope.msgId}`;
+      const failures = (this.failedDeliveries.get(key) ?? 0) + 1;
+      this.failedDeliveries.set(key, failures);
+      if (failures >= maxPoisonAttempts) {
+        await params.dedupe.markSeen(envelope.msgId, params.consumerId);
+        this.failedDeliveries.delete(key);
+        await this.publishAck(ackSubject, createAck(envelope.msgId, params.consumerId, "nack", `poison-message:${reason}`));
+        return;
+      }
+      await this.publishAck(ackSubject, createAck(envelope.msgId, params.consumerId, "nack", reason));
+    }
+  }
+
+  private async processAckFrame(ack: AckV1, outbox: OutboxStore): Promise<void> {
+    if (!ack || typeof ack.msgId !== "string" || ack.msgId.length === 0) return;
+    if (ack.status === "ack") {
+      await outbox.markAcked(ack.msgId);
+      return;
+    }
+    if (ack.status === "nack") {
+      await outbox.markFailed(ack.msgId, ack.reason ?? "nack", new Date().toISOString());
+    }
+  }
+
+  async flushOutbox(params: {
+    outbox: OutboxStore;
+    maxAttempts?: number;
+    batchSize?: number;
+    baseBackoffMs?: number;
+    jitterRatio?: number;
+    ackTimeoutMs?: number;
+    policy?: SecurityPolicy;
+  }): Promise<void> {
+    const maxAttempts = params.maxAttempts ?? 5;
+    if (params.ackTimeoutMs && params.outbox.requeueStaleSent) {
+      await params.outbox.requeueStaleSent(params.ackTimeoutMs);
+    }
+    const due = await params.outbox.claimDue(params.batchSize ?? 50);
+
+    for (const rec of due) {
+      try {
+        await this.publish(rec.subject, rec.envelope, params.policy);
+        await params.outbox.markSent(rec.msgId);
+      } catch (err) {
+        const nextAttemptNum = rec.attempts + 1;
+        const reason = err instanceof Error ? err.message : "publish-failed";
+
+        if (reason.startsWith("policy-rejected:")) {
+          await params.outbox.markDlq(rec.msgId, reason);
+          continue;
+        }
+
+        if (nextAttemptNum >= maxAttempts) {
+          await params.outbox.markDlq(rec.msgId, reason);
+          continue;
+        }
+
+        const backoffMs = computeBackoffMs(nextAttemptNum, params.baseBackoffMs ?? 500);
+        const withJitter = applyJitter(backoffMs, params.jitterRatio ?? 0.2);
+        const nextAt = new Date(Date.now() + withJitter).toISOString();
+        await params.outbox.markFailed(rec.msgId, reason, nextAt);
+      }
+    }
+  }
+}

--- a/packages/broker-ws/test/broker-ws.test.mjs
+++ b/packages/broker-ws/test/broker-ws.test.mjs
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { WebSocket } from "ws";
+import { InMemoryDedupeStore } from "../../core/dist/src/index.js";
+import { WebSocketBroker, WebSocketRelay, wsSubjectMatches } from "../dist/src/index.js";
+
+function envelope(overrides = {}) {
+  return {
+    schemaVersion: "1.0",
+    msgId: "msg-1",
+    conversationId: "conv-1",
+    senderAgentId: "alice",
+    recipients: ["bob"],
+    createdAt: "2026-06-21T23:10:00.000Z",
+    payloadCiphertext: "cipher",
+    payloadNonce: "nonce",
+    signature: "sig",
+    ...overrides,
+  };
+}
+
+async function eventually(fn, timeoutMs = 1500) {
+  const start = Date.now();
+  let lastErr;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      return fn();
+    } catch (err) {
+      lastErr = err;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  throw lastErr;
+}
+
+async function withRelay(fn) {
+  const relay = new WebSocketRelay({ host: "127.0.0.1", port: 0 });
+  const { url } = await relay.listen();
+  try {
+    await fn(url);
+  } finally {
+    await relay.close();
+  }
+}
+
+class MemoryOutbox {
+  acked = [];
+  failed = [];
+
+  async markAcked(msgId) {
+    this.acked.push(msgId);
+  }
+
+  async markFailed(msgId, error) {
+    this.failed.push({ msgId, error });
+  }
+}
+
+test("wsSubjectMatches supports exact, star, and tail wildcards", () => {
+  assert.equal(wsSubjectMatches("msg.bob", "msg.bob"), true);
+  assert.equal(wsSubjectMatches("msg.*", "msg.bob"), true);
+  assert.equal(wsSubjectMatches("msg.>", "msg.bob.one"), true);
+  assert.equal(wsSubjectMatches("msg.*", "msg.bob.one"), false);
+  assert.equal(wsSubjectMatches("ack.alice", "ack.bob"), false);
+});
+
+test("WebSocketBroker publishes envelopes through a relay and correlates ACKs", async () => {
+  await withRelay(async (url) => {
+    const alice = new WebSocketBroker({ url });
+    const bob = new WebSocketBroker({ url });
+    const seen = [];
+    const outbox = new MemoryOutbox();
+
+    await alice.startAckCorrelation({ ackSubject: "ack.alice", outbox });
+    await bob.subscribeWithAck({
+      subject: "msg.bob",
+      consumerId: "bob",
+      dedupe: new InMemoryDedupeStore(),
+      onMessage: async (msg) => {
+        seen.push(msg.msgId);
+      },
+    });
+
+    await alice.publish("msg.bob", envelope());
+
+    await eventually(() => assert.deepEqual(seen, ["msg-1"]));
+    await eventually(() => assert.deepEqual(outbox.acked, ["msg-1"]));
+
+    await alice.close();
+    await bob.close();
+  });
+});
+
+test("WebSocketBroker dedupes duplicate envelope delivery and still ACKs the duplicate", async () => {
+  await withRelay(async (url) => {
+    const alice = new WebSocketBroker({ url });
+    const bob = new WebSocketBroker({ url });
+    const seen = [];
+    const outbox = new MemoryOutbox();
+
+    await alice.startAckCorrelation({ ackSubject: "ack.alice", outbox });
+    await bob.subscribeWithAck({
+      subject: "msg.bob",
+      consumerId: "bob",
+      dedupe: new InMemoryDedupeStore(),
+      onMessage: async (msg) => {
+        seen.push(msg.msgId);
+      },
+    });
+
+    await alice.publish("msg.bob", envelope());
+    await alice.publish("msg.bob", envelope());
+
+    await eventually(() => assert.deepEqual(seen, ["msg-1"]));
+    await eventually(() => assert.deepEqual(outbox.acked, ["msg-1", "msg-1"]));
+
+    await alice.close();
+    await bob.close();
+  });
+});
+
+test("WebSocketBroker NACKs invalid envelope frames", async () => {
+  await withRelay(async (url) => {
+    const alice = new WebSocketBroker({ url });
+    const bob = new WebSocketBroker({ url });
+    const outbox = new MemoryOutbox();
+
+    await alice.startAckCorrelation({ ackSubject: "ack.alice", outbox });
+    await bob.subscribeWithAck({
+      subject: "msg.bob",
+      consumerId: "bob",
+      dedupe: new InMemoryDedupeStore(),
+      onMessage: async () => {
+        throw new Error("should-not-run");
+      },
+    });
+
+    const raw = new WebSocket(url);
+    await new Promise((resolve) => raw.once("open", resolve));
+    raw.send(JSON.stringify({ type: "message", subject: "msg.bob", envelope: { msgId: "bad", senderAgentId: "alice" } }));
+
+    await eventually(() => assert.deepEqual(outbox.failed, [{ msgId: "unknown", error: "invalid-envelope" }]));
+    raw.close();
+    await alice.close();
+    await bob.close();
+  });
+});

--- a/packages/broker-ws/tsconfig.json
+++ b/packages/broker-ws/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "composite": true,
+    "types": [
+      "node"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@murmurv2/core": ["../core/src/index.ts"]
+    }
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../core"
+    }
+  ]
+}

--- a/scripts/prep-publish.mjs
+++ b/scripts/prep-publish.mjs
@@ -19,6 +19,7 @@ const DESCRIPTIONS = {
   "@murmurv2/core": "Murmur V2 core — EnvelopeV1/AckV1 wire types, SQLite outbox + dedupe stores, machine-readable protocol schema.",
   "@murmurv2/security": "Murmur V2 crypto — X25519 + XChaCha20-Poly1305 + Ed25519 envelope encrypt/sign/verify (MLS scaffold).",
   "@murmurv2/broker-nats": "Murmur V2 NATS broker — core pub/sub with optional JetStream durability (finite redelivery + DLQ).",
+  "@murmurv2/broker-ws": "Murmur V2 WebSocket broker adapter — local relay and browser/edge-friendly transport semantics.",
   "@murmurv2/mcp-server": "Murmur V2 MCP server — 7 tools for agent-to-agent messaging over the Model Context Protocol.",
   "@murmurv2/federation": "Murmur V2 federation — org/agent addressing, Ed25519 signed roster + RosterStore, roster-backed auth tokens.",
   "@murmurv2/federation-nats": "Murmur V2 federation NATS contract — fed.* subjects + account-config renderer for cross-org leaf-node meshes.",

--- a/scripts/publish-all.mjs
+++ b/scripts/publish-all.mjs
@@ -14,6 +14,7 @@ const ORDER = [
   "@murmurv2/bridge-murmur",
   "@murmurv2/federation",
   "@murmurv2/broker-nats",
+  "@murmurv2/broker-ws",
   "@murmurv2/bridge-openclaw",
   "@murmurv2/bridge-telegram",
   "@murmurv2/mcp-server",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./packages/core" },
     { "path": "./packages/broker-nats" },
+    { "path": "./packages/broker-ws" },
     { "path": "./packages/bridge-murmur" },
     { "path": "./packages/bridge-openclaw" },
     { "path": "./packages/bridge-telegram" },


### PR DESCRIPTION
## Summary
- add `@murmurv2/broker-ws` workspace
- implement a local WebSocket relay and broker client transport adapter
- support subject subscriptions with `*`/`>` matching, envelope publish, `subscribeWithAck`, ACK correlation, and outbox flushing
- preserve core delivery semantics: policy validation, dedupe, duplicate ACK, invalid-envelope NACK, poison-message NACK after max attempts
- wire the package into root `tsconfig`, root `npm test`, lockfile, and README roadmap/file tree

## Verification
- TDD red first: `@murmurv2/broker-ws` test failed on missing exports
- `npm --workspace @murmurv2/broker-ws test` PASS (4/4)
- `npm test` PASS after rebasing onto `origin/main` (includes #47)

## Boundaries
- This is a transport adapter and local relay, not a production browser deployment recipe yet
- No TLS/auth binding here; auth token enforcement is a follow-up wiring step after #47
- No durable broker semantics in the relay itself; outbox/ACK handling stays at the Murmur client layer, matching the current app-level durability model
