### PR TITLE
fix(security,observability): declare missing runtime deps (republish 0.1.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1869,13 +1869,20 @@
     },
     "packages/observability": {
       "name": "@murmurv2/observability",
-      "version": "0.1.0",
-      "license": "MIT"
+      "version": "0.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "^12.6.2"
+      }
     },
     "packages/security": {
       "name": "@murmurv2/security",
-      "version": "0.1.0",
-      "license": "MIT"
+      "version": "0.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.7"
+      }
     }
   }
 }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,12 +1,15 @@
 {
   "name": "@murmurv2/observability",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "prepack": "npm run build"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.6.2"
   },
   "license": "MIT",
   "repository": {

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@murmurv2/security",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "prepack": "npm run build"
+  },
+  "dependencies": {
+    "@noble/ciphers": "^1.3.0",
+    "@noble/curves": "^1.9.7"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## 🔴 Bug

While building the external **agent-runner** template, an honest external-consumer smoke test (`npm install @murmurv2/*` in a clean dir outside the workspace, exactly as a third party like Stas would) caught two published `0.1.0` packages that **declare empty `dependencies` but import third-party modules**. In-repo they resolved only via workspace hoisting; standalone they crash:

```
ERR_MODULE_NOT_FOUND: Cannot find package '@noble/curves'
  imported from @murmurv2/security/dist/src/index.js
```

Full audit of all 12 packages (imports vs declared deps):

| Package | Missing |
|---|---|
| `@murmurv2/security` | `@noble/ciphers`, `@noble/curves` |
| `@murmurv2/observability` | `better-sqlite3` |

(other 10 packages: clean)

`security` is the blocker — it's a transitive dep of `mcp-server`, `federation`, `bridge-telegram`, `bridge-a2a`, and any external agent.

## Fix

- `security`: declare `@noble/ciphers@^1.3.0` + `@noble/curves@^1.9.7`, bump `0.1.0 → 0.1.1`
- `observability`: declare `better-sqlite3@^12.6.2`, bump `0.1.0 → 0.1.1`

## Verified

- `npm pack` the fixed `security` → install standalone in a clean dir → `@noble/{ciphers,curves,hashes}` resolve, and the full `encrypt/sign → decrypt/verify` round-trip passes (`decrypt match: true | sig verify: true`).
- Full suite green: `npm test` → unit 63, core 6, a2a 6, broker-ws 4, federation 24, federation-nats 10. Clean `tsc -b --force` build OK.

## Release

Needs **republish `@murmurv2/security@0.1.1` + `@murmurv2/observability@0.1.1`** after merge. Consumers on `^0.1.0` pick up `0.1.1` automatically. (This is the concrete reason for the 0.1.1 release CODEX-VOLT flagged.)