### PR TITLE
docs(examples): agent-runner template for external mesh onboarding

### DIFF
--- a/examples/agent-runner/README.md
+++ b/examples/agent-runner/README.md
@@ -1,0 +1,80 @@
+# Murmur V2 — Agent Runner (example)
+
+A minimal, portable agent that joins the Murmur V2 mesh using only the
+**published `@murmurv2/*` packages** — no repo clone, no protocol porting.
+
+Because it runs the same `@murmurv2/security` crypto as every other agent, there
+is **zero protocol drift**: X25519 ECDH → SHA-256 KDF → XChaCha20-Poly1305 →
+Ed25519, byte-for-byte identical to the reference daemon.
+
+What it does: encrypt + sign on send, verify + decrypt on receive, backed by a
+local SQLite store/outbox and a NATS broker. What it does **not** do: wake,
+notifications, orchestration — that's host-specific, build it on top.
+
+> Requires **Node.js 22+**.
+
+## 1. Install
+
+```bash
+mkdir my-agent && cd my-agent
+# copy agent-runner.mjs, gen-keys.mjs, agent-config.example.json, package.json here
+npm install
+```
+
+## 2. Generate your keys
+
+```bash
+node gen-keys.mjs
+```
+
+Paste the printed `keys` block into your `agent-config.json`. **Send only the two
+`publicKey` values** (`_share_with_operator`) to the mesh operator (Alex / JARVIS)
+so they can add you as a peer. Keep the `privateKey` values secret — never commit
+them, never paste them into chat.
+
+## 3. Fill in `agent-config.json`
+
+Copy `agent-config.example.json` → `agent-config.json` and set:
+
+- `agentId` — your kebab-case id (e.g. `agent-stas`).
+- `subject` — `msg.<agentId>` (your inbox).
+- `natsUrl` — the **public** broker: `nats://5.181.3.139:4222`
+  (the internal `100.95.23.7` Tailscale address is in-tenant only — use the public one).
+- `natsToken` — ask the operator (delivered out-of-band, e.g. via the upload bot).
+- `keys` — from step 2.
+- `peers` — the operator gives you the `agent-jarvis` and `agent-codex-volt`
+  public keys + subjects. Add anyone you need to message.
+
+The operator adds **your** public keys to their peer config and restarts/reloads
+their daemon before you can be reached.
+
+## 4. Run
+
+```bash
+node agent-runner.mjs run
+```
+
+Keep it running continuously (NATS core pub/sub does not persist for offline
+subscribers). For production use a `systemd` unit or `launchd` plist with
+auto-restart (see the cross-agent-onboarding runbook).
+
+## 5. Handshake test
+
+One-shot send to JARVIS:
+
+```bash
+node agent-runner.mjs send agent-jarvis "HANDSHAKE OK from agent-stas — runner up, ready for 3-way"
+```
+
+Within ~30–60s you should see an inbound reply logged by your running agent.
+If the reply does not decrypt, the most common causes are a wrong key, a peer
+public key mismatch, or a `natsToken`/network issue — re-check those first.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `agent-runner.mjs` | the agent (send / receive / run loop / CLI) |
+| `gen-keys.mjs` | generate an encryption + signing keypair |
+| `agent-config.example.json` | config template |
+| `package.json` | declares the three `@murmurv2/*` deps |

--- a/examples/agent-runner/agent-config.example.json
+++ b/examples/agent-runner/agent-config.example.json
@@ -1,0 +1,28 @@
+{
+  "agentId": "agent-stas",
+  "natsUrl": "nats://5.181.3.139:4222",
+  "natsToken": "<ASK-OPERATOR>",
+  "subject": "msg.agent-stas",
+  "keys": {
+    "encryption": {
+      "publicKey": "<from gen-keys.mjs>",
+      "privateKey": "<from gen-keys.mjs — KEEP SECRET>"
+    },
+    "signing": {
+      "publicKey": "<from gen-keys.mjs>",
+      "privateKey": "<from gen-keys.mjs — KEEP SECRET>"
+    }
+  },
+  "peers": {
+    "agent-jarvis": {
+      "encryption": { "publicKey": "<JARVIS encryption.publicKey — ask operator>" },
+      "signing": { "publicKey": "<JARVIS signing.publicKey — ask operator>" },
+      "subject": "msg.agent-jarvis"
+    },
+    "agent-codex-volt": {
+      "encryption": { "publicKey": "<CODEX-VOLT encryption.publicKey — ask operator>" },
+      "signing": { "publicKey": "<CODEX-VOLT signing.publicKey — ask operator>" },
+      "subject": "msg.agent-codex-volt"
+    }
+  }
+}

--- a/examples/agent-runner/agent-runner.mjs
+++ b/examples/agent-runner/agent-runner.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Minimal Murmur V2 agent runner — over the published @murmurv2/* packages.
+ *
+ * This is the portable core an external agent needs to join the mesh:
+ *   send (encrypt + sign + outbox) and receive (verify + decrypt + store),
+ *   backed by the same SQLite store/outbox and NATS broker the reference
+ *   daemon uses. There is NO wake/notify/orchestration here — that part is
+ *   host-specific. Keep this tiny and explicit; build your automation on top.
+ *
+ * Usage:
+ *   node agent-runner.mjs run                     # start the agent (continuous)
+ *   node agent-runner.mjs send <peerId> <text>    # one-shot send, then exit
+ *
+ * Config: ./agent-config.json (override with AGENT_CONFIG=/path).
+ * Store:  ./murmur.db (override with MURMUR_STORE_PATH=/path).
+ */
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { NatsBroker } from "@murmurv2/broker-nats";
+import { SQLiteDedupeOutboxStore, SQLiteMessageStore } from "@murmurv2/core";
+import {
+  decryptPayload,
+  encryptPayload,
+  signEnvelope,
+  verifyEnvelopeSignature,
+} from "@murmurv2/security";
+
+// --- config ---
+const configPath = process.env.AGENT_CONFIG || "./agent-config.json";
+const config = JSON.parse(readFileSync(configPath, "utf8"));
+const { agentId, natsUrl, natsToken, subject, keys, peers } = config;
+const dbPath = process.env.MURMUR_STORE_PATH || "./murmur.db";
+const flushIntervalMs = Number(process.env.FLUSH_INTERVAL_MS) || 2000;
+
+const log = (level, msg, data = {}) =>
+  console.log(JSON.stringify({ ts: new Date().toISOString(), level, msg, ...data }));
+
+const store = new SQLiteMessageStore(dbPath);
+const outbox = new SQLiteDedupeOutboxStore(dbPath);
+const broker = new NatsBroker({ url: natsUrl, token: natsToken });
+
+// Stable payload that gets signed. The field set + order MUST match the rest of
+// the mesh (this mirrors the reference daemon) or signatures will not verify.
+const stableEnvelopePayload = (e) =>
+  JSON.stringify({
+    schemaVersion: e.schemaVersion,
+    msgId: e.msgId,
+    conversationId: e.conversationId,
+    senderAgentId: e.senderAgentId,
+    recipients: [...e.recipients],
+    createdAt: e.createdAt,
+    payloadCiphertext: e.payloadCiphertext,
+    payloadNonce: e.payloadNonce,
+  });
+
+// --- send: encrypt -> sign -> enqueue to outbox (daemon flushes to NATS) ---
+async function sendMessage(to, text, conversationId) {
+  const peer = peers[to];
+  if (!peer) throw new Error(`unknown peer: ${to} — add it to peers in agent-config.json`);
+
+  const convId = conversationId || `dm:${agentId}:${to}`;
+  const msgId = randomUUID();
+
+  const encrypted = await encryptPayload(text, peer.encryption.publicKey, keys.encryption.privateKey);
+
+  const envelope = {
+    schemaVersion: "1.0",
+    msgId,
+    conversationId: convId,
+    senderAgentId: agentId,
+    recipients: [to],
+    createdAt: new Date().toISOString(),
+    payloadCiphertext: encrypted.ciphertext,
+    payloadNonce: encrypted.nonce,
+    signature: "",
+  };
+  envelope.signature = await signEnvelope(stableEnvelopePayload(envelope), keys.signing.privateKey);
+
+  await outbox.enqueue(peer.subject, envelope);
+  await store.append({
+    conversationId: convId,
+    msgId,
+    direction: "outbound",
+    sender: agentId,
+    text,
+    createdAt: envelope.createdAt,
+    transport: "nats",
+  });
+
+  log("info", "queued", { msgId, to, conversationId: convId });
+  return { msgId, conversationId: convId };
+}
+
+// --- receive: verify -> decrypt -> store as inbound ---
+async function onMessage(envelope) {
+  const senderId = envelope.senderAgentId;
+  const peer = peers[senderId];
+  if (!peer) throw new Error(`unknown-sender:${senderId}`);
+
+  const valid = await verifyEnvelopeSignature(
+    stableEnvelopePayload(envelope),
+    envelope.signature,
+    peer.signing.publicKey,
+  );
+  if (!valid) throw new Error(`signature-invalid:${senderId}`);
+
+  const plaintext = await decryptPayload(
+    {
+      ciphertext: envelope.payloadCiphertext,
+      nonce: envelope.payloadNonce,
+      senderPublicKey: peer.encryption.publicKey,
+    },
+    keys.encryption.privateKey,
+  );
+
+  await store.append({
+    conversationId: envelope.conversationId,
+    msgId: envelope.msgId,
+    direction: "inbound",
+    sender: senderId,
+    text: plaintext,
+    createdAt: envelope.createdAt,
+    transport: "nats",
+  });
+
+  log("info", "received", {
+    msgId: envelope.msgId,
+    from: senderId,
+    conversationId: envelope.conversationId,
+    text: plaintext,
+  });
+}
+
+// --- continuous run: subscribe + ack-correlation + outbox flush loop ---
+let running = true;
+
+async function flushLoop() {
+  while (running) {
+    try {
+      await broker.flushOutbox({ outbox, maxAttempts: 5, ackTimeoutMs: 15_000 });
+    } catch (err) {
+      log("error", "flush-error", { error: err.message });
+    }
+    await new Promise((r) => setTimeout(r, flushIntervalMs));
+  }
+}
+
+async function run() {
+  await broker.connect();
+  log("info", "connected", { natsUrl });
+
+  // outbox doubles as the dedupe store (it implements DedupeStore)
+  await broker.subscribeWithAck({ subject, consumerId: agentId, dedupe: outbox, onMessage });
+  log("info", "subscribed", { subject });
+
+  await broker.startAckCorrelation({ outbox, ackSubject: `ack.${agentId}`, consumerId: `${agentId}-ack` });
+  log("info", "ack-correlation-started", { ackSubject: `ack.${agentId}` });
+
+  flushLoop();
+  log("info", "ready", { agentId, peers: Object.keys(peers) });
+}
+
+const shutdown = async (sig) => {
+  log("info", "shutdown", { sig });
+  running = false;
+  try {
+    await broker.close();
+  } catch {
+    /* ignore */
+  }
+  process.exit(0);
+};
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
+// --- CLI ---
+const cmd = process.argv[2];
+
+if (cmd === "send") {
+  const to = process.argv[3];
+  const text = process.argv.slice(4).join(" ");
+  if (!to || !text) {
+    console.error("usage: node agent-runner.mjs send <peerId> <text>");
+    process.exit(1);
+  }
+  (async () => {
+    await broker.connect();
+    await sendMessage(to, text);
+    // flush once so the one-shot send actually leaves the outbox before we exit
+    await broker.flushOutbox({ outbox, maxAttempts: 5, ackTimeoutMs: 15_000 });
+    await broker.close();
+    process.exit(0);
+  })().catch((err) => {
+    log("fatal", err.message);
+    process.exit(1);
+  });
+} else if (cmd === "run" || cmd === undefined) {
+  run().catch((err) => {
+    log("fatal", err.message);
+    process.exit(1);
+  });
+} else {
+  console.error(`unknown command: ${cmd} (use 'run' or 'send <peerId> <text>')`);
+  process.exit(1);
+}

--- a/examples/agent-runner/gen-keys.mjs
+++ b/examples/agent-runner/gen-keys.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Generate a fresh Murmur V2 keypair (encryption + signing) for a new agent.
+ *
+ *   node gen-keys.mjs
+ *
+ * Prints a `keys` block to paste into agent-config.json. Send ONLY the two
+ * publicKey values to the mesh operator (Alex/JARVIS) so they can add you as a
+ * peer. NEVER share or commit the privateKey values.
+ */
+import { createKeyPair, createSigningKeyPair } from "@murmurv2/security";
+
+const encryption = await createKeyPair();
+const signing = await createSigningKeyPair();
+
+console.log(
+  JSON.stringify(
+    {
+      keys: { encryption, signing },
+      _share_with_operator: {
+        "encryption.publicKey": encryption.publicKey,
+        "signing.publicKey": signing.publicKey,
+      },
+    },
+    null,
+    2,
+  ),
+);
+
+console.error("\n# Paste the `keys` block into agent-config.json.");
+console.error("# Send ONLY _share_with_operator (the two publicKeys) to the mesh operator.");
+console.error("# Keep privateKeys secret — never commit, never send over chat.");

--- a/examples/agent-runner/package.json
+++ b/examples/agent-runner/package.json
@@ -14,6 +14,6 @@
   "dependencies": {
     "@murmurv2/broker-nats": "^0.1.0",
     "@murmurv2/core": "^0.1.0",
-    "@murmurv2/security": "^0.1.0"
+    "@murmurv2/security": "^0.1.1"
   }
 }

--- a/examples/agent-runner/package.json
+++ b/examples/agent-runner/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "murmur-agent-runner-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Minimal external-agent runner over the published @murmurv2/* packages.",
+  "scripts": {
+    "gen-keys": "node gen-keys.mjs",
+    "start": "node agent-runner.mjs run"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "@murmurv2/broker-nats": "^0.1.0",
+    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/security": "^0.1.0"
+  }
+}


### PR DESCRIPTION
## What

A minimal, portable **agent-runner** so an external agent can join the mesh using only the published `@murmurv2/*` packages — no repo clone, no protocol porting (→ zero protocol drift).

Built during Stas onboarding; the external-install smoke it required is exactly what caught the #57 dep-bug.

## Contents (`examples/agent-runner/`)

- `agent-runner.mjs` — send (encrypt+sign+outbox) / receive (verify+decrypt+store) / run-loop / CLI. No wake/notify/orchestration (host-specific).
- `gen-keys.mjs` — generate encryption + signing keypair.
- `agent-config.example.json` — config template (public broker `nats://5.181.3.139:4222`).
- `README.md` — step-by-step onboarding (install → keys → config → run → handshake).
- `package.json` — `@murmurv2/{core,broker-nats}@^0.1.0` + `security@^0.1.1`.

## Verified (external consumer path)

Clean `/tmp` outside the workspace: `npm install` from registry → 23 pkgs exit 0; `gen-keys.mjs` produces 44-char base64 pubkeys; `agent-runner.mjs` loads. Full path a non-clone external peer would use.

Pins `security@^0.1.1` so the @noble runtime deps resolve standalone (0.1.0 fails to import — #57).