### PR TITLE
feat(core): streaming PR2 NATS ack window and integrity

### DIFF
--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -13,12 +13,14 @@ import {
   applyJitter,
   computeBackoffMs,
   createAck,
+  estimateBase64DecodedBytes,
   type EnvelopeV1,
   isEnvelopeV1,
   type DedupeStore,
   type OutboxStore,
   type AckV1,
   type SecurityPolicy,
+  streamBackpressureAllowsSend,
   validateEnvelopePolicy,
 } from "@murmurv2/core";
 
@@ -49,6 +51,11 @@ export interface BrokerStatusEvent {
   type: string;
   data?: unknown;
   reconnects: number;
+}
+
+export interface AckWindowConfig {
+  maxInFlightChunks: number;
+  maxInFlightBytes: number;
 }
 
 interface JetStreamConsumerAdvisory {
@@ -560,6 +567,7 @@ export class NatsBroker {
     baseBackoffMs?: number;
     jitterRatio?: number;
     ackTimeoutMs?: number;
+    ackWindow?: AckWindowConfig;
     policy?: SecurityPolicy;
   }): Promise<void> {
     const maxAttempts = params.maxAttempts ?? 5;
@@ -567,11 +575,31 @@ export class NatsBroker {
       await params.outbox.requeueStaleSent(params.ackTimeoutMs);
     }
     const due = await params.outbox.claimDue(params.batchSize ?? 50);
+    const inFlight = params.ackWindow && params.outbox.listInFlight
+      ? await params.outbox.listInFlight()
+      : [];
+    let inFlightChunks = inFlight.length;
+    let inFlightBytes = inFlight.reduce((sum, rec) => sum + estimateBase64DecodedBytes(rec.envelope.payloadCiphertext), 0);
 
     for (const rec of due) {
+      const nextChunkBytes = Math.max(1, estimateBase64DecodedBytes(rec.envelope.payloadCiphertext));
+      if (params.ackWindow && !streamBackpressureAllowsSend({
+        inFlightChunks,
+        inFlightBytes,
+        nextChunkBytes,
+        maxInFlightChunks: params.ackWindow.maxInFlightChunks,
+        maxInFlightBytes: params.ackWindow.maxInFlightBytes,
+      })) {
+        break;
+      }
+
       try {
         await this.publish(rec.subject, rec.envelope, params.policy);
         await params.outbox.markSent(rec.msgId);
+        if (params.ackWindow) {
+          inFlightChunks += 1;
+          inFlightBytes += nextChunkBytes;
+        }
       } catch (err) {
         const nextAttemptNum = rec.attempts + 1;
         const reason = err instanceof Error ? err.message : "publish-failed";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { mkdirSync, promises as fs } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -136,6 +136,7 @@ export interface OutboxRecord {
 export interface OutboxStore {
   enqueue(subject: string, envelope: EnvelopeV1): Promise<void>;
   claimDue(limit?: number): Promise<OutboxRecord[]>;
+  listInFlight?(): Promise<OutboxRecord[]>;
   markSent(msgId: string): Promise<void>;
   markAcked(msgId: string): Promise<void>;
   markFailed(msgId: string, error: string, nextAttemptAt: string): Promise<void>;
@@ -192,6 +193,11 @@ export class JsonFileOutboxStore implements OutboxStore {
     return state.records
       .filter((r) => ["pending", "failed"].includes(r.status) && new Date(r.nextAttemptAt).getTime() <= now)
       .slice(0, limit);
+  }
+
+  async listInFlight(): Promise<OutboxRecord[]> {
+    const state = await this.load();
+    return state.records.filter((r) => r.status === "sent");
   }
 
   async markSent(msgId: string): Promise<void> {
@@ -331,6 +337,13 @@ export class SQLiteDedupeOutboxStore implements DedupeStore, OutboxStore {
       )
       .all(new Date().toISOString(), limit) as Array<Record<string, unknown>>;
 
+    return rows.map((row) => this.toOutboxRecord(row));
+  }
+
+  async listInFlight(): Promise<OutboxRecord[]> {
+    const rows = this.db
+      .prepare("SELECT * FROM outbox WHERE status = 'sent' ORDER BY updated_at ASC")
+      .all() as Array<Record<string, unknown>>;
     return rows.map((row) => this.toOutboxRecord(row));
   }
 
@@ -589,6 +602,7 @@ export interface StreamChunk {
   chunkIndex: number;
   chunkCount: number;
   data: string;
+  sha256?: string;
   isLast: boolean;
 }
 
@@ -598,6 +612,7 @@ export interface StreamEnd {
   chunkCount: number;
   totalBytes: number;
   digest?: string;
+  sha256?: string;
 }
 
 export type StreamFrame = StreamStart | StreamChunk | StreamEnd;
@@ -621,6 +636,7 @@ export interface CreateStreamChunkInput {
   chunkIndex: number;
   chunkCount: number;
   data: string;
+  sha256?: string;
 }
 
 export interface CreateStreamEndInput {
@@ -628,6 +644,7 @@ export interface CreateStreamEndInput {
   chunkCount: number;
   totalBytes: number;
   digest?: string;
+  sha256?: string;
 }
 
 export interface StreamReassemblyResult {
@@ -636,12 +653,14 @@ export interface StreamReassemblyResult {
   receivedChunks: number;
   chunkCount: number;
   text?: string;
+  sha256?: string;
 }
 
 export interface StreamReassemblyState {
   streamId: string;
   chunkCount: number;
   receivedChunks: number;
+  sha256?: string;
 }
 
 export interface StreamBackpressureWindow {
@@ -655,6 +674,14 @@ export interface StreamBackpressureWindow {
 const textEncoder = new TextEncoder();
 
 const utf8Bytes = (value: string): number => textEncoder.encode(value).byteLength;
+
+export const sha256Hex = (value: string): string => createHash("sha256").update(value, "utf8").digest("hex");
+
+const isSha256Hex = (value: string): boolean => /^[a-f0-9]{64}$/i.test(value);
+
+const assertSha256 = (name: string, value: string): void => {
+  if (!isSha256Hex(value)) throw new Error(`${name}-invalid`);
+};
 
 const assertPositiveInteger = (name: string, value: number): void => {
   if (!Number.isInteger(value) || value < 1) throw new Error(`${name}-invalid`);
@@ -687,6 +714,11 @@ export const createStreamChunk = (input: CreateStreamChunkInput): StreamChunk =>
   assertPositiveInteger("stream-chunk-count", input.chunkCount);
   if (input.chunkIndex >= input.chunkCount) throw new Error("stream-chunk-index-out-of-range");
   if (input.data.length === 0) throw new Error("stream-chunk-data-required");
+  const computedSha256 = sha256Hex(input.data);
+  if (input.sha256 !== undefined) {
+    assertSha256("stream-chunk-sha256", input.sha256);
+    if (input.sha256 !== computedSha256) throw new Error(`stream-chunk-sha256-mismatch:${input.streamId}:${input.chunkIndex}`);
+  }
 
   return {
     kind: "stream.chunk",
@@ -694,6 +726,7 @@ export const createStreamChunk = (input: CreateStreamChunkInput): StreamChunk =>
     chunkIndex: input.chunkIndex,
     chunkCount: input.chunkCount,
     data: input.data,
+    sha256: input.sha256 ?? computedSha256,
     isLast: input.chunkIndex === input.chunkCount - 1,
   };
 };
@@ -703,6 +736,7 @@ export const createStreamEnd = (input: CreateStreamEndInput): StreamEnd => {
   assertPositiveInteger("stream-chunk-count", input.chunkCount);
   assertNonNegativeInteger("stream-total-bytes", input.totalBytes);
   if (input.digest !== undefined && input.digest.length === 0) throw new Error("stream-digest-invalid");
+  if (input.sha256 !== undefined) assertSha256("stream-sha256", input.sha256);
 
   return {
     kind: "stream.end",
@@ -710,6 +744,7 @@ export const createStreamEnd = (input: CreateStreamEndInput): StreamEnd => {
     chunkCount: input.chunkCount,
     totalBytes: input.totalBytes,
     ...(input.digest !== undefined ? { digest: input.digest } : {}),
+    ...(input.sha256 !== undefined ? { sha256: input.sha256 } : {}),
   };
 };
 
@@ -745,7 +780,24 @@ export const chunkStreamText = (input: ChunkStreamTextInput): StreamChunk[] => {
 };
 
 export class InMemoryStreamReassembler {
-  private readonly streams = new Map<string, { chunkCount: number; chunks: Map<number, string> }>();
+  private readonly streams = new Map<string, { chunkCount: number; chunks: Map<number, string>; endSha256?: string }>();
+
+  acceptEnd(end: StreamEnd): StreamReassemblyResult {
+    this.validateEnd(end);
+    let state = this.streams.get(end.streamId);
+    if (!state) {
+      state = { chunkCount: end.chunkCount, chunks: new Map<number, string>(), endSha256: end.sha256 };
+      this.streams.set(end.streamId, state);
+    } else {
+      if (state.chunkCount !== end.chunkCount) throw new Error(`stream-chunk-count-conflict:${end.streamId}`);
+      if (state.endSha256 !== undefined && end.sha256 !== undefined && state.endSha256 !== end.sha256) {
+        throw new Error(`stream-sha256-conflict:${end.streamId}`);
+      }
+      state.endSha256 = state.endSha256 ?? end.sha256;
+    }
+
+    return this.completeIfReady(end.streamId, state);
+  }
 
   accept(chunk: StreamChunk): StreamReassemblyResult {
     this.validateChunk(chunk);
@@ -769,24 +821,7 @@ export class InMemoryStreamReassembler {
     }
 
     state.chunks.set(chunk.chunkIndex, chunk.data);
-    if (state.chunks.size !== state.chunkCount) {
-      return {
-        status: "pending",
-        streamId: chunk.streamId,
-        receivedChunks: state.chunks.size,
-        chunkCount: state.chunkCount,
-      };
-    }
-
-    const text = Array.from({ length: state.chunkCount }, (_, index) => state.chunks.get(index) ?? "").join("");
-    this.streams.delete(chunk.streamId);
-    return {
-      status: "complete",
-      streamId: chunk.streamId,
-      receivedChunks: state.chunkCount,
-      chunkCount: state.chunkCount,
-      text,
-    };
+    return this.completeIfReady(chunk.streamId, state);
   }
 
   get(streamId: string): StreamReassemblyState | undefined {
@@ -796,6 +831,7 @@ export class InMemoryStreamReassembler {
       streamId,
       chunkCount: state.chunkCount,
       receivedChunks: state.chunks.size,
+      ...(state.endSha256 !== undefined ? { sha256: state.endSha256 } : {}),
     };
   }
 
@@ -815,6 +851,236 @@ export class InMemoryStreamReassembler {
     if (chunk.chunkIndex >= chunk.chunkCount) throw new Error("stream-chunk-index-out-of-range");
     if (chunk.data.length === 0) throw new Error("stream-chunk-data-required");
     if (chunk.isLast !== (chunk.chunkIndex === chunk.chunkCount - 1)) throw new Error("stream-chunk-last-flag-invalid");
+    if (chunk.sha256 !== undefined) {
+      assertSha256("stream-chunk-sha256", chunk.sha256);
+      if (chunk.sha256 !== sha256Hex(chunk.data)) throw new Error(`stream-chunk-sha256-mismatch:${chunk.streamId}:${chunk.chunkIndex}`);
+    }
+  }
+
+  private validateEnd(end: StreamEnd): void {
+    if (end.kind !== "stream.end") throw new Error("stream-end-kind-invalid");
+    if (!end.streamId) throw new Error("stream-id-required");
+    assertPositiveInteger("stream-chunk-count", end.chunkCount);
+    assertNonNegativeInteger("stream-total-bytes", end.totalBytes);
+    if (end.sha256 !== undefined) assertSha256("stream-sha256", end.sha256);
+  }
+
+  private completeIfReady(
+    streamId: string,
+    state: { chunkCount: number; chunks: Map<number, string>; endSha256?: string },
+  ): StreamReassemblyResult {
+    if (state.chunks.size !== state.chunkCount) {
+      return {
+        status: "pending",
+        streamId,
+        receivedChunks: state.chunks.size,
+        chunkCount: state.chunkCount,
+      };
+    }
+
+    const text = Array.from({ length: state.chunkCount }, (_, index) => state.chunks.get(index) ?? "").join("");
+    const actualSha256 = sha256Hex(text);
+    if (state.endSha256 !== undefined && state.endSha256 !== actualSha256) {
+      throw new Error(`stream-sha256-mismatch:${streamId}`);
+    }
+    this.streams.delete(streamId);
+    return {
+      status: "complete",
+      streamId,
+      receivedChunks: state.chunkCount,
+      chunkCount: state.chunkCount,
+      text,
+      sha256: actualSha256,
+    };
+  }
+}
+
+export class SQLiteStreamReassembler {
+  private readonly db: DatabaseSync;
+
+  constructor(dbPath = ".data/murmur.db") {
+    ensureDir(dbPath);
+    this.db = new DatabaseSync(dbPath);
+    this.db.exec(`
+      PRAGMA journal_mode=WAL;
+      CREATE TABLE IF NOT EXISTS stream_reassembly_meta (
+        stream_id TEXT PRIMARY KEY,
+        chunk_count INTEGER NOT NULL,
+        end_sha256 TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS stream_reassembly_chunks (
+        stream_id TEXT NOT NULL,
+        chunk_index INTEGER NOT NULL,
+        chunk_count INTEGER NOT NULL,
+        data TEXT NOT NULL,
+        sha256 TEXT,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (stream_id, chunk_index)
+      );
+      CREATE INDEX IF NOT EXISTS idx_stream_reassembly_chunks_stream ON stream_reassembly_chunks(stream_id);
+    `);
+  }
+
+  acceptEnd(end: StreamEnd): StreamReassemblyResult {
+    this.validateEnd(end);
+    this.ensureMeta(end.streamId, end.chunkCount, end.sha256);
+    return this.completeIfReady(end.streamId);
+  }
+
+  accept(chunk: StreamChunk): StreamReassemblyResult {
+    this.validateChunk(chunk);
+    this.ensureMeta(chunk.streamId, chunk.chunkCount);
+    const existing = this.db
+      .prepare("SELECT data FROM stream_reassembly_chunks WHERE stream_id = ? AND chunk_index = ?")
+      .get(chunk.streamId, chunk.chunkIndex) as { data: string } | undefined;
+
+    if (existing) {
+      if (existing.data !== chunk.data) throw new Error(`stream-chunk-conflict:${chunk.streamId}:${chunk.chunkIndex}`);
+      const state = this.get(chunk.streamId);
+      return {
+        status: "duplicate",
+        streamId: chunk.streamId,
+        receivedChunks: state?.receivedChunks ?? 0,
+        chunkCount: chunk.chunkCount,
+      };
+    }
+
+    this.db
+      .prepare(
+        `INSERT INTO stream_reassembly_chunks
+         (stream_id, chunk_index, chunk_count, data, sha256, created_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(chunk.streamId, chunk.chunkIndex, chunk.chunkCount, chunk.data, chunk.sha256 ?? null, new Date().toISOString());
+
+    return this.completeIfReady(chunk.streamId);
+  }
+
+  get(streamId: string): StreamReassemblyState | undefined {
+    const meta = this.getMeta(streamId);
+    if (!meta) return undefined;
+    const count = this.db
+      .prepare("SELECT COUNT(*) as count FROM stream_reassembly_chunks WHERE stream_id = ?")
+      .get(streamId) as { count: number };
+    return {
+      streamId,
+      chunkCount: meta.chunkCount,
+      receivedChunks: Number(count.count),
+      ...(meta.endSha256 !== undefined ? { sha256: meta.endSha256 } : {}),
+    };
+  }
+
+  delete(streamId: string): boolean {
+    const before = this.get(streamId);
+    this.db.prepare("DELETE FROM stream_reassembly_chunks WHERE stream_id = ?").run(streamId);
+    this.db.prepare("DELETE FROM stream_reassembly_meta WHERE stream_id = ?").run(streamId);
+    return before !== undefined;
+  }
+
+  clear(): void {
+    this.db.prepare("DELETE FROM stream_reassembly_chunks").run();
+    this.db.prepare("DELETE FROM stream_reassembly_meta").run();
+  }
+
+  private ensureMeta(streamId: string, chunkCount: number, endSha256?: string): void {
+    const existing = this.getMeta(streamId);
+    const now = new Date().toISOString();
+    if (!existing) {
+      this.db
+        .prepare(
+          `INSERT INTO stream_reassembly_meta
+           (stream_id, chunk_count, end_sha256, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(streamId, chunkCount, endSha256 ?? null, now, now);
+      return;
+    }
+
+    if (existing.chunkCount !== chunkCount) throw new Error(`stream-chunk-count-conflict:${streamId}`);
+    if (existing.endSha256 !== undefined && endSha256 !== undefined && existing.endSha256 !== endSha256) {
+      throw new Error(`stream-sha256-conflict:${streamId}`);
+    }
+    if (existing.endSha256 === undefined && endSha256 !== undefined) {
+      this.db
+        .prepare("UPDATE stream_reassembly_meta SET end_sha256 = ?, updated_at = ? WHERE stream_id = ?")
+        .run(endSha256, now, streamId);
+    }
+  }
+
+  private getMeta(streamId: string): { chunkCount: number; endSha256?: string } | undefined {
+    const row = this.db
+      .prepare("SELECT chunk_count as chunkCount, end_sha256 as endSha256 FROM stream_reassembly_meta WHERE stream_id = ?")
+      .get(streamId) as { chunkCount: number; endSha256: string | null } | undefined;
+    if (!row) return undefined;
+    return {
+      chunkCount: Number(row.chunkCount),
+      ...(row.endSha256 ? { endSha256: row.endSha256 } : {}),
+    };
+  }
+
+  private completeIfReady(streamId: string): StreamReassemblyResult {
+    const meta = this.getMeta(streamId);
+    if (!meta) throw new Error(`stream-state-missing:${streamId}`);
+    const rows = this.db
+      .prepare("SELECT chunk_index as chunkIndex, data FROM stream_reassembly_chunks WHERE stream_id = ? ORDER BY chunk_index ASC")
+      .all(streamId) as Array<{ chunkIndex: number; data: string }>;
+    if (rows.length !== meta.chunkCount) {
+      return {
+        status: "pending",
+        streamId,
+        receivedChunks: rows.length,
+        chunkCount: meta.chunkCount,
+      };
+    }
+    for (let index = 0; index < meta.chunkCount; index += 1) {
+      if (Number(rows[index]?.chunkIndex) !== index) {
+        return {
+          status: "pending",
+          streamId,
+          receivedChunks: rows.length,
+          chunkCount: meta.chunkCount,
+        };
+      }
+    }
+
+    const text = rows.map((row) => row.data).join("");
+    const actualSha256 = sha256Hex(text);
+    if (meta.endSha256 !== undefined && meta.endSha256 !== actualSha256) {
+      throw new Error(`stream-sha256-mismatch:${streamId}`);
+    }
+    this.delete(streamId);
+    return {
+      status: "complete",
+      streamId,
+      receivedChunks: meta.chunkCount,
+      chunkCount: meta.chunkCount,
+      text,
+      sha256: actualSha256,
+    };
+  }
+
+  private validateChunk(chunk: StreamChunk): void {
+    if (chunk.kind !== "stream.chunk") throw new Error("stream-chunk-kind-invalid");
+    if (!chunk.streamId) throw new Error("stream-id-required");
+    assertNonNegativeInteger("stream-chunk-index", chunk.chunkIndex);
+    assertPositiveInteger("stream-chunk-count", chunk.chunkCount);
+    if (chunk.chunkIndex >= chunk.chunkCount) throw new Error("stream-chunk-index-out-of-range");
+    if (chunk.data.length === 0) throw new Error("stream-chunk-data-required");
+    if (chunk.isLast !== (chunk.chunkIndex === chunk.chunkCount - 1)) throw new Error("stream-chunk-last-flag-invalid");
+    if (chunk.sha256 !== undefined) {
+      assertSha256("stream-chunk-sha256", chunk.sha256);
+      if (chunk.sha256 !== sha256Hex(chunk.data)) throw new Error(`stream-chunk-sha256-mismatch:${chunk.streamId}:${chunk.chunkIndex}`);
+    }
+  }
+
+  private validateEnd(end: StreamEnd): void {
+    if (end.kind !== "stream.end") throw new Error("stream-end-kind-invalid");
+    if (!end.streamId) throw new Error("stream-id-required");
+    assertPositiveInteger("stream-chunk-count", end.chunkCount);
+    assertNonNegativeInteger("stream-total-bytes", end.totalBytes);
+    if (end.sha256 !== undefined) assertSha256("stream-sha256", end.sha256);
   }
 }
 

--- a/packages/core/test/streaming.test.mjs
+++ b/packages/core/test/streaming.test.mjs
@@ -2,12 +2,17 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   InMemoryStreamReassembler,
+  SQLiteStreamReassembler,
   chunkStreamText,
   createStreamEnd,
   createStreamChunk,
   createStreamStart,
+  sha256Hex,
   streamBackpressureAllowsSend,
 } from "../dist/src/index.js";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 test("createStreamStart and createStreamEnd frame stream boundaries without payload data", () => {
   const startedAt = "2026-06-22T13:00:00.000Z";
@@ -61,6 +66,42 @@ test("chunkStreamText splits UTF-8 text without exceeding max payload bytes", ()
     assert.ok(Buffer.byteLength(chunk.data, "utf8") <= 37);
   }
   assert.equal(chunks.map((chunk) => chunk.data).join(""), text);
+  assert.equal(chunks[0].sha256, sha256Hex(chunks[0].data));
+});
+
+test("InMemoryStreamReassembler verifies per-chunk and total sha256", () => {
+  const text = "integrity checked Привет";
+  const chunks = chunkStreamText({ streamId: "stream-sha", text, maxChunkBytes: 9 });
+  const end = createStreamEnd({
+    streamId: "stream-sha",
+    chunkCount: chunks.length,
+    totalBytes: Buffer.byteLength(text, "utf8"),
+    sha256: sha256Hex(text),
+  });
+  const reassembler = new InMemoryStreamReassembler();
+
+  assert.equal(reassembler.acceptEnd(end).status, "pending");
+  let result;
+  for (const chunk of chunks) result = reassembler.accept(chunk);
+
+  assert.equal(result.status, "complete");
+  assert.equal(result.text, text);
+  assert.equal(result.sha256, sha256Hex(text));
+});
+
+test("InMemoryStreamReassembler rejects chunk sha256 mismatch", () => {
+  const reassembler = new InMemoryStreamReassembler();
+  const chunk = createStreamChunk({
+    streamId: "stream-bad-sha",
+    chunkIndex: 0,
+    chunkCount: 1,
+    data: "hello",
+  });
+
+  assert.throws(
+    () => reassembler.accept({ ...chunk, sha256: sha256Hex("HELLO") }),
+    /stream-chunk-sha256-mismatch:stream-bad-sha:0/,
+  );
 });
 
 test("chunkStreamText rejects invalid byte budgets", () => {
@@ -109,9 +150,37 @@ test("InMemoryStreamReassembler rejects conflicting duplicate chunk data", () =>
   reassembler.accept(chunk);
 
   assert.throws(
-    () => reassembler.accept({ ...chunk, data: "HELLO " }),
+    () => reassembler.accept({ ...chunk, data: "HELLO ", sha256: sha256Hex("HELLO ") }),
     /stream-chunk-conflict:stream-3:0/,
   );
+});
+
+test("SQLiteStreamReassembler durably completes after restart", () => {
+  const dir = mkdtempSync(join(tmpdir(), "murmur-stream-"));
+  const dbPath = join(dir, "stream.db");
+  const text = "durable stream payload survives process restart";
+  const chunks = chunkStreamText({ streamId: "stream-sqlite", text, maxChunkBytes: 8 });
+  const end = createStreamEnd({
+    streamId: "stream-sqlite",
+    chunkCount: chunks.length,
+    totalBytes: Buffer.byteLength(text, "utf8"),
+    sha256: sha256Hex(text),
+  });
+
+  const first = new SQLiteStreamReassembler(dbPath);
+  first.accept(chunks[1]);
+  first.acceptEnd(end);
+
+  const second = new SQLiteStreamReassembler(dbPath);
+  let result;
+  for (const chunk of [chunks[0], ...chunks.slice(2)]) {
+    result = second.accept(chunk);
+  }
+
+  assert.equal(result.status, "complete");
+  assert.equal(result.text, text);
+  assert.equal(result.sha256, sha256Hex(text));
+  assert.equal(second.get("stream-sqlite"), undefined);
 });
 
 test("streamBackpressureAllowsSend enforces chunk and byte windows", () => {

--- a/tests/broker-flush.test.mjs
+++ b/tests/broker-flush.test.mjs
@@ -18,7 +18,7 @@ const makeOutbox = (records) => {
   const state = new Map(records.map((r) => [r.msgId, { ...r }]));
   return {
     async claimDue() {
-      return [...state.values()];
+      return [...state.values()].filter((r) => ["pending", "failed"].includes(r.status));
     },
     async markSent(msgId) {
       state.get(msgId).status = "sent";
@@ -34,8 +34,13 @@ const makeOutbox = (records) => {
       row.status = "dlq";
       row.lastError = err;
     },
-    async markAcked() {},
+    async markAcked(msgId) {
+      state.get(msgId).status = "acked";
+    },
     async enqueue() {},
+    async listInFlight() {
+      return [...state.values()].filter((r) => r.status === "sent");
+    },
     __state: state,
   };
 };
@@ -67,4 +72,49 @@ test("flushOutbox retries transient failures with failed status", async () => {
   assert.equal(row.status, "failed");
   assert.equal(row.lastError, "network-timeout");
   assert.ok(new Date(row.nextAttemptAt).getTime() >= Date.now());
+});
+
+test("flushOutbox respects durable ACK window before publishing more chunks", async () => {
+  const sentEnvelope = {
+    ...envelope,
+    msgId: "msg-sent",
+    payloadCiphertext: Buffer.from("already in flight").toString("base64"),
+  };
+  const pendingEnvelope = {
+    ...envelope,
+    msgId: "msg-pending",
+    payloadCiphertext: Buffer.from("next chunk").toString("base64"),
+  };
+  const outbox = makeOutbox([
+    { msgId: sentEnvelope.msgId, subject: "s", envelope: sentEnvelope, attempts: 1, status: "sent", nextAttemptAt: new Date().toISOString() },
+    { msgId: pendingEnvelope.msgId, subject: "s", envelope: pendingEnvelope, attempts: 0, status: "pending", nextAttemptAt: new Date().toISOString() },
+  ]);
+  const published = [];
+  const broker = new NatsBroker({ url: "nats://invalid:4222" });
+  broker.publish = async (_subject, env) => {
+    published.push(env.msgId);
+  };
+
+  await broker.flushOutbox({
+    outbox,
+    ackWindow: {
+      maxInFlightChunks: 1,
+      maxInFlightBytes: 1024,
+    },
+  });
+
+  assert.deepEqual(published, []);
+  assert.equal(outbox.__state.get(pendingEnvelope.msgId).status, "pending");
+
+  await outbox.markAcked(sentEnvelope.msgId);
+  await broker.flushOutbox({
+    outbox,
+    ackWindow: {
+      maxInFlightChunks: 1,
+      maxInFlightBytes: 1024,
+    },
+  });
+
+  assert.deepEqual(published, [pendingEnvelope.msgId]);
+  assert.equal(outbox.__state.get(pendingEnvelope.msgId).status, "sent");
 });


### PR DESCRIPTION
## Summary
- add per-chunk and total sha256 support for streaming frames/reassembly
- add SQLiteStreamReassembler for durable chunk reassembly across process restarts
- add broker ACK-window gating in flushOutbox using durable sent outbox rows and ciphertext byte estimates only

## Verification
- npm test

## Notes
- No shared NATS broker touched; verification is local/unit only.
- PR #61 was reviewed separately; GitHub rejected formal approve because this auth identity is treated as the PR author, so I left a non-approving review comment with smoke evidence.