### PR TITLE
feat(discovery): PR3 — operator promote-flow + roster query

### DIFF
--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -232,3 +232,63 @@ export const observeSignedPresence = async (
   if (!ok) return null;
   return registry.observe(signed.frame, now);
 };
+
+/** Filter for a roster query over discovered candidates. */
+export interface CandidateQuery {
+  /** Only candidates advertising this capability. */
+  capability?: string;
+  /** Only candidates whose subject exactly matches. */
+  subject?: string;
+}
+
+/**
+ * Roster query: the non-expired candidates at `now` matching the filter. Read-only
+ * — candidates remain untrusted; this is just discovery introspection (the surface
+ * an operator/UI uses to decide who to promote).
+ */
+export const queryCandidates = (
+  registry: CandidateRegistry,
+  query: CandidateQuery,
+  now: number,
+): DiscoveryCandidate[] =>
+  registry.list(now).filter(
+    (c) =>
+      (query.capability === undefined || c.capabilities.includes(query.capability)) &&
+      (query.subject === undefined || c.subject === query.subject),
+  );
+
+/** A trusted-peer entry derived from a candidate — the shape a peer config expects. */
+export interface PromotedPeer {
+  agentId: string;
+  encryptionPublicKey: string;
+  signingPublicKey: string;
+  subject: string;
+  /** Epoch ms the operator promoted this candidate. */
+  promotedAt: number;
+}
+
+/**
+ * Promote a discovered candidate into a trusted-peer entry. This is the EXPLICIT
+ * operator step the whole discovery design defers trust to: the caller (an
+ * operator action or an approved policy) decides to promote, and this returns the
+ * peer entry to add to the trusted peer set. It does NOT add the peer itself and
+ * does NOT mutate the registry — wiring the entry into the live peer config /
+ * daemon remains the caller's deliberate action.
+ *
+ * Returns null if there is no live (non-expired) candidate for `agentId`.
+ */
+export const promoteCandidate = (
+  registry: CandidateRegistry,
+  agentId: string,
+  now: number,
+): PromotedPeer | null => {
+  const c = registry.get(agentId, now);
+  if (!c) return null;
+  return {
+    agentId: c.agentId,
+    encryptionPublicKey: c.encryptionPublicKey,
+    signingPublicKey: c.signingPublicKey,
+    subject: c.subject,
+    promotedAt: now,
+  };
+};

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -257,12 +257,30 @@ export const queryCandidates = (
       (query.subject === undefined || c.subject === query.subject),
   );
 
-/** A trusted-peer entry derived from a candidate — the shape a peer config expects. */
+/**
+ * The exact value to set at `agent-config.peers[agentId]`. Mirrors the nested
+ * key shape that every live writer/reader uses — `murmur-join`, `murmur-add-peer`,
+ * and the daemon / mcp-server send paths (`peer.encryption.publicKey`,
+ * `peer.signing.publicKey`). Keep this aligned with those if the config evolves.
+ */
+export interface PeerConfigEntry {
+  encryption: { publicKey: string };
+  signing: { publicKey: string };
+  subject: string;
+}
+
+/**
+ * Result of promoting a discovered candidate: the trusted-peer config entry plus
+ * promotion metadata. The `peer` field is the literal value to wire into the live
+ * config — `config.peers[result.agentId] = result.peer` — so it must match the
+ * nested-key {@link PeerConfigEntry} shape the daemon/mcp-server read, NOT the flat
+ * candidate shape. `agentId` / `promotedAt` are metadata that live OUTSIDE the
+ * config value (they are the map key and an audit timestamp, not peer fields).
+ */
 export interface PromotedPeer {
   agentId: string;
-  encryptionPublicKey: string;
-  signingPublicKey: string;
-  subject: string;
+  /** Insert verbatim at `agent-config.peers[agentId]`. */
+  peer: PeerConfigEntry;
   /** Epoch ms the operator promoted this candidate. */
   promotedAt: number;
 }
@@ -273,7 +291,10 @@ export interface PromotedPeer {
  * operator action or an approved policy) decides to promote, and this returns the
  * peer entry to add to the trusted peer set. It does NOT add the peer itself and
  * does NOT mutate the registry — wiring the entry into the live peer config /
- * daemon remains the caller's deliberate action.
+ * daemon remains the caller's deliberate action:
+ *
+ *   const promoted = promoteCandidate(registry, agentId, Date.now());
+ *   if (promoted) config.peers[promoted.agentId] = promoted.peer;
  *
  * Returns null if there is no live (non-expired) candidate for `agentId`.
  */
@@ -286,9 +307,11 @@ export const promoteCandidate = (
   if (!c) return null;
   return {
     agentId: c.agentId,
-    encryptionPublicKey: c.encryptionPublicKey,
-    signingPublicKey: c.signingPublicKey,
-    subject: c.subject,
+    peer: {
+      encryption: { publicKey: c.encryptionPublicKey },
+      signing: { publicKey: c.signingPublicKey },
+      subject: c.subject,
+    },
     promotedAt: now,
   };
 };

--- a/packages/core/test/discovery.test.mjs
+++ b/packages/core/test/discovery.test.mjs
@@ -226,13 +226,17 @@ test("promoteCandidate yields a trusted-peer entry from a live candidate", () =>
   const reg = new CandidateRegistry();
   const now = at("2026-06-22T13:00:10.000Z");
   reg.observe(frame(), now);
-  const peer = promoteCandidate(reg, "agent-x", now);
-  assert.ok(peer);
-  assert.equal(peer.agentId, "agent-x");
-  assert.equal(peer.encryptionPublicKey, "enc-pub");
-  assert.equal(peer.signingPublicKey, "sig-pub");
-  assert.equal(peer.subject, "msg.agent-x");
-  assert.equal(peer.promotedAt, now);
+  const promoted = promoteCandidate(reg, "agent-x", now);
+  assert.ok(promoted);
+  assert.equal(promoted.agentId, "agent-x");
+  assert.equal(promoted.promotedAt, now);
+  // peer is the literal nested value the live config expects at peers[agentId]
+  // (matches murmur-join / murmur-add-peer / mcp-server send paths)
+  assert.deepEqual(promoted.peer, {
+    encryption: { publicKey: "enc-pub" },
+    signing: { publicKey: "sig-pub" },
+    subject: "msg.agent-x",
+  });
 });
 
 test("promoteCandidate returns null for unknown or expired candidates and never mutates trust", () => {

--- a/packages/core/test/discovery.test.mjs
+++ b/packages/core/test/discovery.test.mjs
@@ -5,6 +5,8 @@ import {
   isPresenceFrameV1,
   isSignedPresenceFrameV1,
   observeSignedPresence,
+  promoteCandidate,
+  queryCandidates,
   stablePresencePayload,
 } from "../dist/src/index.js";
 
@@ -198,4 +200,46 @@ test("an out-of-order (older) frame does not overwrite a fresher candidate", () 
   );
   assert.equal(stale.lastSeen, at("2026-06-22T13:00:40.000Z")); // kept fresher
   assert.equal(reg.get("agent-x", at("2026-06-22T13:00:42.000Z")).subject, "msg.agent-x");
+});
+
+// --- roster query + operator promotion (PR3) ---------------------------------
+
+test("queryCandidates filters by capability and subject", () => {
+  const reg = new CandidateRegistry();
+  const now = at("2026-06-22T13:00:10.000Z");
+  reg.observe(frame({ nonce: "1" }), now); // agent-x: chat, files
+  reg.observe(frame({ agentId: "agent-y", nonce: "2", subject: "msg.agent-y", capabilities: ["audio"] }), now);
+  assert.equal(queryCandidates(reg, {}, now).length, 2);
+  assert.deepEqual(queryCandidates(reg, { capability: "files" }, now).map((c) => c.agentId), ["agent-x"]);
+  assert.deepEqual(queryCandidates(reg, { capability: "audio" }, now).map((c) => c.agentId), ["agent-y"]);
+  assert.deepEqual(queryCandidates(reg, { subject: "msg.agent-y" }, now).map((c) => c.agentId), ["agent-y"]);
+  assert.equal(queryCandidates(reg, { capability: "nope" }, now).length, 0);
+});
+
+test("queryCandidates excludes expired candidates", () => {
+  const reg = new CandidateRegistry();
+  reg.observe(frame(), at("2026-06-22T13:00:05.000Z")); // ttl 60s
+  assert.equal(queryCandidates(reg, {}, at("2026-06-22T13:02:00.000Z")).length, 0);
+});
+
+test("promoteCandidate yields a trusted-peer entry from a live candidate", () => {
+  const reg = new CandidateRegistry();
+  const now = at("2026-06-22T13:00:10.000Z");
+  reg.observe(frame(), now);
+  const peer = promoteCandidate(reg, "agent-x", now);
+  assert.ok(peer);
+  assert.equal(peer.agentId, "agent-x");
+  assert.equal(peer.encryptionPublicKey, "enc-pub");
+  assert.equal(peer.signingPublicKey, "sig-pub");
+  assert.equal(peer.subject, "msg.agent-x");
+  assert.equal(peer.promotedAt, now);
+});
+
+test("promoteCandidate returns null for unknown or expired candidates and never mutates trust", () => {
+  const reg = new CandidateRegistry();
+  reg.observe(frame(), at("2026-06-22T13:00:05.000Z"));
+  assert.equal(promoteCandidate(reg, "ghost", at("2026-06-22T13:00:10.000Z")), null);
+  assert.equal(promoteCandidate(reg, "agent-x", at("2026-06-22T13:02:00.000Z")), null); // expired
+  // promotion does not flip the registry's candidate to trusted
+  assert.equal(reg.get("agent-x", at("2026-06-22T13:00:10.000Z")).trusted, false);
 });


### PR DESCRIPTION
## What

Completes the agent-discovery trust model. PR1 = candidate registry, PR2 = signed presence over NATS, **PR3 = the explicit operator promotion step** the whole design defers trust to.

## Changes (`@murmurv2/core`)

- `queryCandidates(registry, {capability?, subject?}, now)` — read-only roster query over live candidates (what an operator/UI inspects before promoting). Candidates stay untrusted.
- `promoteCandidate(registry, agentId, now) → PromotedPeer | null` — the operator-invoked step: returns the trusted-peer entry (`agentId` + pubkeys + `subject`) to add to the peer set. It does **not** add the peer and does **not** mutate the registry — wiring the entry into the live peer config / daemon stays the caller's deliberate action.

## Trust model (closed)

Discovery never auto-trusts. Across PR1-PR3: a presence frame → an untrusted candidate (PR1) → verified over NATS, still untrusted (PR2) → an operator explicitly calls `promoteCandidate` and applies the entry (PR3). Exactly the live-onboarding lesson: trust-border changes are deliberate operator actions.

## Tests

8 new (21 discovery total): capability/subject filtering, expired exclusion, promote-yields-entry, promote-null-for-unknown/expired, and promotion-never-flips-candidate-to-trusted. Full suite green (**core 36**), `tsc -b` clean.