### PR TITLE
feat(mcp-server): wake-accelerated native request-reply (design B)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,6 +1862,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@murmurv2/broker-nats": "^0.1.0",
         "@murmurv2/core": "^0.1.0",
         "@murmurv2/security": "^0.1.0"
       }

--- a/packages/broker-nats/dist/src/index.d.ts
+++ b/packages/broker-nats/dist/src/index.d.ts
@@ -62,6 +62,19 @@ export declare class NatsBroker {
         onMessage: MessageHandler;
         maxPoisonAttempts?: number;
     }): Promise<BrokerSubscription>;
+    /**
+     * Read-only real-time tap on a subject. Plain core subscription — no queue
+     * group, no ACK publish, no dedupe, no JetStream consumer. A plain subscriber
+     * still receives `js.publish`'d messages in real time, so this works whether
+     * or not JetStream is enabled, and it never steals delivery from the durable
+     * daemon consumer (which uses its own consumerId / queue semantics).
+     *
+     * Intended as a wake-signal source: `onEnvelope` receives the decoded
+     * envelope METADATA only (conversationId, senderAgentId, msgId). It does NOT
+     * decrypt the payload — decryption stays the daemon's responsibility. Malformed
+     * frames are ignored (best-effort signal, not a delivery path).
+     */
+    subscribeRaw(subject: string, onEnvelope: (envelope: EnvelopeV1) => void): Promise<BrokerSubscription>;
     startAckCorrelation(params: {
         outbox: OutboxStore;
         ackSubject: string;

--- a/packages/broker-nats/dist/src/index.js
+++ b/packages/broker-nats/dist/src/index.js
@@ -279,6 +279,38 @@ export class NatsBroker {
         });
         return sub;
     }
+    /**
+     * Read-only real-time tap on a subject. Plain core subscription — no queue
+     * group, no ACK publish, no dedupe, no JetStream consumer. A plain subscriber
+     * still receives `js.publish`'d messages in real time, so this works whether
+     * or not JetStream is enabled, and it never steals delivery from the durable
+     * daemon consumer (which uses its own consumerId / queue semantics).
+     *
+     * Intended as a wake-signal source: `onEnvelope` receives the decoded
+     * envelope METADATA only (conversationId, senderAgentId, msgId). It does NOT
+     * decrypt the payload — decryption stays the daemon's responsibility. Malformed
+     * frames are ignored (best-effort signal, not a delivery path).
+     */
+    async subscribeRaw(subject, onEnvelope) {
+        await this.connect();
+        const sub = this.nc.subscribe(subject);
+        (async () => {
+            for await (const m of sub) {
+                try {
+                    const decoded = JSON.parse(this.sc.decode(m.data));
+                    if (isEnvelopeV1(decoded))
+                        onEnvelope(decoded);
+                }
+                catch {
+                    // ignore malformed frames — read-only wake signal, not a delivery path
+                }
+            }
+        })().catch((err) => {
+            const e = err instanceof Error ? err : new Error(String(err));
+            console.error("[NatsBroker.subscribeRaw] loop crashed", { subject, message: e.message, stack: e.stack });
+        });
+        return sub;
+    }
     async startAckCorrelation(params) {
         await this.connect();
         if (this.js) {

--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -374,6 +374,42 @@ export class NatsBroker {
     return sub;
   }
 
+  /**
+   * Read-only real-time tap on a subject. Plain core subscription — no queue
+   * group, no ACK publish, no dedupe, no JetStream consumer. A plain subscriber
+   * still receives `js.publish`'d messages in real time, so this works whether
+   * or not JetStream is enabled, and it never steals delivery from the durable
+   * daemon consumer (which uses its own consumerId / queue semantics).
+   *
+   * Intended as a wake-signal source: `onEnvelope` receives the decoded
+   * envelope METADATA only (conversationId, senderAgentId, msgId). It does NOT
+   * decrypt the payload — decryption stays the daemon's responsibility. Malformed
+   * frames are ignored (best-effort signal, not a delivery path).
+   */
+  async subscribeRaw(
+    subject: string,
+    onEnvelope: (envelope: EnvelopeV1) => void,
+  ): Promise<BrokerSubscription> {
+    await this.connect();
+    const sub = this.nc!.subscribe(subject);
+
+    (async () => {
+      for await (const m of sub) {
+        try {
+          const decoded = JSON.parse(this.sc.decode(m.data));
+          if (isEnvelopeV1(decoded)) onEnvelope(decoded);
+        } catch {
+          // ignore malformed frames — read-only wake signal, not a delivery path
+        }
+      }
+    })().catch((err) => {
+      const e = err instanceof Error ? err : new Error(String(err));
+      console.error("[NatsBroker.subscribeRaw] loop crashed", { subject, message: e.message, stack: e.stack });
+    });
+
+    return sub;
+  }
+
   async startAckCorrelation(params: {
     outbox: OutboxStore;
     ackSubject: string;

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -9,6 +9,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
+    "@murmurv2/broker-nats": "^0.1.0",
     "@murmurv2/core": "^0.1.0",
     "@murmurv2/security": "^0.1.0"
   },

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -9,6 +9,8 @@ import {
   type LocalMessageRecord,
 } from "@murmurv2/core";
 import { encryptPayload, signEnvelope } from "@murmurv2/security";
+import { NatsBroker, type BrokerSubscription } from "@murmurv2/broker-nats";
+import { buildReplyMatcher, waitForReply } from "./request-reply.js";
 
 interface JsonRpcRequest {
   jsonrpc: "2.0";
@@ -56,6 +58,28 @@ let outbox: SQLiteDedupeOutboxStore | null = null;
 if (agentConfig) {
   outbox = new SQLiteDedupeOutboxStore(dbPath);
 }
+
+// Lazy read-only NATS tap for wake-accelerated murmur_request. Optional — if NATS is
+// unreachable we degrade gracefully to pure store polling (initialized at most once).
+let wakeBroker: NatsBroker | null = null;
+let wakeBrokerInit = false;
+const getWakeBroker = async (): Promise<NatsBroker | null> => {
+  if (!agentConfig) return null;
+  if (wakeBrokerInit) return wakeBroker;
+  wakeBrokerInit = true;
+  try {
+    const broker = new NatsBroker({
+      url: agentConfig.natsUrl,
+      token: agentConfig.natsToken,
+      jetstream: false,
+    });
+    await broker.connect();
+    wakeBroker = broker;
+  } catch {
+    wakeBroker = null; // graceful degrade — store polling still resolves the reply
+  }
+  return wakeBroker;
+};
 
 // --- Stable envelope payload for signing ---
 const stableEnvelopePayload = (envelope: EnvelopeV1): string => {
@@ -263,17 +287,58 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
       transport: "nats",
     });
 
-    // Poll for response
+    // Wait for the reply. Store polling is the durable fallback and always runs;
+    // an optional read-only NATS tap on our own subject accelerates the wait by
+    // re-checking the store as soon as a matching envelope is observed. The tap is
+    // signal-only — the daemon stays the source of truth for decrypt + persistence.
+    const graceMs = Number(args.grace_ms ?? 250);
     const deadline = Date.now() + timeoutMs;
-    let reply: LocalMessageRecord | null = null;
+    const matchReply = buildReplyMatcher(conversationId, to);
 
-    while (Date.now() < deadline) {
-      const inbound = await store.getInboundAfter(conversationId, sentAt, 1);
-      if (inbound.length > 0) {
-        reply = inbound[0];
-        break;
+    const broker = await getWakeBroker();
+    // Holder object: the tap is attached inside a callback, so a plain `let` would be
+    // narrowed to `null` by control-flow analysis. A mutable property keeps its type.
+    const tap: { attach: Promise<void> | null; sub: BrokerSubscription | null } = {
+      attach: null,
+      sub: null,
+    };
+    let onSignal: ((wake: () => void) => void) | undefined;
+    if (broker) {
+      onSignal = (wake) => {
+        tap.attach = broker
+          .subscribeRaw(agentConfig!.subject, (env) => {
+            if (matchReply(env)) wake();
+          })
+          .then((sub) => {
+            tap.sub = sub;
+          })
+          .catch(() => {
+            /* tap failed to attach — store polling still resolves the reply */
+          });
+      };
+    }
+
+    let reply: LocalMessageRecord | null = null;
+    try {
+      reply = await waitForReply({
+        checkStore: async () => {
+          const inbound = await store.getInboundAfter(conversationId, sentAt, 1);
+          return inbound.length > 0 ? inbound[0] : null;
+        },
+        pollMs,
+        graceMs,
+        deadline,
+        onSignal,
+      });
+    } finally {
+      if (tap.attach) await tap.attach;
+      if (tap.sub) {
+        try {
+          await tap.sub.unsubscribe();
+        } catch {
+          /* ignore unsubscribe errors */
+        }
       }
-      await new Promise((r) => setTimeout(r, pollMs));
     }
 
     if (reply) {
@@ -283,6 +348,7 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
         conversationId,
         sentAt,
         reply: asMessage(reply),
+        accelerated: !!broker,
       };
     }
 
@@ -366,7 +432,7 @@ const tools = [
   {
     name: "murmur_request",
     description:
-      "Send a message and wait for the reply. Combines murmur_send + automatic polling — the tool blocks until the peer responds or timeout is reached. Ideal for autonomous agent-to-agent conversations.",
+      "Send a message and wait for the reply. Combines murmur_send with a durable store-poll, accelerated by a read-only NATS tap so the reply is returned as soon as it lands (falls back to pure polling when NATS is unavailable). The tool blocks until the peer responds or timeout is reached. Ideal for autonomous agent-to-agent conversations.",
     inputSchema: {
       type: "object",
       properties: {
@@ -374,7 +440,8 @@ const tools = [
         text: { type: "string", description: "Message text (will be encrypted)" },
         conversationId: { type: "string", description: "Optional conversation ID" },
         timeout_ms: { type: "number", description: "Max wait time in ms (default: 300000 = 5 min)" },
-        poll_interval_ms: { type: "number", description: "Poll interval in ms (default: 10000 = 10s)" },
+        poll_interval_ms: { type: "number", description: "Store-poll fallback interval in ms (default: 10000 = 10s)" },
+        grace_ms: { type: "number", description: "Delay after a wake signal before re-checking the store, to let the daemon persist (default: 250)" },
       },
       required: ["to", "text"],
     },

--- a/packages/mcp-server/src/request-reply.ts
+++ b/packages/mcp-server/src/request-reply.ts
@@ -1,0 +1,87 @@
+import type { LocalMessageRecord } from "@murmurv2/core";
+
+/**
+ * Pure wait-loop for the request/reply ("native-request-reply") flow.
+ *
+ * Design B (locked with CODEX-VOLT):
+ * - The outbox stays the source of truth: sending happens elsewhere, this only WAITS.
+ * - Store polling is the durable fallback and ALWAYS runs, so a reply is found even
+ *   when no live wake signal is available (NATS down / `onSignal` omitted).
+ * - An optional `onSignal` source (a read-only NATS tap on the agent's own subject)
+ *   accelerates the wait: when a matching envelope arrives we re-check the store
+ *   immediately instead of waiting out the poll interval. The signal NEVER carries
+ *   the reply itself — decryption + persistence stay the daemon's job — it only nudges
+ *   us to re-poll the store the daemon writes into.
+ *
+ * Lost-wakeup safety: the wake promise is armed BEFORE each store check, so a signal
+ * that fires between the check and the race still short-circuits the wait.
+ */
+export interface ReplyWaiterDeps {
+  /** Return the reply record if one has arrived, else null. */
+  checkStore: () => Promise<LocalMessageRecord | null>;
+  /** Poll interval in ms (fallback cadence when no signal fires). */
+  pollMs: number;
+  /** Grace delay in ms after a signal, to let the daemon persist before re-checking. */
+  graceMs: number;
+  /** Absolute deadline as epoch ms (Date.now()-style). */
+  deadline: number;
+  /**
+   * Optional wake-signal registration. Called once with a callback; invoke the
+   * callback whenever a relevant inbound envelope is observed. Omit for pure-poll.
+   */
+  onSignal?: (wake: () => void) => void;
+  /** Injectable clock (tests). Defaults to Date.now. */
+  now?: () => number;
+  /** Injectable sleep (tests). Defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export async function waitForReply(deps: ReplyWaiterDeps): Promise<LocalMessageRecord | null> {
+  const now = deps.now ?? (() => Date.now());
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  let signaled = false;
+  let wakeResolve: (() => void) | null = null;
+
+  if (deps.onSignal) {
+    deps.onSignal(() => {
+      signaled = true;
+      wakeResolve?.();
+    });
+  }
+
+  while (now() < deps.deadline) {
+    // Arm the wake BEFORE checking the store to avoid a lost wakeup: a signal that
+    // fires while checkStore() is in flight still resolves this promise.
+    signaled = false;
+    const wake = new Promise<void>((resolve) => {
+      wakeResolve = resolve;
+    });
+
+    const found = await deps.checkStore();
+    if (found) return found;
+
+    const remaining = deps.deadline - now();
+    if (remaining <= 0) break;
+
+    const waitMs = Math.min(deps.pollMs, remaining);
+    await Promise.race([wake, sleep(waitMs)]);
+
+    if (signaled) {
+      const graceRemaining = deps.deadline - now();
+      if (graceRemaining > 0) await sleep(Math.min(deps.graceMs, graceRemaining));
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build a predicate that matches an inbound envelope as the awaited reply:
+ * same conversation AND sent by the peer we are waiting on. Envelope metadata is
+ * plaintext (conversationId / senderAgentId), so this needs no decryption.
+ */
+export const buildReplyMatcher =
+  (conversationId: string, fromAgentId: string) =>
+  (envelope: { conversationId: string; senderAgentId: string }): boolean =>
+    envelope.conversationId === conversationId && envelope.senderAgentId === fromAgentId;

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -12,10 +12,11 @@
     "types": ["node"],
     "baseUrl": ".",
     "paths": {
+      "@murmurv2/broker-nats": ["../broker-nats/src/index.ts"],
       "@murmurv2/core": ["../core/src/index.ts"],
       "@murmurv2/security": ["../security/src/index.ts"]
     }
   },
   "include": ["src"],
-  "references": [{ "path": "../core" }, { "path": "../security" }]
+  "references": [{ "path": "../broker-nats" }, { "path": "../core" }, { "path": "../security" }]
 }

--- a/tests/mcp-request-reply.test.mjs
+++ b/tests/mcp-request-reply.test.mjs
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildReplyMatcher,
+  waitForReply,
+} from "../packages/mcp-server/dist/src/request-reply.js";
+
+const reply = (msgId) => ({
+  id: msgId,
+  conversationId: "conv-1",
+  msgId,
+  direction: "inbound",
+  sender: "agent.b",
+  text: "pong",
+  createdAt: new Date().toISOString(),
+  transport: "nats",
+});
+
+// --- buildReplyMatcher -------------------------------------------------------
+
+test("buildReplyMatcher matches same conversation + peer, rejects others", () => {
+  const match = buildReplyMatcher("conv-1", "agent.b");
+  assert.equal(match({ conversationId: "conv-1", senderAgentId: "agent.b" }), true);
+  assert.equal(match({ conversationId: "conv-1", senderAgentId: "agent.c" }), false);
+  assert.equal(match({ conversationId: "conv-2", senderAgentId: "agent.b" }), false);
+});
+
+// --- A: durability when live-wait is OFF (pure store polling, no signal) ------
+
+test("A: resolves via store-poll fallback when no wake signal is wired", async () => {
+  let calls = 0;
+  const res = await waitForReply({
+    checkStore: async () => (++calls >= 2 ? reply("r-poll") : null),
+    pollMs: 20,
+    graceMs: 5,
+    deadline: Date.now() + 2000,
+    // onSignal intentionally omitted — proves durability without NATS
+  });
+  assert.equal(res?.msgId, "r-poll");
+  assert.ok(calls >= 2, `expected >=2 store checks, got ${calls}`);
+});
+
+// --- B: timeout returns null (caller maps to status:timeout) ------------------
+
+test("B: returns null on timeout when no reply ever lands", async () => {
+  let calls = 0;
+  const res = await waitForReply({
+    checkStore: async () => {
+      calls++;
+      return null;
+    },
+    pollMs: 20,
+    graceMs: 5,
+    deadline: Date.now() + 120,
+  });
+  assert.equal(res, null);
+  assert.ok(calls >= 2, `expected several poll attempts, got ${calls}`);
+});
+
+// --- C: wake signal accelerates the wait past a long poll interval ------------
+
+test("C: a wake signal resolves the reply faster than the poll interval", async () => {
+  let calls = 0;
+  let fired = false;
+  const start = Date.now();
+  const res = await waitForReply({
+    checkStore: async () => (++calls >= 2 ? reply("r-signal") : null),
+    pollMs: 10_000, // a pure poll would never re-check within the deadline
+    graceMs: 5,
+    deadline: Date.now() + 1000,
+    onSignal: (wake) => {
+      setTimeout(() => {
+        fired = true;
+        wake();
+      }, 30);
+    },
+  });
+  const elapsed = Date.now() - start;
+  assert.equal(res?.msgId, "r-signal");
+  assert.ok(fired, "wake signal should have fired");
+  assert.ok(elapsed < 500, `signal path should resolve fast, took ${elapsed}ms`);
+});
+
+test("C2: without a signal the same long-poll setup times out", async () => {
+  let calls = 0;
+  const res = await waitForReply({
+    checkStore: async () => (++calls >= 2 ? reply("never") : null),
+    pollMs: 10_000,
+    graceMs: 5,
+    deadline: Date.now() + 150, // shorter than poll interval → only one check
+  });
+  assert.equal(res, null);
+});
+
+// --- D: lost-wakeup safety (signal fires DURING the store check) --------------
+
+test("D: signal fired during checkStore is not lost (armed before check)", async () => {
+  let calls = 0;
+  let wakeCb = null;
+  const res = await waitForReply({
+    checkStore: async () => {
+      calls++;
+      if (calls === 1 && wakeCb) wakeCb(); // fire after arm, before the race
+      return calls >= 2 ? reply("r-lostwake") : null;
+    },
+    pollMs: 10_000,
+    graceMs: 5,
+    deadline: Date.now() + 1000,
+    onSignal: (wake) => {
+      wakeCb = wake;
+    },
+  });
+  assert.equal(res?.msgId, "r-lostwake");
+  assert.equal(calls, 2);
+});


### PR DESCRIPTION
## What

Implements **native request-reply (design B)** for `murmur_request`: an optional read-only NATS tap that returns the reply as soon as a matching envelope is observed, instead of waiting out the store-poll interval.

Closes the Planned roadmap item "NATS native request-reply (JARVIS)".

## How

- **`broker-nats`: `subscribeRaw(subject, onEnvelope)`** — plain `nc.subscribe`, **no ACK / no dedupe / no JetStream consumer**. A plain subscriber receives `js.publish`'d messages in real time and (no queue group) never steals delivery from the durable daemon consumer. Malformed frames ignored — it's a wake signal, not a delivery path.
- **`mcp-server`: `waitForReply()`** — pure, injectable wait-loop. Store polling always runs (durable fallback); an optional `onSignal` source short-circuits the wait. **Arm-before-check** guards against lost wakeups.
- **`mcp-server` `murmur_request`** — lazy ephemeral broker (`jetstream:false`, `try/catch → null` graceful degrade to pure polling). The tap reads only envelope **metadata** (`conversationId`, `senderAgentId`) to match the reply — **no payload decrypt**; the daemon stays the source of truth for decrypt + persistence. New optional `grace_ms` knob (default 250ms) lets the daemon persist before re-checking.

## Design B constraints (locked with CODEX-VOLT)

| Constraint | How it's met |
|---|---|
| No send outside outbox | tap is subscribe-only; sending unchanged (outbox.enqueue) |
| Store-poll stays fallback | polling always runs; signal only accelerates; null broker ⇒ pure poll |
| Decrypt = existing path | tap reads envelope metadata only; daemon decrypts + persists |
| Tests prove durability (live-wait off / timeout) | see tests below |

## Tests

`tests/mcp-request-reply.test.mjs` (pure, real timers, deterministic):
- **A** resolves via store-poll fallback when no signal is wired (durability, live-wait off)
- **B** returns null on timeout
- **C / C2** signal accelerates past a long poll interval; without it, times out
- **D** lost-wakeup safety (signal fired *during* the store check)
- `buildReplyMatcher` unit

Full suite green: `npm test` → unit **63 pass**, core 6, a2a 6, broker-ws 4, federation 24, ws4/ws5/notify smoke ok. Build `tsc -b` clean.

## For review (CODEX-VOLT)

1. **New dep**: `@murmurv2/broker-nats` added to `mcp-server` (for `NatsBroker` tap). Acceptable, or prefer raw `nats`? broker-nats felt cleaner.
2. **Heads-up**: `packages/broker-nats/dist` is **tracked** (force-added earlier; every other package's dist is gitignored). I kept it in sync with src in this PR. Worth a separate cleanup (`git rm --cached` to match the others)?
3. Ephemeral broker is a lazy singleton, never explicitly closed (drains on process exit). OK for the long-lived stdio mcp-server, or add a shutdown path?