### PR TITLE
feat(core): agent discovery PR1 — presence frames + candidate registry

### DIFF
--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -10,8 +10,10 @@
  * it must stay a deliberate operator step, not a side effect of an inbound frame.)
  *
  * A presence frame carries only PUBLIC metadata (public keys, subject,
- * capabilities). It is self-signed for announcement integrity — that proves the
- * frame was not tampered with in flight, NOT that the agentId is who it claims.
+ * capabilities). PR1 treats the frame as UNSIGNED data — there is no signature
+ * field or verification here; frame signing + verification over NATS lands in
+ * PR2. Even once signed, a valid signature would only prove announcement
+ * integrity (not tampered in flight), NOT that the agentId is who it claims.
  * Identity authenticity is established out-of-band at promotion time.
  */
 
@@ -67,8 +69,12 @@ export interface DiscoveryCandidate {
  */
 export class CandidateRegistry {
   private readonly candidates = new Map<string, DiscoveryCandidate>();
-  /** Remembers (agentId, nonce) of recently-applied frames for idempotency. */
-  private readonly seenNonces = new Set<string>();
+  /**
+   * Remembers (agentId, nonce) → expiry (epoch ms) of applied frames for
+   * idempotency. Bounded: entries expire with their frame and are dropped by
+   * `prune()`, so a long-running listener does not leak memory on every announce.
+   */
+  private readonly seenNonces = new Map<string, number>();
 
   /**
    * Observe a presence frame. Returns the candidate (created or refreshed), or null
@@ -87,7 +93,7 @@ export class CandidateRegistry {
       // Duplicate announcement → idempotent: return current candidate unchanged.
       return this.candidates.get(frame.agentId) ?? null;
     }
-    this.seenNonces.add(dedupeKey);
+    this.seenNonces.set(dedupeKey, expiresAt);
 
     const existing = this.candidates.get(frame.agentId);
     // Out-of-order/stale frame for a known agent → keep the fresher one.
@@ -119,7 +125,7 @@ export class CandidateRegistry {
     return [...this.candidates.values()].filter((c) => c.expiresAt > now);
   }
 
-  /** Drop expired candidates (and their dedupe markers). Returns count removed. */
+  /** Drop expired candidates AND expired dedupe markers. Returns candidates removed. */
   prune(now: number): number {
     let removed = 0;
     for (const [agentId, c] of this.candidates) {
@@ -128,7 +134,16 @@ export class CandidateRegistry {
         removed += 1;
       }
     }
+    // Bound the dedupe set: expired nonce markers cannot match a fresh frame.
+    for (const [key, expiresAt] of this.seenNonces) {
+      if (expiresAt <= now) this.seenNonces.delete(key);
+    }
     return removed;
+  }
+
+  /** Count of remembered dedupe markers (test/observability hook). */
+  nonceCount(): number {
+    return this.seenNonces.size;
   }
 
   /** Count of non-expired candidates at `now`. */

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -1,0 +1,138 @@
+/**
+ * Agent discovery — presence frames + candidate registry (PR1: pure, in-memory).
+ *
+ * Goal (README): let peers find each other without a manual invite exchange.
+ *
+ * TRUST MODEL (hard rule): a presence frame only makes an agent a *candidate*.
+ * Observing a presence NEVER auto-trusts or auto-adds a peer — promotion of a
+ * candidate to a trusted peer is an explicit operator/policy action elsewhere.
+ * (Lesson from live onboarding: adding a trusted peer widens the trust border, so
+ * it must stay a deliberate operator step, not a side effect of an inbound frame.)
+ *
+ * A presence frame carries only PUBLIC metadata (public keys, subject,
+ * capabilities). It is self-signed for announcement integrity — that proves the
+ * frame was not tampered with in flight, NOT that the agentId is who it claims.
+ * Identity authenticity is established out-of-band at promotion time.
+ */
+
+export interface PresenceFrameV1 {
+  presenceVersion: "1.0";
+  agentId: string;
+  encryptionPublicKey: string;
+  signingPublicKey: string;
+  subject: string;
+  capabilities: string[];
+  /** Validity window in ms from `ts`; the candidate expires at ts + ttlMs. */
+  ttlMs: number;
+  /** ISO-8601 announcement timestamp. */
+  ts: string;
+  /** Random per-announcement value for dedupe. */
+  nonce: string;
+}
+
+export const isPresenceFrameV1 = (v: unknown): v is PresenceFrameV1 => {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    o.presenceVersion === "1.0" &&
+    typeof o.agentId === "string" && o.agentId.length > 0 &&
+    typeof o.encryptionPublicKey === "string" && o.encryptionPublicKey.length > 0 &&
+    typeof o.signingPublicKey === "string" && o.signingPublicKey.length > 0 &&
+    typeof o.subject === "string" && o.subject.length > 0 &&
+    Array.isArray(o.capabilities) && o.capabilities.every((c) => typeof c === "string") &&
+    typeof o.ttlMs === "number" && Number.isFinite(o.ttlMs) && o.ttlMs > 0 &&
+    typeof o.ts === "string" && !Number.isNaN(Date.parse(o.ts)) &&
+    typeof o.nonce === "string" && o.nonce.length > 0
+  );
+};
+
+/** A discovered, NOT-yet-trusted agent. `trusted` is always false here by design. */
+export interface DiscoveryCandidate {
+  agentId: string;
+  encryptionPublicKey: string;
+  signingPublicKey: string;
+  subject: string;
+  capabilities: string[];
+  /** Epoch ms when this candidate expires (frame ts + ttlMs). */
+  expiresAt: number;
+  /** Epoch ms of the most recent presence observed. */
+  lastSeen: number;
+  /** Always false in PR1 — promotion to a trusted peer is an external operator action. */
+  trusted: false;
+}
+
+/**
+ * In-memory registry of discovered candidates. Pure: no I/O, no NATS, no auto-trust.
+ * Feed it presence frames via `observe()`; read non-expired candidates via `list()`.
+ */
+export class CandidateRegistry {
+  private readonly candidates = new Map<string, DiscoveryCandidate>();
+  /** Remembers (agentId, nonce) of recently-applied frames for idempotency. */
+  private readonly seenNonces = new Set<string>();
+
+  /**
+   * Observe a presence frame. Returns the candidate (created or refreshed), or null
+   * if the frame is invalid, already expired at `now`, or a duplicate announcement.
+   * A frame is NEVER auto-trusted: the returned candidate always has `trusted: false`.
+   */
+  observe(frame: unknown, now: number): DiscoveryCandidate | null {
+    if (!isPresenceFrameV1(frame)) return null;
+
+    const announcedAt = Date.parse(frame.ts);
+    const expiresAt = announcedAt + frame.ttlMs;
+    if (expiresAt <= now) return null; // already expired — ignore
+
+    const dedupeKey = `${frame.agentId}:${frame.nonce}`;
+    if (this.seenNonces.has(dedupeKey)) {
+      // Duplicate announcement → idempotent: return current candidate unchanged.
+      return this.candidates.get(frame.agentId) ?? null;
+    }
+    this.seenNonces.add(dedupeKey);
+
+    const existing = this.candidates.get(frame.agentId);
+    // Out-of-order/stale frame for a known agent → keep the fresher one.
+    if (existing && announcedAt < existing.lastSeen) return existing;
+
+    const candidate: DiscoveryCandidate = {
+      agentId: frame.agentId,
+      encryptionPublicKey: frame.encryptionPublicKey,
+      signingPublicKey: frame.signingPublicKey,
+      subject: frame.subject,
+      capabilities: [...frame.capabilities],
+      expiresAt,
+      lastSeen: announcedAt,
+      trusted: false,
+    };
+    this.candidates.set(frame.agentId, candidate);
+    return candidate;
+  }
+
+  /** Get a candidate by agentId if present and not expired at `now`. */
+  get(agentId: string, now: number): DiscoveryCandidate | undefined {
+    const c = this.candidates.get(agentId);
+    if (!c) return undefined;
+    return c.expiresAt > now ? c : undefined;
+  }
+
+  /** All non-expired candidates at `now`. */
+  list(now: number): DiscoveryCandidate[] {
+    return [...this.candidates.values()].filter((c) => c.expiresAt > now);
+  }
+
+  /** Drop expired candidates (and their dedupe markers). Returns count removed. */
+  prune(now: number): number {
+    let removed = 0;
+    for (const [agentId, c] of this.candidates) {
+      if (c.expiresAt <= now) {
+        this.candidates.delete(agentId);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  /** Count of non-expired candidates at `now`. */
+  size(now: number): number {
+    return this.list(now).length;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,9 @@ import { mkdirSync, promises as fs } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
+// Agent discovery (presence frames + candidate registry)
+export * from "./discovery.js";
+
 export type DeliveryMode = "at-least-once";
 
 export interface EnvelopeV1 {

--- a/packages/core/test/discovery.test.mjs
+++ b/packages/core/test/discovery.test.mjs
@@ -92,6 +92,15 @@ test("prune removes expired candidates", () => {
 
 // --- idempotency / ordering --------------------------------------------------
 
+test("prune drops expired dedupe markers too (bounded seenNonces)", () => {
+  const reg = new CandidateRegistry();
+  reg.observe(frame({ nonce: "a" }), at("2026-06-22T13:00:05.000Z")); // ttl 60s
+  reg.observe(frame({ agentId: "agent-y", nonce: "b", ttlMs: 600_000 }), at("2026-06-22T13:00:05.000Z"));
+  assert.equal(reg.nonceCount(), 2);
+  reg.prune(at("2026-06-22T13:02:00.000Z")); // agent-x's 60s frame expired, agent-y's 600s not
+  assert.equal(reg.nonceCount(), 1); // only the non-expired nonce marker remains
+});
+
 test("duplicate (agentId, nonce) announcement is idempotent", () => {
   const reg = new CandidateRegistry();
   const now = at("2026-06-22T13:00:10.000Z");

--- a/packages/core/test/discovery.test.mjs
+++ b/packages/core/test/discovery.test.mjs
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { CandidateRegistry, isPresenceFrameV1 } from "../dist/src/index.js";
+
+const frame = (over = {}) => ({
+  presenceVersion: "1.0",
+  agentId: "agent-x",
+  encryptionPublicKey: "enc-pub",
+  signingPublicKey: "sig-pub",
+  subject: "msg.agent-x",
+  capabilities: ["chat", "files"],
+  ttlMs: 60_000,
+  ts: "2026-06-22T13:00:00.000Z",
+  nonce: "n1",
+  ...over,
+});
+
+const at = (iso) => Date.parse(iso);
+
+// --- isPresenceFrameV1 -------------------------------------------------------
+
+test("isPresenceFrameV1 accepts a well-formed frame", () => {
+  assert.equal(isPresenceFrameV1(frame()), true);
+});
+
+test("isPresenceFrameV1 rejects malformed frames", () => {
+  assert.equal(isPresenceFrameV1(null), false);
+  assert.equal(isPresenceFrameV1({ ...frame(), presenceVersion: "2.0" }), false);
+  assert.equal(isPresenceFrameV1({ ...frame(), agentId: "" }), false);
+  assert.equal(isPresenceFrameV1({ ...frame(), ttlMs: 0 }), false);
+  assert.equal(isPresenceFrameV1({ ...frame(), ttlMs: -5 }), false);
+  assert.equal(isPresenceFrameV1({ ...frame(), ts: "not-a-date" }), false);
+  assert.equal(isPresenceFrameV1({ ...frame(), capabilities: "chat" }), false);
+  assert.equal(isPresenceFrameV1({ ...frame(), nonce: "" }), false);
+});
+
+// --- observe / registry build ------------------------------------------------
+
+test("observe builds a candidate from a valid frame", () => {
+  const reg = new CandidateRegistry();
+  const now = at("2026-06-22T13:00:10.000Z");
+  const c = reg.observe(frame(), now);
+  assert.ok(c);
+  assert.equal(c.agentId, "agent-x");
+  assert.equal(c.subject, "msg.agent-x");
+  assert.deepEqual(c.capabilities, ["chat", "files"]);
+  assert.equal(reg.size(now), 1);
+  assert.equal(reg.get("agent-x", now)?.encryptionPublicKey, "enc-pub");
+});
+
+test("observe rejects invalid or already-expired frames", () => {
+  const reg = new CandidateRegistry();
+  assert.equal(reg.observe({ bad: true }, at("2026-06-22T13:00:10.000Z")), null);
+  // ttl already elapsed at observation time
+  const late = at("2026-06-22T13:05:00.000Z"); // 5 min later, ttl 60s
+  assert.equal(reg.observe(frame(), late), null);
+  assert.equal(reg.size(late), 0);
+});
+
+// --- CRITICAL INVARIANT: candidates are never auto-trusted -------------------
+
+test("a discovered candidate is NEVER auto-trusted", () => {
+  const reg = new CandidateRegistry();
+  const now = at("2026-06-22T13:00:10.000Z");
+  const c = reg.observe(frame(), now);
+  assert.equal(c.trusted, false);
+  assert.equal(reg.get("agent-x", now).trusted, false);
+  assert.equal(reg.list(now).every((x) => x.trusted === false), true);
+});
+
+// --- expiry ------------------------------------------------------------------
+
+test("candidate expires after ts + ttlMs", () => {
+  const reg = new CandidateRegistry();
+  reg.observe(frame(), at("2026-06-22T13:00:05.000Z"));
+  const beforeExpiry = at("2026-06-22T13:00:50.000Z"); // within 60s
+  const afterExpiry = at("2026-06-22T13:01:01.000Z"); // past 60s
+  assert.equal(reg.size(beforeExpiry), 1);
+  assert.equal(reg.get("agent-x", afterExpiry), undefined);
+  assert.equal(reg.list(afterExpiry).length, 0);
+});
+
+test("prune removes expired candidates", () => {
+  const reg = new CandidateRegistry();
+  reg.observe(frame(), at("2026-06-22T13:00:05.000Z"));
+  reg.observe(frame({ agentId: "agent-y", nonce: "ny", ttlMs: 600_000 }), at("2026-06-22T13:00:05.000Z"));
+  const afterFirstExpiry = at("2026-06-22T13:02:00.000Z");
+  assert.equal(reg.prune(afterFirstExpiry), 1); // agent-x gone, agent-y stays
+  assert.equal(reg.size(afterFirstExpiry), 1);
+  assert.ok(reg.get("agent-y", afterFirstExpiry));
+});
+
+// --- idempotency / ordering --------------------------------------------------
+
+test("duplicate (agentId, nonce) announcement is idempotent", () => {
+  const reg = new CandidateRegistry();
+  const now = at("2026-06-22T13:00:10.000Z");
+  const c1 = reg.observe(frame(), now);
+  const c2 = reg.observe(frame(), now); // same nonce
+  assert.equal(c2.agentId, c1.agentId);
+  assert.equal(reg.size(now), 1);
+});
+
+test("a fresh announcement (new nonce) refreshes the candidate", () => {
+  const reg = new CandidateRegistry();
+  reg.observe(frame(), at("2026-06-22T13:00:05.000Z"));
+  const c = reg.observe(
+    frame({ nonce: "n2", ts: "2026-06-22T13:00:40.000Z", capabilities: ["chat", "files", "audio"] }),
+    at("2026-06-22T13:00:41.000Z"),
+  );
+  assert.deepEqual(c.capabilities, ["chat", "files", "audio"]);
+  assert.equal(c.lastSeen, at("2026-06-22T13:00:40.000Z"));
+});
+
+test("an out-of-order (older) frame does not overwrite a fresher candidate", () => {
+  const reg = new CandidateRegistry();
+  reg.observe(frame({ nonce: "new", ts: "2026-06-22T13:00:40.000Z" }), at("2026-06-22T13:00:41.000Z"));
+  const stale = reg.observe(
+    frame({ nonce: "old", ts: "2026-06-22T13:00:10.000Z", subject: "msg.stale" }),
+    at("2026-06-22T13:00:42.000Z"),
+  );
+  assert.equal(stale.lastSeen, at("2026-06-22T13:00:40.000Z")); // kept fresher
+  assert.equal(reg.get("agent-x", at("2026-06-22T13:00:42.000Z")).subject, "msg.agent-x");
+});


### PR DESCRIPTION
## What

First slice of the **agent discovery protocol** (README: *find peers without manual invite exchange*). Pure, in-memory, no I/O.

Implements the design draft v0 shared with the team (CODEX-VOLT + agent-stas).

## Changes (`@murmurv2/core`)

- **`PresenceFrameV1` + `isPresenceFrameV1`** — self-describing frame of PUBLIC metadata only: `agentId`, `encryptionPublicKey`, `signingPublicKey`, `subject`, `capabilities[]`, `ttlMs`, `ts`, `nonce`.
- **`CandidateRegistry`** — `observe / get / list / prune / size` with: ttl expiry (`ts + ttlMs`), `(agentId, nonce)` dedupe, and an out-of-order staleness guard (older frame never overwrites a fresher candidate).

## 🔒 Trust invariant (the important part)

Observing a presence only ever produces a **candidate** — it **never auto-trusts or auto-adds a peer**. `candidate.trusted` is hard-`false`; promotion to a trusted peer stays an explicit operator/policy action (PR3). A test enforces this.

This is the direct lesson from our live 4-way onboarding: adding a trusted peer widens the trust border (write access via the receiver's automation), so it must be a deliberate operator step, not a side effect of an inbound frame.

## Tests

10 tests: frame validation, candidate build, expiry, prune, idempotent duplicate, fresh refresh, out-of-order guard, and the no-auto-trust invariant. Full suite green (**core 16**, +10; unit 63, a2a 6, broker-ws 4, federation 24, federation-nats 10). `tsc -b` clean.

## Roadmap

- **PR1 (this):** core types + registry, pure/in-memory.
- **PR2:** NATS `discovery.announce` / `discovery.query` integration over the broker.
- **PR3:** operator promote-candidate→trusted-peer flow + policy.

Open questions from the design draft still welcome: (1) `discovery.query` pull in PR2? (2) capabilities = A2A agent-card schema 1:1 or minimal? Trust stays manual-promote in v0 — confirmed by the onboarding lesson.