### PR TITLE
feat(core): add streaming frame utilities

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -569,6 +569,265 @@ export class SQLiteMessageStore {
   }
 }
 
+export type StreamFrameKind = "stream.start" | "stream.chunk" | "stream.end";
+
+export interface StreamStart {
+  kind: "stream.start";
+  streamId: string;
+  chunkCount: number;
+  totalBytes: number;
+  contentType?: string;
+  startedAt?: string;
+}
+
+export interface StreamChunk {
+  kind: "stream.chunk";
+  streamId: string;
+  chunkIndex: number;
+  chunkCount: number;
+  data: string;
+  isLast: boolean;
+}
+
+export interface StreamEnd {
+  kind: "stream.end";
+  streamId: string;
+  chunkCount: number;
+  totalBytes: number;
+  digest?: string;
+}
+
+export type StreamFrame = StreamStart | StreamChunk | StreamEnd;
+
+export interface ChunkStreamTextInput {
+  streamId: string;
+  text: string;
+  maxChunkBytes: number;
+}
+
+export interface CreateStreamStartInput {
+  streamId: string;
+  chunkCount: number;
+  totalBytes: number;
+  contentType?: string;
+  startedAt?: string;
+}
+
+export interface CreateStreamChunkInput {
+  streamId: string;
+  chunkIndex: number;
+  chunkCount: number;
+  data: string;
+}
+
+export interface CreateStreamEndInput {
+  streamId: string;
+  chunkCount: number;
+  totalBytes: number;
+  digest?: string;
+}
+
+export interface StreamReassemblyResult {
+  status: "pending" | "duplicate" | "complete";
+  streamId: string;
+  receivedChunks: number;
+  chunkCount: number;
+  text?: string;
+}
+
+export interface StreamReassemblyState {
+  streamId: string;
+  chunkCount: number;
+  receivedChunks: number;
+}
+
+export interface StreamBackpressureWindow {
+  inFlightChunks: number;
+  inFlightBytes: number;
+  nextChunkBytes: number;
+  maxInFlightChunks: number;
+  maxInFlightBytes: number;
+}
+
+const textEncoder = new TextEncoder();
+
+const utf8Bytes = (value: string): number => textEncoder.encode(value).byteLength;
+
+const assertPositiveInteger = (name: string, value: number): void => {
+  if (!Number.isInteger(value) || value < 1) throw new Error(`${name}-invalid`);
+};
+
+const assertNonNegativeInteger = (name: string, value: number): void => {
+  if (!Number.isInteger(value) || value < 0) throw new Error(`${name}-invalid`);
+};
+
+export const createStreamStart = (input: CreateStreamStartInput): StreamStart => {
+  if (!input.streamId) throw new Error("stream-id-required");
+  assertPositiveInteger("stream-chunk-count", input.chunkCount);
+  assertNonNegativeInteger("stream-total-bytes", input.totalBytes);
+  if (input.contentType !== undefined && input.contentType.length === 0) throw new Error("stream-content-type-invalid");
+  if (input.startedAt !== undefined && Number.isNaN(Date.parse(input.startedAt))) throw new Error("stream-started-at-invalid");
+
+  return {
+    kind: "stream.start",
+    streamId: input.streamId,
+    chunkCount: input.chunkCount,
+    totalBytes: input.totalBytes,
+    ...(input.contentType !== undefined ? { contentType: input.contentType } : {}),
+    ...(input.startedAt !== undefined ? { startedAt: input.startedAt } : {}),
+  };
+};
+
+export const createStreamChunk = (input: CreateStreamChunkInput): StreamChunk => {
+  if (!input.streamId) throw new Error("stream-id-required");
+  assertNonNegativeInteger("stream-chunk-index", input.chunkIndex);
+  assertPositiveInteger("stream-chunk-count", input.chunkCount);
+  if (input.chunkIndex >= input.chunkCount) throw new Error("stream-chunk-index-out-of-range");
+  if (input.data.length === 0) throw new Error("stream-chunk-data-required");
+
+  return {
+    kind: "stream.chunk",
+    streamId: input.streamId,
+    chunkIndex: input.chunkIndex,
+    chunkCount: input.chunkCount,
+    data: input.data,
+    isLast: input.chunkIndex === input.chunkCount - 1,
+  };
+};
+
+export const createStreamEnd = (input: CreateStreamEndInput): StreamEnd => {
+  if (!input.streamId) throw new Error("stream-id-required");
+  assertPositiveInteger("stream-chunk-count", input.chunkCount);
+  assertNonNegativeInteger("stream-total-bytes", input.totalBytes);
+  if (input.digest !== undefined && input.digest.length === 0) throw new Error("stream-digest-invalid");
+
+  return {
+    kind: "stream.end",
+    streamId: input.streamId,
+    chunkCount: input.chunkCount,
+    totalBytes: input.totalBytes,
+    ...(input.digest !== undefined ? { digest: input.digest } : {}),
+  };
+};
+
+export const chunkStreamText = (input: ChunkStreamTextInput): StreamChunk[] => {
+  if (!input.streamId) throw new Error("stream-id-required");
+  assertPositiveInteger("stream-max-chunk-bytes", input.maxChunkBytes);
+  if (input.text.length === 0) throw new Error("stream-text-required");
+
+  const parts: string[] = [];
+  let current = "";
+  let currentBytes = 0;
+
+  for (const symbol of input.text) {
+    const symbolBytes = utf8Bytes(symbol);
+    if (symbolBytes > input.maxChunkBytes) throw new Error("stream-symbol-exceeds-max-chunk-bytes");
+    if (current && currentBytes + symbolBytes > input.maxChunkBytes) {
+      parts.push(current);
+      current = symbol;
+      currentBytes = symbolBytes;
+    } else {
+      current += symbol;
+      currentBytes += symbolBytes;
+    }
+  }
+
+  if (current) parts.push(current);
+  return parts.map((data, index) => createStreamChunk({
+    streamId: input.streamId,
+    chunkIndex: index,
+    chunkCount: parts.length,
+    data,
+  }));
+};
+
+export class InMemoryStreamReassembler {
+  private readonly streams = new Map<string, { chunkCount: number; chunks: Map<number, string> }>();
+
+  accept(chunk: StreamChunk): StreamReassemblyResult {
+    this.validateChunk(chunk);
+    let state = this.streams.get(chunk.streamId);
+    if (!state) {
+      state = { chunkCount: chunk.chunkCount, chunks: new Map<number, string>() };
+      this.streams.set(chunk.streamId, state);
+    } else if (state.chunkCount !== chunk.chunkCount) {
+      throw new Error(`stream-chunk-count-conflict:${chunk.streamId}`);
+    }
+
+    const existing = state.chunks.get(chunk.chunkIndex);
+    if (existing !== undefined) {
+      if (existing !== chunk.data) throw new Error(`stream-chunk-conflict:${chunk.streamId}:${chunk.chunkIndex}`);
+      return {
+        status: "duplicate",
+        streamId: chunk.streamId,
+        receivedChunks: state.chunks.size,
+        chunkCount: state.chunkCount,
+      };
+    }
+
+    state.chunks.set(chunk.chunkIndex, chunk.data);
+    if (state.chunks.size !== state.chunkCount) {
+      return {
+        status: "pending",
+        streamId: chunk.streamId,
+        receivedChunks: state.chunks.size,
+        chunkCount: state.chunkCount,
+      };
+    }
+
+    const text = Array.from({ length: state.chunkCount }, (_, index) => state.chunks.get(index) ?? "").join("");
+    this.streams.delete(chunk.streamId);
+    return {
+      status: "complete",
+      streamId: chunk.streamId,
+      receivedChunks: state.chunkCount,
+      chunkCount: state.chunkCount,
+      text,
+    };
+  }
+
+  get(streamId: string): StreamReassemblyState | undefined {
+    const state = this.streams.get(streamId);
+    if (!state) return undefined;
+    return {
+      streamId,
+      chunkCount: state.chunkCount,
+      receivedChunks: state.chunks.size,
+    };
+  }
+
+  delete(streamId: string): boolean {
+    return this.streams.delete(streamId);
+  }
+
+  clear(): void {
+    this.streams.clear();
+  }
+
+  private validateChunk(chunk: StreamChunk): void {
+    if (chunk.kind !== "stream.chunk") throw new Error("stream-chunk-kind-invalid");
+    if (!chunk.streamId) throw new Error("stream-id-required");
+    assertNonNegativeInteger("stream-chunk-index", chunk.chunkIndex);
+    assertPositiveInteger("stream-chunk-count", chunk.chunkCount);
+    if (chunk.chunkIndex >= chunk.chunkCount) throw new Error("stream-chunk-index-out-of-range");
+    if (chunk.data.length === 0) throw new Error("stream-chunk-data-required");
+    if (chunk.isLast !== (chunk.chunkIndex === chunk.chunkCount - 1)) throw new Error("stream-chunk-last-flag-invalid");
+  }
+}
+
+export const streamBackpressureAllowsSend = (window: StreamBackpressureWindow): boolean => {
+  assertNonNegativeInteger("stream-in-flight-chunks", window.inFlightChunks);
+  assertNonNegativeInteger("stream-in-flight-bytes", window.inFlightBytes);
+  assertPositiveInteger("stream-next-chunk-bytes", window.nextChunkBytes);
+  assertPositiveInteger("stream-max-in-flight-chunks", window.maxInFlightChunks);
+  assertPositiveInteger("stream-max-in-flight-bytes", window.maxInFlightBytes);
+
+  return (
+    window.inFlightChunks < window.maxInFlightChunks &&
+    window.inFlightBytes + window.nextChunkBytes <= window.maxInFlightBytes
+  );
+};
+
 export const isEnvelopeV1 = (v: unknown): v is EnvelopeV1 => {
   if (!v || typeof v !== "object") return false;
   const o = v as Record<string, unknown>;

--- a/packages/core/test/streaming.test.mjs
+++ b/packages/core/test/streaming.test.mjs
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  InMemoryStreamReassembler,
+  chunkStreamText,
+  createStreamEnd,
+  createStreamChunk,
+  createStreamStart,
+  streamBackpressureAllowsSend,
+} from "../dist/src/index.js";
+
+test("createStreamStart and createStreamEnd frame stream boundaries without payload data", () => {
+  const startedAt = "2026-06-22T13:00:00.000Z";
+  assert.deepEqual(
+    createStreamStart({
+      streamId: "stream-0",
+      chunkCount: 3,
+      totalBytes: 42,
+      contentType: "text/plain",
+      startedAt,
+    }),
+    {
+      kind: "stream.start",
+      streamId: "stream-0",
+      chunkCount: 3,
+      totalBytes: 42,
+      contentType: "text/plain",
+      startedAt,
+    },
+  );
+  assert.deepEqual(
+    createStreamEnd({
+      streamId: "stream-0",
+      chunkCount: 3,
+      totalBytes: 42,
+    }),
+    {
+      kind: "stream.end",
+      streamId: "stream-0",
+      chunkCount: 3,
+      totalBytes: 42,
+    },
+  );
+});
+
+test("chunkStreamText splits UTF-8 text without exceeding max payload bytes", () => {
+  const text = "hello Привет 👋".repeat(24);
+  const chunks = chunkStreamText({
+    streamId: "stream-1",
+    text,
+    maxChunkBytes: 37,
+  });
+
+  assert.ok(chunks.length > 1);
+  assert.equal(chunks[0].kind, "stream.chunk");
+  assert.equal(chunks.at(-1).isLast, true);
+  assert.deepEqual(chunks.map((chunk) => chunk.chunkIndex), chunks.map((_, index) => index));
+  assert.equal(new Set(chunks.map((chunk) => chunk.chunkCount)).size, 1);
+
+  for (const chunk of chunks) {
+    assert.ok(Buffer.byteLength(chunk.data, "utf8") <= 37);
+  }
+  assert.equal(chunks.map((chunk) => chunk.data).join(""), text);
+});
+
+test("chunkStreamText rejects invalid byte budgets", () => {
+  assert.throws(
+    () => chunkStreamText({ streamId: "stream-1", text: "abc", maxChunkBytes: 0 }),
+    /stream-max-chunk-bytes-invalid/,
+  );
+});
+
+test("InMemoryStreamReassembler deduplicates chunks and completes out of order", () => {
+  const reassembler = new InMemoryStreamReassembler();
+  const chunks = chunkStreamText({
+    streamId: "stream-2",
+    text: "chunked message payload",
+    maxChunkBytes: 6,
+  });
+
+  const first = reassembler.accept(chunks[1]);
+  assert.equal(first.status, "pending");
+  assert.equal(first.receivedChunks, 1);
+
+  const duplicate = reassembler.accept(chunks[1]);
+  assert.equal(duplicate.status, "duplicate");
+  assert.equal(duplicate.receivedChunks, 1);
+
+  let result;
+  for (const chunk of [chunks[0], ...chunks.slice(2)]) {
+    result = reassembler.accept(chunk);
+  }
+
+  assert.equal(result.status, "complete");
+  assert.equal(result.text, "chunked message payload");
+  assert.equal(result.receivedChunks, chunks.length);
+  assert.equal(result.chunkCount, chunks.length);
+  assert.equal(reassembler.get("stream-2"), undefined);
+});
+
+test("InMemoryStreamReassembler rejects conflicting duplicate chunk data", () => {
+  const reassembler = new InMemoryStreamReassembler();
+  const chunk = createStreamChunk({
+    streamId: "stream-3",
+    chunkIndex: 0,
+    chunkCount: 2,
+    data: "hello ",
+  });
+  reassembler.accept(chunk);
+
+  assert.throws(
+    () => reassembler.accept({ ...chunk, data: "HELLO " }),
+    /stream-chunk-conflict:stream-3:0/,
+  );
+});
+
+test("streamBackpressureAllowsSend enforces chunk and byte windows", () => {
+  assert.equal(
+    streamBackpressureAllowsSend({
+      inFlightChunks: 3,
+      inFlightBytes: 120,
+      nextChunkBytes: 30,
+      maxInFlightChunks: 4,
+      maxInFlightBytes: 150,
+    }),
+    true,
+  );
+  assert.equal(
+    streamBackpressureAllowsSend({
+      inFlightChunks: 4,
+      inFlightBytes: 120,
+      nextChunkBytes: 1,
+      maxInFlightChunks: 4,
+      maxInFlightBytes: 150,
+    }),
+    false,
+  );
+  assert.equal(
+    streamBackpressureAllowsSend({
+      inFlightChunks: 2,
+      inFlightBytes: 140,
+      nextChunkBytes: 11,
+      maxInFlightChunks: 4,
+      maxInFlightBytes: 150,
+    }),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- add pure stream frame helpers for `stream.start`, `stream.chunk`, and `stream.end` payloads
- add UTF-8 safe text chunking without EnvelopeV1 schema changes
- add in-memory reassembler with duplicate/conflict handling
- add a small backpressure predicate for chunk/byte in-flight windows

## Scope
PR1 only: core utilities + tests. No broker integration, SQLite reassembly store, daemon behavior, or encrypted payload routing changes yet.

## Verification
- TDD fail observed first: `npm --workspace @murmurv2/core test` failed on missing streaming exports
- `npm --workspace @murmurv2/core test` PASS: 12/12
- `npm run build` PASS
- `git diff --check` PASS
- `npm run test:unit` PASS: 63/63
- `npm test -- --test-name-pattern noop` PASS before final start/end helper addition; reran focused core + unit + build after final change

## Review Notes
- `stream.start`/`stream.end` are explicit boundary frames but contain no plaintext metadata beyond counts/bytes/contentType/digest fields supplied by caller; actual payload transport remains inside encrypted message body.
- Reassembly idempotency is per `(streamId, chunkIndex)` and conflicting duplicate data throws.
- Backpressure helper is deliberately pure; broker ACK-window wiring belongs in PR2.

Requested reviewers: JARVIS + fedoseevstan formal approve if available.