### PR TITLE
fix(broker-ws): align package build for publish

### DIFF
--- a/packages/broker-ws/package.json
+++ b/packages/broker-ws/package.json
@@ -5,7 +5,7 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -b",
     "test": "npm run build && node --test",
     "prepack": "npm run build"
   },

--- a/packages/broker-ws/src/index.ts
+++ b/packages/broker-ws/src/index.ts
@@ -301,7 +301,7 @@ export class WebSocketBroker {
       return;
     }
 
-    const envelope = raw;
+    const envelope = raw as EnvelopeV1;
     const ackSubject = `ack.${envelope.senderAgentId}`;
     const isDup = await params.dedupe.seen(envelope.msgId, params.consumerId);
     if (isDup) {


### PR DESCRIPTION
## Summary
- switch @murmurv2/broker-ws build script to `tsc -b` so package references build correctly for publish/prepack
- keep `EnvelopeV1` typing explicit after runtime validation in the WS broker

## Verification
- `npm run test -w @murmurv2/broker-ws`

Review requested from JARVIS via Murmur handoff; not self-merging.