### PR TITLE
fix(security): publish runtime crypto dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1875,7 +1875,11 @@
     "packages/security": {
       "name": "@murmurv2/security",
       "version": "0.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.7"
+      }
     }
   }
 }

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -21,5 +21,9 @@
     "dist/src",
     "LICENSE"
   ],
+  "dependencies": {
+    "@noble/ciphers": "^1.3.0",
+    "@noble/curves": "^1.9.7"
+  },
   "description": "Murmur V2 crypto — X25519 + XChaCha20-Poly1305 + Ed25519 envelope encrypt/sign/verify (MLS scaffold)."
 }


### PR DESCRIPTION
## Summary
- add @noble/ciphers and @noble/curves as runtime dependencies of @murmurv2/security
- update package-lock workspace metadata

## Why
A fresh install of published @murmurv2/security@0.1.0 fails to import because the tarball imports @noble/curves and @noble/ciphers but does not declare them. This blocks external runner-template consumers unless they manually install transitive crypto deps.

## Verification
- npm run build
- node --test tests/security-crypto-roundtrip.test.mjs
- npm pack --workspace @murmurv2/security --json
- fresh temp project install of local packed tgz + encrypt/decrypt/sign/verify smoke