### PR TITLE
Add core streaming reassembler

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,9 +466,9 @@ See [protocol-v1.md](docs/protocol-v1.md) for the full specification.
 - [x] Prometheus metrics exporter — outbox depth, delivery latency, error rates
 - [x] **npm package publishing** — all `@murmurv2/*` packages published public on npm @ `0.1.0` (MIT); `@murmurv2/broker-ws` ships in the next release
 - [ ] NATS native request-reply — replace polling with ephemeral inbox subjects (design locked: read-only ephemeral subscription accelerates the wait, SQLite outbox stays source of truth)
+- [ ] **Message streaming PR1** — pure `@murmurv2/core` chunk payloads + in-memory reassembler with hash checks, duplicate handling, and count/byte backpressure. `streamId`/`chunkIndex` stay inside encrypted payload content; SQLite durability and NATS integration remain PR2.
 
 ### Planned (next wave)
-- [ ] Message streaming — large payload chunking with backpressure
 - [ ] Agent discovery protocol — find peers without manual invite exchange
 - [ ] Reference deployment examples — docker-compose, Kubernetes manifests
 - [ ] Conformance test suite — integration tests for third-party implementations

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,8 @@ import { mkdirSync, promises as fs } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
+export * from "./streaming.js";
+
 export type DeliveryMode = "at-least-once";
 
 export interface EnvelopeV1 {

--- a/packages/core/src/streaming.ts
+++ b/packages/core/src/streaming.ts
@@ -1,0 +1,257 @@
+import { createHash } from "node:crypto";
+
+export interface StreamChunkPayloadV1 {
+  type: "murmur.stream.chunk.v1";
+  streamId: string;
+  chunkIndex: number;
+  chunkCount: number;
+  totalBytes: number;
+  payloadBytes: number;
+  payloadBase64: string;
+  payloadSha256: string;
+  streamSha256: string;
+}
+
+export interface CreateStreamChunksOptions {
+  streamId: string;
+  maxChunkBytes: number;
+}
+
+export type StreamNackReason =
+  | "stream-chunk-invalid"
+  | "stream-chunk-hash-invalid"
+  | "stream-chunk-hash-mismatch"
+  | "stream-chunk-count-mismatch"
+  | "stream-total-bytes-mismatch"
+  | "stream-hash-mismatch"
+  | "stream-backpressure-chunks"
+  | "stream-backpressure-bytes";
+
+export type StreamAcceptResult =
+  | { status: "accepted"; streamId: string; receivedChunks: number; chunkCount: number }
+  | { status: "complete"; streamId: string; payload: Uint8Array }
+  | { status: "nack"; streamId?: string; reason: StreamNackReason };
+
+export interface StreamReassemblerOptions {
+  maxInFlightChunks?: number;
+  maxPendingBytes?: number;
+}
+
+interface PendingStream {
+  chunkCount: number;
+  totalBytes: number;
+  streamSha256: string;
+  pendingBytes: number;
+  chunks: Map<number, StreamChunkPayloadV1>;
+}
+
+interface CompletedStream {
+  payload: Uint8Array;
+  hashesByIndex: Map<number, string>;
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const sha256 = (bytes: Uint8Array): string => createHash("sha256").update(bytes).digest("hex");
+
+const toBytes = (payload: Uint8Array | string): Uint8Array => (
+  typeof payload === "string" ? encoder.encode(payload) : payload
+);
+
+const fromBase64 = (payloadBase64: string): Uint8Array => Buffer.from(payloadBase64, "base64");
+
+const validatePositiveInteger = (value: number): boolean => Number.isInteger(value) && value > 0;
+
+const validateNonNegativeInteger = (value: number): boolean => Number.isInteger(value) && value >= 0;
+
+export const createStreamChunks = (
+  payload: Uint8Array | string,
+  options: CreateStreamChunksOptions,
+): StreamChunkPayloadV1[] => {
+  if (!options.streamId) throw new Error("stream-id-required");
+  if (!validatePositiveInteger(options.maxChunkBytes)) throw new Error("max-chunk-bytes-invalid");
+
+  const bytes = toBytes(payload);
+  const chunkCount = Math.max(1, Math.ceil(bytes.byteLength / options.maxChunkBytes));
+  const streamSha256 = sha256(bytes);
+  const chunks: StreamChunkPayloadV1[] = [];
+
+  for (let index = 0; index < chunkCount; index += 1) {
+    const start = index * options.maxChunkBytes;
+    const end = Math.min(start + options.maxChunkBytes, bytes.byteLength);
+    const slice = bytes.slice(start, end);
+    chunks.push({
+      type: "murmur.stream.chunk.v1",
+      streamId: options.streamId,
+      chunkIndex: index,
+      chunkCount,
+      totalBytes: bytes.byteLength,
+      payloadBytes: slice.byteLength,
+      payloadBase64: Buffer.from(slice).toString("base64"),
+      payloadSha256: sha256(slice),
+      streamSha256,
+    });
+  }
+
+  return chunks;
+};
+
+export const streamChunksToBytes = (chunks: StreamChunkPayloadV1[]): Uint8Array => {
+  const sorted = [...chunks].sort((a, b) => a.chunkIndex - b.chunkIndex);
+  const parts = sorted.map((chunk) => fromBase64(chunk.payloadBase64));
+  const total = parts.reduce((sum, part) => sum + part.byteLength, 0);
+  const output = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.byteLength;
+  }
+  return output;
+};
+
+export const streamChunksToText = (chunks: StreamChunkPayloadV1[]): string => decoder.decode(streamChunksToBytes(chunks));
+
+export const streamPayloadVisibleEnvelopeFields = (payload: Record<string, unknown>): string[] => {
+  const visibleEnvelopeFields = [
+    "msgId",
+    "conversationId",
+    "senderAgentId",
+    "recipients",
+    "createdAt",
+    "ttlSeconds",
+    "traceId",
+    "sequence",
+    "parentMsgId",
+  ];
+  return visibleEnvelopeFields.filter((field) => field in payload);
+};
+
+export class InMemoryStreamReassembler {
+  private readonly pending = new Map<string, PendingStream>();
+  private readonly completed = new Map<string, CompletedStream>();
+  private readonly maxInFlightChunks: number;
+  private readonly maxPendingBytes: number;
+  private pendingBytes = 0;
+
+  constructor(options: StreamReassemblerOptions = {}) {
+    this.maxInFlightChunks = Math.max(1, Math.floor(options.maxInFlightChunks ?? 64));
+    this.maxPendingBytes = Math.max(1, Math.floor(options.maxPendingBytes ?? 16 * 1024 * 1024));
+  }
+
+  accept(chunk: StreamChunkPayloadV1): StreamAcceptResult {
+    const validation = this.validateChunk(chunk);
+    if (validation) return validation;
+
+    const completed = this.completed.get(chunk.streamId);
+    if (completed) {
+      const existingHash = completed.hashesByIndex.get(chunk.chunkIndex);
+      if (existingHash !== chunk.payloadSha256) {
+        return { status: "nack", streamId: chunk.streamId, reason: "stream-chunk-hash-mismatch" };
+      }
+      return { status: "complete", streamId: chunk.streamId, payload: completed.payload };
+    }
+
+    const pending = this.pending.get(chunk.streamId) ?? this.createPending(chunk);
+    const consistency = this.validateConsistency(pending, chunk);
+    if (consistency) return consistency;
+
+    const existing = pending.chunks.get(chunk.chunkIndex);
+    if (existing) {
+      if (existing.payloadSha256 !== chunk.payloadSha256) {
+        return { status: "nack", streamId: chunk.streamId, reason: "stream-chunk-hash-mismatch" };
+      }
+      return { status: "accepted", streamId: chunk.streamId, receivedChunks: pending.chunks.size, chunkCount: pending.chunkCount };
+    }
+
+    const backpressure = this.validateBackpressure(pending, chunk);
+    if (backpressure) return backpressure;
+
+    pending.chunks.set(chunk.chunkIndex, chunk);
+    pending.pendingBytes += chunk.payloadBytes;
+    this.pendingBytes += chunk.payloadBytes;
+
+    if (!this.pending.has(chunk.streamId)) this.pending.set(chunk.streamId, pending);
+    if (pending.chunks.size < pending.chunkCount) {
+      return { status: "accepted", streamId: chunk.streamId, receivedChunks: pending.chunks.size, chunkCount: pending.chunkCount };
+    }
+
+    return this.completeStream(chunk.streamId, pending);
+  }
+
+  pendingStats(): { streamCount: number; pendingChunks: number; pendingBytes: number } {
+    let pendingChunks = 0;
+    for (const stream of this.pending.values()) pendingChunks += stream.chunks.size;
+    return { streamCount: this.pending.size, pendingChunks, pendingBytes: this.pendingBytes };
+  }
+
+  private validateChunk(chunk: StreamChunkPayloadV1): StreamAcceptResult | undefined {
+    if (
+      chunk?.type !== "murmur.stream.chunk.v1" ||
+      !chunk.streamId ||
+      !validateNonNegativeInteger(chunk.chunkIndex) ||
+      !validatePositiveInteger(chunk.chunkCount) ||
+      chunk.chunkIndex >= chunk.chunkCount ||
+      !validateNonNegativeInteger(chunk.totalBytes) ||
+      !validateNonNegativeInteger(chunk.payloadBytes) ||
+      typeof chunk.payloadBase64 !== "string" ||
+      typeof chunk.payloadSha256 !== "string" ||
+      typeof chunk.streamSha256 !== "string"
+    ) {
+      return { status: "nack", streamId: chunk?.streamId, reason: "stream-chunk-invalid" };
+    }
+
+    const payload = fromBase64(chunk.payloadBase64);
+    if (payload.byteLength !== chunk.payloadBytes || sha256(payload) !== chunk.payloadSha256) {
+      return { status: "nack", streamId: chunk.streamId, reason: "stream-chunk-hash-invalid" };
+    }
+    return undefined;
+  }
+
+  private createPending(chunk: StreamChunkPayloadV1): PendingStream {
+    return {
+      chunkCount: chunk.chunkCount,
+      totalBytes: chunk.totalBytes,
+      streamSha256: chunk.streamSha256,
+      pendingBytes: 0,
+      chunks: new Map<number, StreamChunkPayloadV1>(),
+    };
+  }
+
+  private validateConsistency(pending: PendingStream, chunk: StreamChunkPayloadV1): StreamAcceptResult | undefined {
+    if (pending.chunkCount !== chunk.chunkCount) {
+      return { status: "nack", streamId: chunk.streamId, reason: "stream-chunk-count-mismatch" };
+    }
+    if (pending.totalBytes !== chunk.totalBytes) {
+      return { status: "nack", streamId: chunk.streamId, reason: "stream-total-bytes-mismatch" };
+    }
+    if (pending.streamSha256 !== chunk.streamSha256) {
+      return { status: "nack", streamId: chunk.streamId, reason: "stream-hash-mismatch" };
+    }
+    return undefined;
+  }
+
+  private validateBackpressure(pending: PendingStream, chunk: StreamChunkPayloadV1): StreamAcceptResult | undefined {
+    if (pending.chunks.size + 1 > this.maxInFlightChunks) {
+      return { status: "nack", streamId: chunk.streamId, reason: "stream-backpressure-chunks" };
+    }
+    if (this.pendingBytes + chunk.payloadBytes > this.maxPendingBytes) {
+      return { status: "nack", streamId: chunk.streamId, reason: "stream-backpressure-bytes" };
+    }
+    return undefined;
+  }
+
+  private completeStream(streamId: string, pending: PendingStream): StreamAcceptResult {
+    const chunks = [...pending.chunks.values()].sort((a, b) => a.chunkIndex - b.chunkIndex);
+    const payload = streamChunksToBytes(chunks);
+    if (payload.byteLength !== pending.totalBytes || sha256(payload) !== pending.streamSha256) {
+      return { status: "nack", streamId, reason: "stream-hash-mismatch" };
+    }
+
+    const hashesByIndex = new Map(chunks.map((chunk) => [chunk.chunkIndex, chunk.payloadSha256]));
+    this.pending.delete(streamId);
+    this.pendingBytes -= pending.pendingBytes;
+    this.completed.set(streamId, { payload, hashesByIndex });
+    return { status: "complete", streamId, payload };
+  }
+}

--- a/packages/core/test/streaming.test.mjs
+++ b/packages/core/test/streaming.test.mjs
@@ -1,0 +1,129 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  InMemoryStreamReassembler,
+  createStreamChunks,
+  streamChunksToText,
+  streamPayloadVisibleEnvelopeFields,
+} from "../dist/src/index.js";
+
+const text = (value) => new TextEncoder().encode(value);
+
+test("createStreamChunks splits payloads and preserves byte order", () => {
+  const chunks = createStreamChunks(text("abcdefghij"), { streamId: "stream-a", maxChunkBytes: 4 });
+
+  assert.equal(chunks.length, 3);
+  assert.deepEqual(chunks.map((chunk) => chunk.chunkIndex), [0, 1, 2]);
+  assert.deepEqual(chunks.map((chunk) => chunk.payloadBase64), ["YWJjZA==", "ZWZnaA==", "aWo="]);
+  assert.equal(streamChunksToText(chunks), "abcdefghij");
+});
+
+test("chunk metadata is payload-only and does not require visible envelope fields", () => {
+  const [chunk] = createStreamChunks("hello", { streamId: "stream-no-leak", maxChunkBytes: 64 });
+
+  assert.deepEqual(streamPayloadVisibleEnvelopeFields(chunk), []);
+  assert.ok("streamId" in chunk);
+  assert.ok("chunkIndex" in chunk);
+  assert.ok(!("parentMsgId" in chunk));
+  assert.ok(!("sequence" in chunk));
+});
+
+test("reassembler completes when chunks arrive out of order", () => {
+  const chunks = createStreamChunks("abcdefghij", { streamId: "stream-b", maxChunkBytes: 3 });
+  const reassembler = new InMemoryStreamReassembler();
+
+  assert.equal(reassembler.accept(chunks[2]).status, "accepted");
+  assert.equal(reassembler.accept(chunks[0]).status, "accepted");
+  const result = reassembler.accept(chunks[1]);
+
+  assert.equal(result.status, "accepted");
+  const final = reassembler.accept(chunks[3]);
+  assert.equal(final.status, "complete");
+  assert.equal(new TextDecoder().decode(final.payload), "abcdefghij");
+});
+
+test("duplicate chunks with the same hash are idempotent", () => {
+  const [chunk] = createStreamChunks("hello", { streamId: "stream-c", maxChunkBytes: 64 });
+  const reassembler = new InMemoryStreamReassembler();
+
+  assert.equal(reassembler.accept(chunk).status, "complete");
+  const duplicate = reassembler.accept(chunk);
+
+  assert.equal(duplicate.status, "complete");
+  assert.equal(new TextDecoder().decode(duplicate.payload), "hello");
+});
+
+test("same streamId and chunkIndex with a different hash is rejected", () => {
+  const [chunk] = createStreamChunks("hello", { streamId: "stream-d", maxChunkBytes: 64 });
+  const [different] = createStreamChunks("world", { streamId: "stream-d", maxChunkBytes: 64 });
+  const reassembler = new InMemoryStreamReassembler();
+
+  assert.equal(reassembler.accept(chunk).status, "complete");
+  const conflict = reassembler.accept({
+    ...chunk,
+    payloadBase64: different.payloadBase64,
+    payloadBytes: different.payloadBytes,
+    payloadSha256: different.payloadSha256,
+  });
+
+  assert.equal(conflict.status, "nack");
+  assert.equal(conflict.reason, "stream-chunk-hash-mismatch");
+});
+
+test("backpressure rejects streams above max in-flight chunk count", () => {
+  const reassembler = new InMemoryStreamReassembler({ maxInFlightChunks: 2, maxPendingBytes: 1024 });
+  const chunks = createStreamChunks("abcdefghi", { streamId: "stream-e", maxChunkBytes: 3 });
+
+  assert.equal(reassembler.accept(chunks[0]).status, "accepted");
+  assert.equal(reassembler.accept(chunks[1]).status, "accepted");
+  const result = reassembler.accept(chunks[2]);
+
+  assert.equal(result.status, "nack");
+  assert.equal(result.reason, "stream-backpressure-chunks");
+});
+
+test("backpressure rejects streams above max pending bytes", () => {
+  const reassembler = new InMemoryStreamReassembler({ maxInFlightChunks: 10, maxPendingBytes: 5 });
+  const chunks = createStreamChunks("abcdefghi", { streamId: "stream-f", maxChunkBytes: 3 });
+
+  assert.equal(reassembler.accept(chunks[0]).status, "accepted");
+  const result = reassembler.accept(chunks[1]);
+
+  assert.equal(result.status, "nack");
+  assert.equal(result.reason, "stream-backpressure-bytes");
+});
+
+test("invalid chunk hashes are rejected before storage", () => {
+  const [chunk] = createStreamChunks("hello", { streamId: "stream-g", maxChunkBytes: 64 });
+  const reassembler = new InMemoryStreamReassembler();
+
+  const result = reassembler.accept({ ...chunk, payloadSha256: "bad" });
+
+  assert.equal(result.status, "nack");
+  assert.equal(result.reason, "stream-chunk-hash-invalid");
+  assert.equal(reassembler.pendingStats().streamCount, 0);
+});
+
+test("inconsistent chunk count for the same stream is rejected", () => {
+  const chunks = createStreamChunks("abcdefghi", { streamId: "stream-h", maxChunkBytes: 3 });
+  const reassembler = new InMemoryStreamReassembler();
+
+  assert.equal(reassembler.accept(chunks[0]).status, "accepted");
+  const result = reassembler.accept({ ...chunks[1], chunkCount: 4 });
+
+  assert.equal(result.status, "nack");
+  assert.equal(result.reason, "stream-chunk-count-mismatch");
+});
+
+test("completed streams are retained without pending-byte pressure", () => {
+  const chunks = createStreamChunks("hello", { streamId: "stream-i", maxChunkBytes: 2 });
+  const reassembler = new InMemoryStreamReassembler({ maxPendingBytes: 5 });
+
+  assert.equal(reassembler.accept(chunks[0]).status, "accepted");
+  assert.equal(reassembler.accept(chunks[1]).status, "accepted");
+  const complete = reassembler.accept(chunks[2]);
+
+  assert.equal(complete.status, "complete");
+  assert.equal(reassembler.pendingStats().pendingBytes, 0);
+  assert.equal(new TextDecoder().decode(complete.payload), "hello");
+});


### PR DESCRIPTION
## Summary
- add pure `@murmurv2/core` stream chunk payload helpers
- add `InMemoryStreamReassembler` with hash validation, duplicate handling, out-of-order completion, and count/byte backpressure
- document PR1 scope: metadata stays inside encrypted payload; SQLite durability and NATS integration remain PR2

## Verification
- `npm run build`
- `npm run test:unit`
- `npm run test:core`

## Notes
No writes to the live `/opt/lifecoach/mur-mur-v2` checkout and no shared NATS broker interaction. Work was done in a dev clone under `vault/tmp/mur-mur-v2-streaming-pr1`.
