### PR TITLE
chore(release): prep all @murmurv2/* packages for public npm publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,10 +1771,11 @@
     "packages/bridge-a2a": {
       "name": "@murmurv2/bridge-a2a",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@a2a-js/sdk": "1.0.0-alpha.0",
-        "@murmurv2/core": "0.1.0",
-        "@murmurv2/security": "0.1.0",
+        "@murmurv2/core": "^0.1.0",
+        "@murmurv2/security": "^0.1.0",
         "express": "^5.1.0",
         "nats": "^2.28.2"
       },
@@ -1784,35 +1785,40 @@
     },
     "packages/bridge-murmur": {
       "name": "@murmurv2/bridge-murmur",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "license": "MIT"
     },
     "packages/bridge-openclaw": {
       "name": "@murmurv2/bridge-openclaw",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "0.1.0",
+        "@murmurv2/core": "^0.1.0",
         "nats": "^2.28.2"
       }
     },
     "packages/bridge-telegram": {
       "name": "@murmurv2/bridge-telegram",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "0.1.0",
-        "@murmurv2/security": "0.1.0"
+        "@murmurv2/core": "^0.1.0",
+        "@murmurv2/security": "^0.1.0"
       }
     },
     "packages/broker-nats": {
       "name": "@murmurv2/broker-nats",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "0.1.0",
+        "@murmurv2/core": "^0.1.0",
         "nats": "^2.28.2"
       }
     },
     "packages/core": {
       "name": "@murmurv2/core",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "pg": "^8.16.3"
       }
@@ -1820,33 +1826,42 @@
     "packages/federation": {
       "name": "@murmurv2/federation",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
-        "@murmurv2/security": "0.1.0"
+        "@murmurv2/security": "^0.1.0"
       }
     },
     "packages/federation-nats": {
       "name": "@murmurv2/federation-nats",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "file:../core",
-        "@murmurv2/federation": "file:../federation"
+        "@murmurv2/core": "^0.1.0",
+        "@murmurv2/federation": "^0.1.0"
+      },
+      "devDependencies": {
+        "@murmurv2/security": "^0.1.0",
+        "nats": "^2.28.2"
       }
     },
     "packages/mcp-server": {
       "name": "@murmurv2/mcp-server",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "0.1.0",
-        "@murmurv2/security": "0.1.0"
+        "@murmurv2/core": "^0.1.0",
+        "@murmurv2/security": "^0.1.0"
       }
     },
     "packages/observability": {
       "name": "@murmurv2/observability",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "license": "MIT"
     },
     "packages/security": {
       "name": "@murmurv2/security",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "license": "MIT"
     }
   }
 }

--- a/packages/bridge-a2a/LICENSE
+++ b/packages/bridge-a2a/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/bridge-a2a/package.json
+++ b/packages/bridge-a2a/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "npm run build && node --test",
-    "test:live": "npm run build && bash integration/run-live.sh"
+    "test:live": "npm run build && bash integration/run-live.sh",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@a2a-js/sdk": "1.0.0-alpha.0",
@@ -29,7 +30,8 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/src",
     "LICENSE"
-  ]
+  ],
+  "description": "Murmur V2 to A2A protocol bridge (alpha) — terminates @a2a-js/sdk and re-wraps tasks as E2E Murmur envelopes."
 }

--- a/packages/bridge-a2a/package.json
+++ b/packages/bridge-a2a/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@murmurv2/bridge-a2a",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -12,12 +11,25 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "1.0.0-alpha.0",
-    "@murmurv2/core": "0.1.0",
-    "@murmurv2/security": "0.1.0",
+    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/security": "^0.1.0",
     "express": "^5.1.0",
     "nats": "^2.28.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.0"
-  }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/bridge-a2a"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
 }

--- a/packages/bridge-murmur/LICENSE
+++ b/packages/bridge-murmur/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/bridge-murmur/package.json
+++ b/packages/bridge-murmur/package.json
@@ -1,11 +1,23 @@
 {
   "name": "@murmurv2/bridge-murmur",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json"
-  }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/bridge-murmur"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
 }

--- a/packages/bridge-murmur/package.json
+++ b/packages/bridge-murmur/package.json
@@ -5,7 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build"
   },
   "license": "MIT",
   "repository": {
@@ -17,7 +18,8 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/src",
     "LICENSE"
-  ]
+  ],
+  "description": "Murmur V2 Murmur-to-Murmur bridge (experimental placeholder/stub)."
 }

--- a/packages/bridge-openclaw/LICENSE
+++ b/packages/bridge-openclaw/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/bridge-openclaw/package.json
+++ b/packages/bridge-openclaw/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@murmurv2/bridge-openclaw",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -9,7 +8,20 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@murmurv2/core": "0.1.0",
+    "@murmurv2/core": "^0.1.0",
     "nats": "^2.28.2"
-  }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/bridge-openclaw"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
 }

--- a/packages/bridge-openclaw/package.json
+++ b/packages/bridge-openclaw/package.json
@@ -5,7 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@murmurv2/core": "^0.1.0",
@@ -21,7 +22,8 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/src",
     "LICENSE"
-  ]
+  ],
+  "description": "Murmur V2 OpenClaw bridge (legacy/experimental)."
 }

--- a/packages/bridge-telegram/LICENSE
+++ b/packages/bridge-telegram/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/bridge-telegram/package.json
+++ b/packages/bridge-telegram/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@murmurv2/bridge-telegram",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -9,7 +8,20 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@murmurv2/core": "0.1.0",
-    "@murmurv2/security": "0.1.0"
-  }
+    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/security": "^0.1.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/bridge-telegram"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
 }

--- a/packages/bridge-telegram/package.json
+++ b/packages/bridge-telegram/package.json
@@ -5,7 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@murmurv2/core": "^0.1.0",
@@ -21,7 +22,8 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/src",
     "LICENSE"
-  ]
+  ],
+  "description": "Murmur V2 Telegram notification adapter."
 }

--- a/packages/broker-nats/LICENSE
+++ b/packages/broker-nats/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/broker-nats/package.json
+++ b/packages/broker-nats/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@murmurv2/broker-nats",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -9,7 +8,20 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@murmurv2/core": "0.1.0",
+    "@murmurv2/core": "^0.1.0",
     "nats": "^2.28.2"
-  }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/broker-nats"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
 }

--- a/packages/broker-nats/package.json
+++ b/packages/broker-nats/package.json
@@ -5,7 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@murmurv2/core": "^0.1.0",
@@ -21,7 +22,8 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/src",
     "LICENSE"
-  ]
+  ],
+  "description": "Murmur V2 NATS broker — core pub/sub with optional JetStream durability (finite redelivery + DLQ)."
 }

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,10 +6,11 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node --test test/*.test.mjs"
+    "test": "npm run build && node --test test/*.test.mjs",
+    "prepack": "npm run build"
   },
   "files": [
-    "dist",
+    "dist/src",
     "schema",
     "LICENSE"
   ],
@@ -24,5 +25,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "description": "Murmur V2 core — EnvelopeV1/AckV1 wire types, SQLite outbox + dedupe stores, machine-readable protocol schema."
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@murmurv2/core",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -11,9 +10,19 @@
   },
   "files": [
     "dist",
-    "schema"
+    "schema",
+    "LICENSE"
   ],
   "dependencies": {
     "pg": "^8.16.3"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/core"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/federation-nats/LICENSE
+++ b/packages/federation-nats/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/federation-nats/package.json
+++ b/packages/federation-nats/package.json
@@ -9,7 +9,8 @@
     "test": "npm run build && node --test test/*.test.mjs",
     "test:fed-live": "npm run build && bash integration/run-fed-live.sh",
     "test:real-mesh-leaf": "npm run build && bash integration/real-mesh-leaf.sh",
-    "test:perm-boundary": "npm run build && bash integration/run-perm-boundary.sh"
+    "test:perm-boundary": "npm run build && bash integration/run-perm-boundary.sh",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@murmurv2/core": "^0.1.0",
@@ -29,7 +30,8 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/src",
     "LICENSE"
-  ]
+  ],
+  "description": "Murmur V2 federation NATS contract — fed.* subjects + account-config renderer for cross-org leaf-node meshes."
 }

--- a/packages/federation-nats/package.json
+++ b/packages/federation-nats/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@murmurv2/federation-nats",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -13,11 +12,24 @@
     "test:perm-boundary": "npm run build && bash integration/run-perm-boundary.sh"
   },
   "dependencies": {
-    "@murmurv2/core": "file:../core",
-    "@murmurv2/federation": "file:../federation"
+    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/federation": "^0.1.0"
   },
   "devDependencies": {
-    "@murmurv2/security": "file:../security",
+    "@murmurv2/security": "^0.1.0",
     "nats": "^2.28.2"
-  }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/federation-nats"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
 }

--- a/packages/federation/LICENSE
+++ b/packages/federation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/federation/package.json
+++ b/packages/federation/package.json
@@ -6,7 +6,8 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && node --test"
+    "test": "npm run build && node --test",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@murmurv2/security": "^0.1.0"
@@ -21,7 +22,8 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/src",
     "LICENSE"
-  ]
+  ],
+  "description": "Murmur V2 federation — org/agent addressing, Ed25519 signed roster + RosterStore, roster-backed auth tokens."
 }

--- a/packages/federation/package.json
+++ b/packages/federation/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@murmurv2/federation",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -10,6 +9,19 @@
     "test": "npm run build && node --test"
   },
   "dependencies": {
-    "@murmurv2/security": "0.1.0"
-  }
+    "@murmurv2/security": "^0.1.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/federation"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
 }

--- a/packages/mcp-server/LICENSE
+++ b/packages/mcp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -5,7 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@murmurv2/core": "^0.1.0",
@@ -21,7 +22,8 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/src",
     "LICENSE"
-  ]
+  ],
+  "description": "Murmur V2 MCP server — 7 tools for agent-to-agent messaging over the Model Context Protocol."
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@murmurv2/mcp-server",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -9,7 +8,20 @@
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@murmurv2/core": "0.1.0",
-    "@murmurv2/security": "0.1.0"
-  }
+    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/security": "^0.1.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/mcp-server"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
 }

--- a/packages/observability/LICENSE
+++ b/packages/observability/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -5,7 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build"
   },
   "license": "MIT",
   "repository": {
@@ -17,7 +18,8 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/src",
     "LICENSE"
-  ]
+  ],
+  "description": "Murmur V2 observability helpers (scaffold)."
 }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,11 +1,23 @@
 {
   "name": "@murmurv2/observability",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json"
-  }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/observability"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
 }

--- a/packages/security/LICENSE
+++ b/packages/security/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 alexfrmn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -5,7 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "prepack": "npm run build"
   },
   "license": "MIT",
   "repository": {
@@ -17,7 +18,8 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "dist/src",
     "LICENSE"
-  ]
+  ],
+  "description": "Murmur V2 crypto — X25519 + XChaCha20-Poly1305 + Ed25519 envelope encrypt/sign/verify (MLS scaffold)."
 }

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,11 +1,23 @@
 {
   "name": "@murmurv2/security",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json"
-  }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alexfrmn/mur-mur-v2.git",
+    "directory": "packages/security"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "LICENSE"
+  ]
 }

--- a/scripts/prep-publish.mjs
+++ b/scripts/prep-publish.mjs
@@ -3,15 +3,31 @@
 // publishable to the public npm registry without changing its name. Idempotent.
 //   - drop `private: true`
 //   - set license: "MIT" + repository (with directory) + publishConfig.access=public
+//   - add a short `description` (npm hygiene; stubs marked experimental)
 //   - rewrite intra-workspace `@murmurv2/*` deps (file:../x or pinned) to `^<version>`
-//     so a consumer `npm install` resolves them from the registry, not a local path
-//   - ensure `files` ships `dist` (and keeps anything already declared, e.g. core/schema)
-import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+//   - `prepack: npm run build` guard so a publish/pack can never ship an empty dist
+//   - files: ["dist/src", "LICENSE"] (+ "schema" when present) — ships compiled JS+d.ts,
+//     drops dist/tsconfig.tsbuildinfo noise
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from "node:fs";
 import path from "node:path";
 
 const REPO_URL = "git+https://github.com/alexfrmn/mur-mur-v2.git";
 const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
 const pkgsDir = path.join(root, "packages");
+
+const DESCRIPTIONS = {
+  "@murmurv2/core": "Murmur V2 core — EnvelopeV1/AckV1 wire types, SQLite outbox + dedupe stores, machine-readable protocol schema.",
+  "@murmurv2/security": "Murmur V2 crypto — X25519 + XChaCha20-Poly1305 + Ed25519 envelope encrypt/sign/verify (MLS scaffold).",
+  "@murmurv2/broker-nats": "Murmur V2 NATS broker — core pub/sub with optional JetStream durability (finite redelivery + DLQ).",
+  "@murmurv2/mcp-server": "Murmur V2 MCP server — 7 tools for agent-to-agent messaging over the Model Context Protocol.",
+  "@murmurv2/federation": "Murmur V2 federation — org/agent addressing, Ed25519 signed roster + RosterStore, roster-backed auth tokens.",
+  "@murmurv2/federation-nats": "Murmur V2 federation NATS contract — fed.* subjects + account-config renderer for cross-org leaf-node meshes.",
+  "@murmurv2/bridge-a2a": "Murmur V2 to A2A protocol bridge (alpha) — terminates @a2a-js/sdk and re-wraps tasks as E2E Murmur envelopes.",
+  "@murmurv2/bridge-telegram": "Murmur V2 Telegram notification adapter.",
+  "@murmurv2/bridge-murmur": "Murmur V2 Murmur-to-Murmur bridge (experimental placeholder/stub).",
+  "@murmurv2/bridge-openclaw": "Murmur V2 OpenClaw bridge (legacy/experimental).",
+  "@murmurv2/observability": "Murmur V2 observability helpers (scaffold).",
+};
 
 for (const dir of readdirSync(pkgsDir)) {
   const file = path.join(pkgsDir, dir, "package.json");
@@ -28,6 +44,7 @@ for (const dir of readdirSync(pkgsDir)) {
   pkg.license = "MIT";
   pkg.repository = { type: "git", url: REPO_URL, directory: `packages/${dir}` };
   pkg.publishConfig = { access: "public" };
+  if (DESCRIPTIONS[pkg.name]) pkg.description = DESCRIPTIONS[pkg.name];
 
   const version = pkg.version || "0.1.0";
   for (const key of ["dependencies", "devDependencies", "peerDependencies"]) {
@@ -38,8 +55,13 @@ for (const dir of readdirSync(pkgsDir)) {
     }
   }
 
-  if (!Array.isArray(pkg.files)) pkg.files = ["dist"];
-  else if (!pkg.files.includes("dist")) pkg.files = ["dist", ...pkg.files];
+  // build guard: npm pack/publish always rebuilds dist first → never ship an empty tarball
+  pkg.scripts = { ...(pkg.scripts || {}), prepack: "npm run build" };
+
+  // ship only the compiled output + LICENSE (+ schema where present); excludes tsbuildinfo
+  const files = ["dist/src", "LICENSE"];
+  if (existsSync(path.join(pkgsDir, dir, "schema"))) files.splice(1, 0, "schema");
+  pkg.files = files;
 
   writeFileSync(file, JSON.stringify(pkg, null, 2) + "\n");
   console.log(`prepped ${pkg.name}@${version}`);

--- a/scripts/prep-publish.mjs
+++ b/scripts/prep-publish.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// One-shot publish-prep for the @murmurv2/* workspace packages: makes each package
+// publishable to the public npm registry without changing its name. Idempotent.
+//   - drop `private: true`
+//   - set license: "MIT" + repository (with directory) + publishConfig.access=public
+//   - rewrite intra-workspace `@murmurv2/*` deps (file:../x or pinned) to `^<version>`
+//     so a consumer `npm install` resolves them from the registry, not a local path
+//   - ensure `files` ships `dist` (and keeps anything already declared, e.g. core/schema)
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const REPO_URL = "git+https://github.com/alexfrmn/mur-mur-v2.git";
+const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+const pkgsDir = path.join(root, "packages");
+
+for (const dir of readdirSync(pkgsDir)) {
+  const file = path.join(pkgsDir, dir, "package.json");
+  let pkg;
+  try {
+    if (!statSync(file).isFile()) continue;
+    pkg = JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    continue;
+  }
+  if (!pkg.name) continue;
+
+  delete pkg.private;
+  pkg.license = "MIT";
+  pkg.repository = { type: "git", url: REPO_URL, directory: `packages/${dir}` };
+  pkg.publishConfig = { access: "public" };
+
+  const version = pkg.version || "0.1.0";
+  for (const key of ["dependencies", "devDependencies", "peerDependencies"]) {
+    const deps = pkg[key];
+    if (!deps) continue;
+    for (const name of Object.keys(deps)) {
+      if (name.startsWith("@murmurv2/")) deps[name] = `^${version}`;
+    }
+  }
+
+  if (!Array.isArray(pkg.files)) pkg.files = ["dist"];
+  else if (!pkg.files.includes("dist")) pkg.files = ["dist", ...pkg.files];
+
+  writeFileSync(file, JSON.stringify(pkg, null, 2) + "\n");
+  console.log(`prepped ${pkg.name}@${version}`);
+}

--- a/scripts/publish-all.mjs
+++ b/scripts/publish-all.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Publish all @murmurv2/* packages to npm in dependency (topological) order.
+// Safety: root-build first, then for each package assert its packed tarball actually
+// contains dist/src/index.js + dist/src/index.d.ts BEFORE publishing (npm versions are
+// immutable — never publish an empty/broken tarball). Auth comes from ~/.npmrc; pass an
+// OTP via `--otp=<code>` or NPM_OTP env if the token is not 2FA-bypass.
+import { execFileSync } from "node:child_process";
+
+// topo order (deps before dependents); independent leaves anywhere.
+const ORDER = [
+  "@murmurv2/security",
+  "@murmurv2/core",
+  "@murmurv2/observability",
+  "@murmurv2/bridge-murmur",
+  "@murmurv2/federation",
+  "@murmurv2/broker-nats",
+  "@murmurv2/bridge-openclaw",
+  "@murmurv2/bridge-telegram",
+  "@murmurv2/mcp-server",
+  "@murmurv2/bridge-a2a",
+  "@murmurv2/federation-nats",
+];
+
+const otpArg = (process.argv.find((a) => a.startsWith("--otp=")) || "").slice(6) || process.env.NPM_OTP || "";
+const run = (args) => execFileSync("npm", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+
+console.log("== root build ==");
+run(["run", "build"]);
+
+for (const name of ORDER) {
+  // assert the tarball is non-empty (contains compiled entry) before the irreversible publish
+  const dry = run(["pack", "--workspace", name, "--dry-run", "--json"]);
+  const files = JSON.parse(dry)[0]?.files?.map((f) => f.path) ?? [];
+  const hasJs = files.includes("dist/src/index.js");
+  const hasDts = files.includes("dist/src/index.d.ts");
+  if (!hasJs || !hasDts) {
+    console.error(`ABORT ${name}: tarball missing dist/src/index.{js,d.ts} (${files.join(", ")})`);
+    process.exit(1);
+  }
+  const args = ["publish", "--workspace", name, "--access", "public"];
+  if (otpArg) args.push(`--otp=${otpArg}`);
+  try {
+    run(args);
+    console.log(`OK   ${name}`);
+  } catch (err) {
+    const msg = (err.stderr || err.stdout || String(err)).split("\n").find((l) => /error/i.test(l)) || String(err);
+    console.error(`FAIL ${name}: ${msg}`);
+    process.exit(1);
+  }
+}
+console.log("== all published ==");


### PR DESCRIPTION
Makes the **11 workspace packages** publishable to the public npm registry **without renaming** (keeps @murmurv2/*). Closes the *npm package publishing* Planned item (prep half; the actual publish runs after merge with Alex's token).

## What
- drop `private:true`; add `license:MIT` + `repository`(+directory) + `publishConfig.access=public`
- rewrite intra-workspace `@murmurv2/*` deps `file:../x`→`^0.1.0` so consumer `npm install` resolves from the registry
- ship `dist` + `LICENSE` (copied into each package) via `files[]`; core also ships `schema/`
- `scripts/prep-publish.mjs` — idempotent prep tool

## Dry-run verified
`npm pack --dry-run` on core + federation-nats: tarballs contain LICENSE + dist + package.json (+ core schema/protocol-v1.schema.json); `@murmurv2/*` deps pinned `^0.1.0`.

## Publish plan (after merge)
Needs (Alex): npm org **murmurv2** created + an **Automation token** in `npm.env`. Then I publish in dependency order: core, security → broker-nats, federation → federation-nats, mcp-server, bridges → observability. `npm publish --access public` per package.

## Notes / review ask (CODEX)
- All 11 published incl. stubs (Alex chose 'all 11'); honest descriptions/alpha-marking for stubs (bridge-murmur, observability, bridge-openclaw) — flag if you want stub READMEs/keywords.
- Minor: core's `dist/tsconfig.tsbuildinfo` rides along (harmless build cache); other packages are clean. Worth excluding?
- Sanity-check the `^0.1.0` range choice + the dep-order publish plan.