### PR TITLE
docs(release): v2.2.0 — npm install + published packages + current roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-06-22
+
+### Added
+
+- **Published on npm.** All `@murmurv2/*` packages are public on the npm registry @ `0.1.0` (MIT), under the `murmurv2` org. Publish tooling: `scripts/prep-publish.mjs` (private→public, license, `publishConfig`, intra-workspace `file:`→`^0.1.0`, per-package `prepack` build guard, `files: dist/src + LICENSE`) and `scripts/publish-all.mjs` (root build → topological order → per-tarball assertion that `dist/src/index.{js,d.ts}` exist → publish). `@murmurv2/broker-ws` ships in the next release.
+- **WebSocket transport adapter** — `@murmurv2/broker-ws`: relay server + broker client with envelope delivery, ACK correlation, dedupe, and invalid-envelope NACKs, reusing the core primitives. Browser/edge deployment examples pending.
+- **Roster-backed auth tokens** — `@murmurv2/federation`: `signAuthToken`/`verifyAuthToken` issue Ed25519-signed tokens with audience, scopes, and `nbf`/`exp` windows; the issuer verify key is resolved from the verified roster (no embedded trust root).
+- **`RosterStore`** — `@murmurv2/federation`: pinned-key trust + monotonic-version replay guard (rejects stale/downgraded rosters) + trust-epoch reset on key rotation.
+- **Machine-readable protocol schema + conformance** — `@murmurv2/core/schema/protocol-v1.schema.json` (Draft 2020-12; root validates `EnvelopeV1`, `#/$defs/AckV1` for acks) + `docs/protocol-compatibility.md` matrix; the conformance suite asserts the schema and `isEnvelopeV1` agree on every accept/reject.
+- **Federation live interop (in isolation)** — cross-org sealed+signed delivery proven over real NATS accounts and a leaf-node topology with least-privilege publish/subscribe boundaries (`packages/federation-nats/integration/`); a NATS accounts-config renderer generates each org's account contract.
+- **ACP autonomy loop** — idempotent Murmur→ACP task producer + a gated send-boundary worker client.
+
+### Changed
+
+- README, file tree, and Roadmap synced to the real state, with honest scoping for in-isolation / mock-counterpart features.
+
 ## [2.1.0] - 2026-06-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 </p>
 
 <p align="center">
+  <a href="#install">Install</a> ·
   <a href="#quick-start">Quick Start</a> ·
   <a href="#how-it-works">How It Works</a> ·
   <a href="#features">Features</a> ·
@@ -25,7 +26,8 @@
   <img src="https://github.com/alexfrmn/mur-mur-v2/actions/workflows/ci.yml/badge.svg" alt="CI" />
   <img src="https://img.shields.io/badge/node-%3E%3D22-brightgreen" alt="Node 22+" />
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License" />
-  <img src="https://img.shields.io/badge/version-2.1.0-blue" alt="version 2.1.0" />
+  <img src="https://img.shields.io/badge/version-2.2.0-blue" alt="version 2.2.0" />
+  <a href="https://www.npmjs.com/org/murmurv2"><img src="https://img.shields.io/npm/v/@murmurv2/core" alt="npm @murmurv2/core" /></a>
   <img src="https://img.shields.io/badge/transport-core_NATS_%2B_SQLite_outbox-purple" alt="core NATS plus SQLite outbox" />
   <img src="https://img.shields.io/badge/durability-optional_JetStream-teal" alt="optional JetStream durability" />
   <img src="https://img.shields.io/badge/crypto-XChaCha20--Poly1305-orange" alt="E2E Encrypted" />
@@ -45,14 +47,37 @@ A **murmuration** is one of nature's most extraordinary phenomena — thousands 
 
 ---
 
-## What's New in v2.1
+## What's New in v2.2
 
+- **Published on npm.** All packages are public under the [`@murmurv2`](https://www.npmjs.com/org/murmurv2) scope (MIT) — `npm install @murmurv2/core` (and the rest). See [Install](#install).
+- **WebSocket transport adapter.** `@murmurv2/broker-ws` — relay + broker client with envelope delivery, ACK correlation, dedupe, and invalid-envelope NACKs (browser/edge deployment pending).
+- **Roster-backed auth tokens.** Signed audience/scope/time-windowed tokens verified against the federation roster (no embedded trust root) — `@murmurv2/federation`.
+- **Machine-readable protocol schema + conformance suite.** Draft 2020-12 JSON Schema for `EnvelopeV1`/`AckV1` (`@murmurv2/core/schema`) + a compatibility matrix; conformance tests keep the schema and the runtime guard in lock-step.
 - **Durable JetStream transport (opt-in).** Turn on at-least-once durability with NATS JetStream — finite redelivery (`max_deliver`), explicit ACK, dead-letter on exhaustion — while keeping the SQLite outbox as the transactional source of truth. Default-OFF; set `MURMUR_JETSTREAM=1` to enable.
 - **Federation (live-proven in isolation; no real partner yet).** `org/agentId` addressing, an Ed25519-signed key directory, a `fed.*` NATS leaf-node/account contract, a `RosterStore` (pinned-key trust + monotonic-version replay guard), and an account-config renderer. Proven end-to-end against a **real local NATS mesh** — cross-org sealed+signed delivery on isolated accounts, the same over a **leaf-node topology** (org-per-server), and least-privilege publish/subscribe boundaries. Still **not wired to a second real partner org** (the only remaining gate).
 - **A2A bridge (live client round-trip; mock internal counterpart).** A bridge against the industry-standard [A2A protocol](https://a2aproject.github.io/A2A/). A **real `@a2a-js/sdk` client → bridge → NATS → reply** round-trip is proven over HTTP (against a mock internal agent), and Agent-Card transport discovery is fixed. Still **not connected to a real remote A2A agent**.
 - **Native wake.** This repo ships **live-session** wake — Claude asyncRewake, Codex app-server UDS, self-healing thread re-seed (`WakeMonitor`). **Always-on wake into a *dead* session** is provided by an **out-of-repo cold-start sidecar in the reference Codex deployment** (spawn-on-inbound → fresh `codex exec` per message batch, under a linger-enabled systemd user service); a repo-shipped version and the strict no-live-session proof are still pending.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full list.
+
+## Install
+
+All packages are published on npm under the [`@murmurv2`](https://www.npmjs.com/org/murmurv2) scope (MIT):
+
+```bash
+# core types + SQLite stores, crypto, MCP server
+npm install @murmurv2/core @murmurv2/security @murmurv2/mcp-server
+
+# transports
+npm install @murmurv2/broker-nats   # NATS core + optional JetStream durability
+npm install @murmurv2/broker-ws     # WebSocket relay/client
+
+# federation + bridges
+npm install @murmurv2/federation @murmurv2/federation-nats
+npm install @murmurv2/bridge-a2a @murmurv2/bridge-telegram
+```
+
+Prefer to run the full mesh from source? See [Quick Start](#quick-start).
 
 ## The Problem
 
@@ -439,8 +464,8 @@ See [protocol-v1.md](docs/protocol-v1.md) for the full specification.
 - [ ] **Auth/authz token model** — roster-backed signed tokens with audience/scope/time verification are coded and unit-tested; remaining gate: wire token enforcement into live transports/bridges
 - [ ] **WebSocket transport adapter** — relay + broker client are coded and unit-tested for envelope delivery, ACK correlation, dedupe, and invalid-envelope NACKs; remaining gate: browser/edge deployment examples and hardening
 - [x] Prometheus metrics exporter — outbox depth, delivery latency, error rates
-- [ ] npm package publishing — `@murmurv2/*` on npm registry
-- [ ] NATS native request-reply — replace polling with ephemeral inbox subjects
+- [x] **npm package publishing** — all `@murmurv2/*` packages published public on npm @ `0.1.0` (MIT); `@murmurv2/broker-ws` ships in the next release
+- [ ] NATS native request-reply — replace polling with ephemeral inbox subjects (design locked: read-only ephemeral subscription accelerates the wait, SQLite outbox stays source of truth)
 
 ### Planned (next wave)
 - [ ] Message streaming — large payload chunking with backpressure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mur-mur-v2",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mur-mur-v2",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mur-mur-v2",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Reliable secure multi-agent messaging core",
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
Brings README + CHANGELOG to the real current state after this release wave.

- **README:** 'What's New in v2.2' (npm publish headline, WebSocket transport, roster-backed auth tokens, machine-readable protocol schema); new **Install** section (`npm i @murmurv2/*`); nav + 2.2.0 version badge + npm badge; Roadmap: npm publishing → done, native-request-reply design note.
- **CHANGELOG:** [2.2.0] entry — npm publish + publish tooling, `broker-ws`, auth tokens, `RosterStore`, protocol schema + conformance, federation live-in-isolation, ACP loop.
- root version 2.1.0 → 2.2.0; lock synced.

Docs-only (no code). All @murmurv2/* are live on npm @ 0.1.0; broker-ws ships next release.
@CODEX-VOLT quick sanity-check welcome (esp. any over-claim vs reality).