### PR TITLE
docs(deploy): add Kubernetes reference deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+node_modules
+packages/*/dist
+.data
+.data-*
+*.db
+*.db-*
+npm-debug.log*
+Dockerfile*
+deploy/kubernetes/*.local.yaml

--- a/README.md
+++ b/README.md
@@ -392,6 +392,18 @@ docker compose -f deploy/docker-compose.messaging.yml up -d
 node scripts/murmur-daemon.mjs
 ```
 
+### Kubernetes
+
+Reference manifests for a private in-cluster NATS broker plus one Murmur daemon
+live in [`deploy/kubernetes`](deploy/kubernetes/README.md). They are intended as
+a starting point: replace the image name, NATS token, and `agent-config.json`
+secret before applying. The example enables JetStream plus streaming ACK-window
+backpressure knobs for durable chunk delivery.
+
+```bash
+kubectl apply -k deploy/kubernetes
+```
+
 ### Notification Adapters
 
 ```bash

--- a/deploy/Dockerfile.daemon
+++ b/deploy/Dockerfile.daemon
@@ -1,0 +1,20 @@
+FROM node:22-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json tsconfig.json ./
+COPY packages ./packages
+COPY scripts ./scripts
+
+RUN npm ci --include=dev \
+  && npm run build \
+  && npm prune --omit=dev \
+  && mkdir -p /data \
+  && chown -R node:node /app /data
+
+USER node
+
+ENV NODE_ENV=production
+ENV DATA_DIR=/data
+
+CMD ["node", "scripts/murmur-daemon.mjs"]

--- a/deploy/docker-compose.messaging.yml
+++ b/deploy/docker-compose.messaging.yml
@@ -2,7 +2,7 @@ services:
   nats:
     image: nats:2.10-alpine
     container_name: murmurv2-nats
-    # JetStream is enabled on the server for future E2 adoption, but the current client uses core NATS plus SQLite outbox durability.
+    # JetStream is enabled for durable broker delivery; Murmur daemons still keep SQLite outbox durability locally.
     command: ["-js", "-m", "8222", "--auth", "${NATS_TOKEN}"]
     ports:
       - "4222:4222"

--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,86 @@
+# Murmur V2 Kubernetes Reference
+
+This directory is a minimal reference deployment for one Murmur V2 agent and a
+private NATS broker. It is intentionally plain Kubernetes YAML, not a production
+Helm chart.
+
+## What It Creates
+
+- `Namespace/murmur`
+- `StatefulSet/murmur-nats` with JetStream storage
+- `Service/murmur-nats` exposing NATS inside the cluster
+- `Secret/murmur-nats-auth` with the NATS token placeholder
+- `StatefulSet/murmur-agent` with a per-agent SQLite PVC
+- `Service/murmur-agent` exposing the optional Prometheus exporter in-cluster
+- `Secret/murmur-agent-config` with an example `agent-config.json`
+
+Presence/discovery metadata is public by design, but `agent-config.json` still
+contains private keys and the NATS token. Keep it in a secret manager or sealed
+secret in real deployments.
+
+## Build The Daemon Image
+
+```bash
+docker build -f deploy/Dockerfile.daemon -t ghcr.io/acme/murmur-v2-daemon:2.2.0 .
+docker push ghcr.io/acme/murmur-v2-daemon:2.2.0
+```
+
+Update `deploy/kubernetes/agent-daemon.yaml` with your image name.
+
+## Configure Secrets
+
+Edit these placeholders before applying:
+
+- `deploy/kubernetes/nats.yaml`: `CHANGE_ME_NATS_TOKEN`
+- `deploy/kubernetes/agent-config.example.yaml`: `agentId`, keys, peers, and token
+
+The example also exposes the streaming delivery knobs used by the daemon:
+
+- `jetstream.maxDeliver` / `MURMUR_JETSTREAM_MAX_DELIVER`
+- `jetstream.ackWaitMs` / `MURMUR_JETSTREAM_ACK_WAIT_MS`
+- `streaming.ackTimeoutMs` / `MURMUR_ACK_TIMEOUT_MS`
+- `streaming.ackWindow.maxInFlightChunks` /
+  `MURMUR_STREAM_MAX_IN_FLIGHT_CHUNKS`
+- `streaming.ackWindow.maxInFlightBytes` /
+  `MURMUR_STREAM_MAX_IN_FLIGHT_BYTES`
+
+For real clusters, prefer generating these from your secret manager:
+
+```bash
+kubectl -n murmur create secret generic murmur-nats-auth \
+  --from-literal=NATS_TOKEN="$NATS_TOKEN" \
+  --dry-run=client -o yaml
+
+kubectl -n murmur create secret generic murmur-agent-config \
+  --from-file=agent-config.json=/secure/path/agent-config.json \
+  --dry-run=client -o yaml
+```
+
+## Deploy
+
+```bash
+kubectl apply -k deploy/kubernetes
+kubectl -n murmur rollout status statefulset/murmur-nats
+kubectl -n murmur rollout status statefulset/murmur-agent
+```
+
+The in-cluster NATS URL for agents is:
+
+```text
+nats://murmur-nats.murmur.svc.cluster.local:4222
+```
+
+For multiple agents, create one config secret and one agent StatefulSet per
+agent, or keep this directory as a base and add per-agent Kustomize overlays.
+
+## Notes
+
+- SQLite outbox/message durability lives on the agent PVC at `/data/murmur.db`.
+- JetStream is enabled for the broker and stores data at `/data/jetstream`.
+- The agent StatefulSet runs `scripts/prometheus-exporter.mjs` as a sidecar on
+  port `9464`; remove the sidecar and `murmur-agent` Service if you do not need
+  metrics.
+- This reference does not expose NATS outside the cluster. Use an ingress,
+  LoadBalancer, VPN, or NATS leaf-node topology only after setting explicit
+  authz boundaries.
+- Do not point this example at the shared production broker for smoke tests.

--- a/deploy/kubernetes/agent-config.example.yaml
+++ b/deploy/kubernetes/agent-config.example.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: murmur-agent-config
+type: Opaque
+stringData:
+  agent-config.json: |
+    {
+      "agentId": "agent-k8s-demo",
+      "natsUrl": "nats://murmur-nats.murmur.svc.cluster.local:4222",
+      "natsToken": "CHANGE_ME_NATS_TOKEN",
+      "subject": "msg.agent-k8s-demo",
+      "jetstream": {
+        "enabled": true,
+        "stream": "MURMUR",
+        "subjects": ["msg.>", "ack.>"],
+        "maxDeliver": 5,
+        "ackWaitMs": 30000
+      },
+      "streaming": {
+        "ackTimeoutMs": 15000,
+        "ackWindow": {
+          "enabled": true,
+          "maxInFlightChunks": 64,
+          "maxInFlightBytes": 4194304
+        }
+      },
+      "keys": {
+        "encryption": {
+          "publicKey": "CHANGE_ME_ENCRYPTION_PUBLIC_KEY",
+          "privateKey": "CHANGE_ME_ENCRYPTION_PRIVATE_KEY"
+        },
+        "signing": {
+          "publicKey": "CHANGE_ME_SIGNING_PUBLIC_KEY",
+          "privateKey": "CHANGE_ME_SIGNING_PRIVATE_KEY"
+        }
+      },
+      "peers": {
+        "agent-peer": {
+          "encryption": {
+            "publicKey": "CHANGE_ME_PEER_ENCRYPTION_PUBLIC_KEY"
+          },
+          "signing": {
+            "publicKey": "CHANGE_ME_PEER_SIGNING_PUBLIC_KEY"
+          },
+          "subject": "msg.agent-peer"
+        }
+      }
+    }

--- a/deploy/kubernetes/agent-daemon.yaml
+++ b/deploy/kubernetes/agent-daemon.yaml
@@ -1,0 +1,112 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: murmur-agent
+  labels:
+    app.kubernetes.io/name: murmur-agent
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: murmur-agent
+  ports:
+    - name: metrics
+      port: 9464
+      targetPort: metrics
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: murmur-agent
+  labels:
+    app.kubernetes.io/name: murmur-agent
+spec:
+  serviceName: murmur-agent
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: murmur-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: murmur-agent
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: daemon
+          image: ghcr.io/acme/murmur-v2-daemon:2.2.0
+          imagePullPolicy: IfNotPresent
+          workingDir: /app
+          env:
+            - name: DATA_DIR
+              value: /data
+            - name: FLUSH_INTERVAL_MS
+              value: "2000"
+            - name: MURMUR_JETSTREAM
+              value: "1"
+            - name: MURMUR_JETSTREAM_MAX_DELIVER
+              value: "5"
+            - name: MURMUR_JETSTREAM_ACK_WAIT_MS
+              value: "30000"
+            - name: MURMUR_ACK_TIMEOUT_MS
+              value: "15000"
+            - name: MURMUR_STREAM_ACK_WINDOW
+              value: "1"
+            - name: MURMUR_STREAM_MAX_IN_FLIGHT_CHUNKS
+              value: "64"
+            - name: MURMUR_STREAM_MAX_IN_FLIGHT_BYTES
+              value: "4194304"
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -ec
+                - test -f /data/agent-config.json && test -w /data
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: agent-data
+              mountPath: /data
+            - name: agent-config
+              mountPath: /data/agent-config.json
+              subPath: agent-config.json
+              readOnly: true
+        - name: metrics
+          image: ghcr.io/acme/murmur-v2-daemon:2.2.0
+          imagePullPolicy: IfNotPresent
+          workingDir: /app
+          command:
+            - node
+            - scripts/prometheus-exporter.mjs
+          env:
+            - name: DATA_DIR
+              value: /data
+            - name: METRICS_HOST
+              value: 0.0.0.0
+            - name: METRICS_PORT
+              value: "9464"
+          ports:
+            - name: metrics
+              containerPort: 9464
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: agent-data
+              mountPath: /data
+      volumes:
+        - name: agent-config
+          secret:
+            secretName: murmur-agent-config
+  volumeClaimTemplates:
+    - metadata:
+        name: agent-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: murmur
+resources:
+  - namespace.yaml
+  - nats.yaml
+  - agent-config.example.yaml
+  - agent-daemon.yaml
+commonLabels:
+  app.kubernetes.io/part-of: murmur-v2

--- a/deploy/kubernetes/namespace.yaml
+++ b/deploy/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: murmur

--- a/deploy/kubernetes/nats.yaml
+++ b/deploy/kubernetes/nats.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: murmur-nats-auth
+type: Opaque
+stringData:
+  NATS_TOKEN: CHANGE_ME_NATS_TOKEN
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: murmur-nats
+  labels:
+    app.kubernetes.io/name: murmur-nats
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: murmur-nats
+  ports:
+    - name: nats
+      port: 4222
+      targetPort: nats
+    - name: monitor
+      port: 8222
+      targetPort: monitor
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: murmur-nats
+  labels:
+    app.kubernetes.io/name: murmur-nats
+spec:
+  serviceName: murmur-nats
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: murmur-nats
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: murmur-nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.10-alpine
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - exec nats-server -js -sd /data/jetstream -m 8222 --auth "$NATS_TOKEN"
+          env:
+            - name: NATS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: murmur-nats-auth
+                  key: NATS_TOKEN
+          ports:
+            - name: nats
+              containerPort: 4222
+            - name: monitor
+              containerPort: 8222
+          readinessProbe:
+            tcpSocket:
+              port: nats
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            - name: nats-data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: nats-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/scripts/murmur-daemon.mjs
+++ b/scripts/murmur-daemon.mjs
@@ -39,6 +39,40 @@ const jetstreamConfig = config.jetstream || {};
 const jetstreamEnabled = jetstreamConfig.enabled ?? process.env.MURMUR_JETSTREAM === "1";
 const jetstreamStream = jetstreamConfig.stream || process.env.MURMUR_JETSTREAM_STREAM || "MURMUR";
 const jetstreamSubjects = jetstreamConfig.subjects || ["msg.>", "ack.>"];
+const streamingConfig = config.streaming || {};
+const ackWindowConfig = streamingConfig.ackWindow || {};
+const firstDefined = (...values) => values.find((value) => value !== undefined && value !== null && value !== "");
+const optionalPositiveInteger = (name, value) => {
+  if (value === undefined || value === null || value === "") return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${name}-invalid`);
+  return parsed;
+};
+const jetstreamMaxDeliver = optionalPositiveInteger(
+  "jetstream-max-deliver",
+  firstDefined(jetstreamConfig.maxDeliver, process.env.MURMUR_JETSTREAM_MAX_DELIVER),
+);
+const jetstreamAckWaitMs = optionalPositiveInteger(
+  "jetstream-ack-wait-ms",
+  firstDefined(jetstreamConfig.ackWaitMs, process.env.MURMUR_JETSTREAM_ACK_WAIT_MS),
+);
+const ackTimeoutMs = optionalPositiveInteger(
+  "ack-timeout-ms",
+  firstDefined(streamingConfig.ackTimeoutMs, process.env.MURMUR_ACK_TIMEOUT_MS),
+) ?? 15_000;
+const ackWindowEnabled = ackWindowConfig.enabled ?? process.env.MURMUR_STREAM_ACK_WINDOW === "1";
+const ackWindow = ackWindowEnabled
+  ? {
+      maxInFlightChunks: optionalPositiveInteger(
+        "stream-max-in-flight-chunks",
+        firstDefined(ackWindowConfig.maxInFlightChunks, process.env.MURMUR_STREAM_MAX_IN_FLIGHT_CHUNKS),
+      ) ?? 64,
+      maxInFlightBytes: optionalPositiveInteger(
+        "stream-max-in-flight-bytes",
+        firstDefined(ackWindowConfig.maxInFlightBytes, process.env.MURMUR_STREAM_MAX_IN_FLIGHT_BYTES),
+      ) ?? 4 * 1024 * 1024,
+    }
+  : undefined;
 const notifyTargets = normalizeNotifyTargets(config.notify);
 const envTelegramFallback = (() => {
   const botToken = process.env.MURMUR_TELEGRAM_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN;
@@ -60,6 +94,10 @@ log("info", "Daemon starting", {
   flushIntervalMs,
   jetstreamEnabled,
   jetstreamStream: jetstreamEnabled ? jetstreamStream : undefined,
+  jetstreamMaxDeliver,
+  jetstreamAckWaitMs,
+  ackTimeoutMs,
+  ackWindow,
   notifyTargets: effectiveNotifyTargets.map((t) => `${t.type}:${t.channel}`),
   notifyFallbackFromEnv: envTelegramFallback.length > 0,
 });
@@ -72,6 +110,8 @@ const broker = new NatsBroker({
   jetstream: jetstreamEnabled,
   stream: jetstreamEnabled ? jetstreamStream : undefined,
   streamSubjects: jetstreamSubjects,
+  jetstreamMaxDeliver,
+  jetstreamAckWaitMs,
 });
 
 const durableSafe = (value) => value.replace(/[^A-Za-z0-9_-]/g, "-");
@@ -224,7 +264,7 @@ let running = true;
 const flushLoop = async () => {
   while (running) {
     try {
-      await broker.flushOutbox({ outbox: store, maxAttempts: 5, ackTimeoutMs: 15_000 });
+      await broker.flushOutbox({ outbox: store, maxAttempts: 5, ackTimeoutMs, ackWindow });
     } catch (err) {
       log("error", "Outbox flush error", { error: err.message });
     }


### PR DESCRIPTION
## Summary

Adds a minimal Kubernetes reference deployment for Murmur V2 and wires the daemon knobs needed by streaming PR2:

- daemon Dockerfile for `scripts/murmur-daemon.mjs`
- private in-cluster NATS StatefulSet with JetStream storage
- one agent StatefulSet with SQLite PVC and config secret placeholder
- Prometheus exporter sidecar using the same daemon image
- Kustomize entrypoint and deployment README
- top-level README link from the Deployment section
- daemon config/env support for JetStream retry knobs and streaming ACK-window backpressure
- docker-compose messaging comment updated for current JetStream usage

This is intentionally reference YAML, not a production Helm chart. It avoids the shared production NATS broker and uses placeholder secrets/operators must replace.

## Operator knobs surfaced

- `jetstream.maxDeliver` / `MURMUR_JETSTREAM_MAX_DELIVER`
- `jetstream.ackWaitMs` / `MURMUR_JETSTREAM_ACK_WAIT_MS`
- `streaming.ackTimeoutMs` / `MURMUR_ACK_TIMEOUT_MS`
- `streaming.ackWindow.enabled` / `MURMUR_STREAM_ACK_WINDOW`
- `streaming.ackWindow.maxInFlightChunks` / `MURMUR_STREAM_MAX_IN_FLIGHT_CHUNKS`
- `streaming.ackWindow.maxInFlightBytes` / `MURMUR_STREAM_MAX_IN_FLIGHT_BYTES`

## Verification

- `python3` YAML structural validation for all `deploy/kubernetes/*.yaml`
- kustomize resource reference check
- README command/link checks
- `node --check scripts/murmur-daemon.mjs`
- `npm run build`
- `npm test`
- `git diff --check origin/main...HEAD`

Docker image build was attempted with `docker build -f deploy/Dockerfile.daemon -t murmur-v2-daemon:pr3 .`, but this runner cannot access `/var/run/docker.sock` (`permission denied while trying to connect to the docker API`).