### PR TITLE
feat(discovery): PR2 — signed presence frames + NATS announce/listen

### DIFF
--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -15,6 +15,8 @@ import {
   createAck,
   type EnvelopeV1,
   isEnvelopeV1,
+  isSignedPresenceFrameV1,
+  type SignedPresenceFrameV1,
   type DedupeStore,
   type OutboxStore,
   type AckV1,
@@ -405,6 +407,51 @@ export class NatsBroker {
     })().catch((err) => {
       const e = err instanceof Error ? err : new Error(String(err));
       console.error("[NatsBroker.subscribeRaw] loop crashed", { subject, message: e.message, stack: e.stack });
+    });
+
+    return sub;
+  }
+
+  /**
+   * Broadcast a signed presence frame for agent discovery. Presence is PUBLIC
+   * (public keys + capabilities), so it is published in the clear — not encrypted
+   * like a message envelope. Integrity/authorship come from the frame signature.
+   */
+  async announcePresence(subject: string, signed: SignedPresenceFrameV1): Promise<void> {
+    await this.connect();
+    const payload = this.sc.encode(JSON.stringify(signed));
+    if (this.js) {
+      await this.js.publish(subject, payload);
+      return;
+    }
+    this.nc!.publish(subject, payload);
+  }
+
+  /**
+   * Listen for signed presence frames on a discovery subject. Plain read-only
+   * subscription — no ACK, no dedupe, no JetStream consumer. Signature
+   * verification + registry folding are the caller's job (see
+   * `observeSignedPresence` in @murmurv2/core). Malformed frames are dropped.
+   */
+  async subscribePresence(
+    subject: string,
+    onPresence: (signed: SignedPresenceFrameV1) => void,
+  ): Promise<BrokerSubscription> {
+    await this.connect();
+    const sub = this.nc!.subscribe(subject);
+
+    (async () => {
+      for await (const m of sub) {
+        try {
+          const decoded = JSON.parse(this.sc.decode(m.data));
+          if (isSignedPresenceFrameV1(decoded)) onPresence(decoded);
+        } catch {
+          // ignore malformed presence frames — discovery is best-effort
+        }
+      }
+    })().catch((err) => {
+      const e = err instanceof Error ? err : new Error(String(err));
+      console.error("[NatsBroker.subscribePresence] loop crashed", { subject, message: e.message, stack: e.stack });
     });
 
     return sub;

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -151,3 +151,74 @@ export class CandidateRegistry {
     return this.list(now).length;
   }
 }
+
+/**
+ * Canonical string a presence frame is signed over. Fixed field set + order so
+ * both sides hash identical bytes regardless of object key order. Mirrors the
+ * envelope's stable-payload approach. The `signature` field is NOT included.
+ */
+export const stablePresencePayload = (frame: PresenceFrameV1): string =>
+  JSON.stringify({
+    presenceVersion: frame.presenceVersion,
+    agentId: frame.agentId,
+    encryptionPublicKey: frame.encryptionPublicKey,
+    signingPublicKey: frame.signingPublicKey,
+    subject: frame.subject,
+    capabilities: [...frame.capabilities],
+    ttlMs: frame.ttlMs,
+    ts: frame.ts,
+    nonce: frame.nonce,
+  });
+
+/**
+ * A presence frame plus an Ed25519 signature over `stablePresencePayload(frame)`.
+ *
+ * The signature proves the announcement was not tampered with in flight AND that
+ * the announcer holds the private key for the `signingPublicKey` it advertises
+ * (key-of-record consistency). It does NOT prove the `agentId` maps to a known,
+ * trusted identity — that is still established out-of-band at operator promotion.
+ * Verification itself lives in the transport/listener layer via @murmurv2/security.
+ */
+export interface SignedPresenceFrameV1 {
+  frame: PresenceFrameV1;
+  signature: string;
+}
+
+export const isSignedPresenceFrameV1 = (v: unknown): v is SignedPresenceFrameV1 => {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.signature === "string" && o.signature.length > 0 &&
+    isPresenceFrameV1(o.frame)
+  );
+};
+
+/** Verifies an Ed25519 signature over a stable payload. Injected so core stays
+ *  free of a crypto dependency (the listener passes @murmurv2/security's verify). */
+export type PresenceVerifier = (
+  payload: string,
+  signature: string,
+  publicKey: string,
+) => Promise<boolean>;
+
+/**
+ * Verify a signed presence frame and, only if the signature checks out against
+ * the key the frame advertises, fold it into the registry as a (still untrusted)
+ * candidate. Returns the candidate, or null if the input is malformed or the
+ * signature is invalid. Never trusts — `observe()` still yields `trusted: false`.
+ */
+export const observeSignedPresence = async (
+  registry: CandidateRegistry,
+  signed: unknown,
+  verify: PresenceVerifier,
+  now: number,
+): Promise<DiscoveryCandidate | null> => {
+  if (!isSignedPresenceFrameV1(signed)) return null;
+  const ok = await verify(
+    stablePresencePayload(signed.frame),
+    signed.signature,
+    signed.frame.signingPublicKey,
+  );
+  if (!ok) return null;
+  return registry.observe(signed.frame, now);
+};

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -214,11 +214,21 @@ export const observeSignedPresence = async (
   now: number,
 ): Promise<DiscoveryCandidate | null> => {
   if (!isSignedPresenceFrameV1(signed)) return null;
-  const ok = await verify(
-    stablePresencePayload(signed.frame),
-    signed.signature,
-    signed.frame.signingPublicKey,
-  );
+  // Discovery frames are PUBLIC, untrusted traffic. A real Ed25519 verifier throws
+  // on malformed signature/public-key bytes (wrong length, bad base64) rather than
+  // returning false, and the wrapper guard only checks for non-empty strings — so a
+  // hostile/garbage frame must be DROPPED here, never allowed to escalate into an
+  // unhandled rejection that crashes the listen loop.
+  let ok = false;
+  try {
+    ok = await verify(
+      stablePresencePayload(signed.frame),
+      signed.signature,
+      signed.frame.signingPublicKey,
+    );
+  } catch {
+    return null;
+  }
   if (!ok) return null;
   return registry.observe(signed.frame, now);
 };

--- a/packages/core/test/discovery.test.mjs
+++ b/packages/core/test/discovery.test.mjs
@@ -1,6 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { CandidateRegistry, isPresenceFrameV1 } from "../dist/src/index.js";
+import {
+  CandidateRegistry,
+  isPresenceFrameV1,
+  isSignedPresenceFrameV1,
+  observeSignedPresence,
+  stablePresencePayload,
+} from "../dist/src/index.js";
 
 const frame = (over = {}) => ({
   presenceVersion: "1.0",
@@ -119,6 +125,55 @@ test("a fresh announcement (new nonce) refreshes the candidate", () => {
   );
   assert.deepEqual(c.capabilities, ["chat", "files", "audio"]);
   assert.equal(c.lastSeen, at("2026-06-22T13:00:40.000Z"));
+});
+
+// --- signed presence (PR2) ---------------------------------------------------
+
+test("stablePresencePayload is deterministic and excludes the signature", () => {
+  const a = stablePresencePayload(frame());
+  const b = stablePresencePayload({ ...frame() });
+  assert.equal(a, b);
+  assert.ok(!a.includes("signature"));
+  assert.ok(a.includes("agent-x") && a.includes("n1"));
+});
+
+test("isSignedPresenceFrameV1 validates the wrapper", () => {
+  assert.equal(isSignedPresenceFrameV1({ frame: frame(), signature: "sig" }), true);
+  assert.equal(isSignedPresenceFrameV1({ frame: frame(), signature: "" }), false);
+  assert.equal(isSignedPresenceFrameV1({ frame: { bad: 1 }, signature: "sig" }), false);
+  assert.equal(isSignedPresenceFrameV1(null), false);
+});
+
+test("observeSignedPresence folds a valid-signature frame as an untrusted candidate", async () => {
+  const reg = new CandidateRegistry();
+  const now = at("2026-06-22T13:00:10.000Z");
+  const verifyOk = async () => true;
+  const c = await observeSignedPresence(reg, { frame: frame(), signature: "sig" }, verifyOk, now);
+  assert.ok(c);
+  assert.equal(c.agentId, "agent-x");
+  assert.equal(c.trusted, false);
+  assert.equal(reg.size(now), 1);
+});
+
+test("observeSignedPresence rejects a bad signature and a malformed wrapper", async () => {
+  const reg = new CandidateRegistry();
+  const now = at("2026-06-22T13:00:10.000Z");
+  const verifyBad = async () => false;
+  assert.equal(await observeSignedPresence(reg, { frame: frame(), signature: "sig" }, verifyBad, now), null);
+  assert.equal(await observeSignedPresence(reg, { nope: true }, async () => true, now), null);
+  assert.equal(reg.size(now), 0);
+});
+
+test("observeSignedPresence verifies against the key the frame advertises", async () => {
+  const reg = new CandidateRegistry();
+  const now = at("2026-06-22T13:00:10.000Z");
+  const seen = {};
+  const verify = async (payload, signature, publicKey) => {
+    seen.payload = payload; seen.publicKey = publicKey; return true;
+  };
+  await observeSignedPresence(reg, { frame: frame(), signature: "sig" }, verify, now);
+  assert.equal(seen.publicKey, "sig-pub");
+  assert.equal(seen.payload, stablePresencePayload(frame()));
 });
 
 test("an out-of-order (older) frame does not overwrite a fresher candidate", () => {

--- a/packages/core/test/discovery.test.mjs
+++ b/packages/core/test/discovery.test.mjs
@@ -164,6 +164,19 @@ test("observeSignedPresence rejects a bad signature and a malformed wrapper", as
   assert.equal(reg.size(now), 0);
 });
 
+test("observeSignedPresence drops a frame when the verifier THROWS (malformed bytes)", async () => {
+  const reg = new CandidateRegistry();
+  const now = at("2026-06-22T13:00:10.000Z");
+  // Real Ed25519 verifiers throw on bad-length/garbage signature or key bytes;
+  // untrusted public frames must be dropped, not escalated to an unhandled rejection.
+  const verifyThrows = async () => {
+    throw new Error("signature of length 64 expected, got 9");
+  };
+  const r = await observeSignedPresence(reg, { frame: frame(), signature: "not-b64" }, verifyThrows, now);
+  assert.equal(r, null);
+  assert.equal(reg.size(now), 0);
+});
+
 test("observeSignedPresence verifies against the key the frame advertises", async () => {
   const reg = new CandidateRegistry();
   const now = at("2026-06-22T13:00:10.000Z");


### PR DESCRIPTION
## What

Discovery PR2 — the wire layer for agent discovery over NATS, on top of PR1 (#60). The PR1 trust model is preserved: **candidates are never auto-trusted**.

## Changes

**`@murmurv2/core`**
- `SignedPresenceFrameV1` + `isSignedPresenceFrameV1` — a presence frame plus an Ed25519 signature.
- `stablePresencePayload(frame)` — canonical, signature-excluded payload (mirrors the envelope's stable-payload) so both sides sign identical bytes.
- `observeSignedPresence(registry, signed, verify, now)` — verifies the signature (verifier **injected**, so core stays crypto-free) against the key the frame advertises, and only then folds it in as an **untrusted** candidate.

**`@murmurv2/broker-nats`**
- `announcePresence(subject, signed)` — publish a signed frame in the clear (presence is public; integrity/authorship come from the signature, not encryption).
- `subscribePresence(subject, onPresence)` — plain read-only subscription that parses signed frames; signature verify + registry folding stay the caller's job (composed via `observeSignedPresence`).

## Trust / security note

The signature proves **announcement integrity** + **key-of-record consistency** (the announcer holds the private key for the `signingPublicKey` it advertises). It does **NOT** prove the `agentId` is a known, trusted identity — promotion of a candidate to a trusted peer stays an explicit operator action (PR3).

## Tests

12 discovery tests (+5): stable-payload determinism + signature-exclusion, signed-wrapper guard, valid-sig fold-as-untrusted, bad-sig + malformed reject, verify-uses-advertised-key. Full suite green (**core 28**), `tsc -b` clean.

PR3: operator promote-candidate→trusted-peer flow + policy.