### PR TITLE
docs(protocol): versioned spec for presence + stream frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,9 +482,9 @@ See [protocol-v1.md](docs/protocol-v1.md) for the full specification.
 ### Planned (next wave)
 - [ ] **Message streaming** — *PR1 merged:* pure core stream frames (start/chunk/end), UTF-8-safe chunking, in-memory reassembler (out-of-order + idempotent + conflict-reject), backpressure predicate (chunk + byte windows). PR2: NATS wiring + durable reassembly + sha256 integrity
 - [ ] **Agent discovery protocol** — *PR1 merged:* presence frames + candidate registry (ttl expiry, dedupe, out-of-order guard). Trust stays an explicit operator promote — candidates are never auto-trusted. PR2: NATS announce/listen (`announcePresence` / `subscribePresence`) + signed presence frames. PR3: operator promote-flow + a query/roster API
-- [ ] Reference deployment examples — docker-compose, Kubernetes manifests
-- [ ] Conformance test suite — integration tests for third-party implementations
-- [ ] Versioned protocol spec — machine-readable schema + compatibility matrix
+- [x] Reference deployment examples — docker-compose (`deploy/docker-compose.messaging.yml`) + Kubernetes manifests (`deploy/kubernetes/`)
+- [x] Conformance test suite — schema↔guard agreement matrices for every wire type (`packages/core/test/conformance.test.mjs`); port the fixtures to check a third-party implementation
+- [x] Versioned protocol spec — machine-readable schema (`protocol-v1.schema.json`) + prose ([`docs/protocol-v1.md`](docs/protocol-v1.md)) + compatibility matrix ([`docs/protocol-compatibility.md`](docs/protocol-compatibility.md)) covering envelope, ack, presence, and stream frames
 
 ### Research
 - [ ] MLS group encryption (RFC 9420) — forward secrecy for multi-agent groups via OpenMLS WASM

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -142,8 +142,12 @@ no other protocol JSON schemas exist in the repo.
 The schema validates structural shape. A few checks live only in the runtime guards
 and are intentionally **outside** the schema↔guard agreement matrices:
 
-- **`ts` / `createdAt` / `at` date-time validity** — `format: date-time` is an advisory
-  annotation in Draft 2020-12; the guards enforce it via `Date.parse`.
+- **`createdAt` / `ts` date-time validity** — `format: date-time` is an advisory
+  annotation in Draft 2020-12; the runtime guards enforce it via `Date.parse`
+  (`isEnvelopeV1` for `EnvelopeV1.createdAt`, `isPresenceFrameV1` for `PresenceFrameV1.ts`).
+- **`AckV1.at`** — generated as an ISO-8601 string by `createAck`, but there is **no
+  `isAckV1` guard**: its `format: date-time` is advisory only (validator-dependent) with
+  no runtime enforcement on read.
 - **signature verification & payload decryption** — `@murmurv2/security`, not shape.
 - **stream semantics** — `chunkIndex` bounds, `totalBytes` accounting, and
   `digest`/`sha256` matching are the reassembler's job, not the frame guards'.

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -10,7 +10,11 @@ guard `isEnvelopeV1` in `@murmurv2/core` mirrors it, and the conformance suite
 
 | `schemaVersion` | Status  | Envelope | Ack    | Notes |
 |-----------------|---------|----------|--------|-------|
-| `1.0`           | current | `EnvelopeV1` | `AckV1` | Shipped in v2.x. Only accepted wire version. |
+| `1.0`           | current | `EnvelopeV1` | `AckV1` | Shipped in v2.x. Only accepted wire version. Also covers the discovery (`PresenceFrameV1`, `SignedPresenceFrameV1`) and streaming (`StreamStart`/`StreamChunk`/`StreamEnd`) frames below. |
+
+Only `EnvelopeV1` carries `schemaVersion` on the wire; the presence and stream frames
+are versioned together with it (they ship and break as one protocol version) and are
+discriminated structurally — `presenceVersion: "1.0"` for presence, `kind` for streams.
 
 ## Compatibility policy
 
@@ -56,17 +60,93 @@ guard `isEnvelopeV1` in `@murmurv2/core` mirrors it, and the conformance suite
 | `at` | ✅ | string | ISO-8601 date-time |
 | `reason` | — | string | |
 
+## PresenceFrameV1 (discovery)
+
+Public discovery metadata only — no secret. The signed wrapper proves integrity, not
+identity; trust is an out-of-band operator promotion.
+
+| Field | Required | Type | Constraint |
+|-------|----------|------|------------|
+| `presenceVersion` | ✅ | string | `const "1.0"` |
+| `agentId` | ✅ | string | non-empty |
+| `encryptionPublicKey` | ✅ | string | non-empty |
+| `signingPublicKey` | ✅ | string | non-empty |
+| `subject` | ✅ | string | non-empty |
+| `capabilities` | ✅ | string[] | each a string (may be empty array) |
+| `ttlMs` | ✅ | number | `> 0` (`exclusiveMinimum`) |
+| `ts` | ✅ | string | ISO-8601 date-time (validity runtime-only) |
+| `nonce` | ✅ | string | non-empty |
+
+### SignedPresenceFrameV1
+
+| Field | Required | Type | Constraint |
+|-------|----------|------|------------|
+| `frame` | ✅ | object | a valid `PresenceFrameV1` |
+| `signature` | ✅ | string | non-empty (Ed25519 over the canonical frame) |
+
+## Stream frames
+
+Discriminated by `kind`. `StreamFrame` is the `oneOf` union of the three.
+
+### StreamStart (`kind: "stream.start"`)
+
+| Field | Required | Type | Constraint |
+|-------|----------|------|------------|
+| `kind` | ✅ | string | `const "stream.start"` |
+| `streamId` | ✅ | string | non-empty |
+| `chunkCount` | ✅ | number | declared total chunks |
+| `totalBytes` | ✅ | number | declared total bytes |
+| `contentType` | — | string | |
+| `startedAt` | — | string | |
+
+### StreamChunk (`kind: "stream.chunk"`)
+
+| Field | Required | Type | Constraint |
+|-------|----------|------|------------|
+| `kind` | ✅ | string | `const "stream.chunk"` |
+| `streamId` | ✅ | string | non-empty |
+| `chunkIndex` | ✅ | number | |
+| `chunkCount` | ✅ | number | |
+| `data` | ✅ | string | **non-empty** (zero-byte chunk rejected: `stream-chunk-data-required`) |
+| `isLast` | ✅ | boolean | |
+| `sha256` | — | string | optional per-chunk integrity tag |
+
+### StreamEnd (`kind: "stream.end"`)
+
+| Field | Required | Type | Constraint |
+|-------|----------|------|------------|
+| `kind` | ✅ | string | `const "stream.end"` |
+| `streamId` | ✅ | string | non-empty |
+| `chunkCount` | ✅ | number | |
+| `totalBytes` | ✅ | number | |
+| `digest` | — | string | optional whole-stream integrity tag |
+| `sha256` | — | string | optional whole-stream integrity tag |
+
 ## Entrypoints
 
-`protocol-v1.schema.json` is a single file with two validation targets:
+`protocol-v1.schema.json` is a single file; validate each wire type against its target:
 
 | Validate | Entrypoint |
 |----------|------------|
 | an inbound **envelope** | the document **root** (it `$ref`s `#/$defs/EnvelopeV1`) — so validating against the file directly is correct |
 | an **ack** | `#/$defs/AckV1` |
+| a **presence frame** | `#/$defs/PresenceFrameV1` |
+| a **signed presence frame** | `#/$defs/SignedPresenceFrameV1` |
+| a **stream frame** | `#/$defs/StreamFrame` (or a specific `#/$defs/StreamStart` \| `StreamChunk` \| `StreamEnd`) |
 
 There is one canonical machine-readable schema (`packages/core/schema/protocol-v1.schema.json`);
-no other EnvelopeV1/AckV1 JSON schemas exist in the repo.
+no other protocol JSON schemas exist in the repo.
+
+### Runtime-only checks (not assertable in JSON Schema)
+
+The schema validates structural shape. A few checks live only in the runtime guards
+and are intentionally **outside** the schema↔guard agreement matrices:
+
+- **`ts` / `createdAt` / `at` date-time validity** — `format: date-time` is an advisory
+  annotation in Draft 2020-12; the guards enforce it via `Date.parse`.
+- **signature verification & payload decryption** — `@murmurv2/security`, not shape.
+- **stream semantics** — `chunkIndex` bounds, `totalBytes` accounting, and
+  `digest`/`sha256` matching are the reassembler's job, not the frame guards'.
 
 ## For third-party implementations
 

--- a/docs/protocol-v1.md
+++ b/docs/protocol-v1.md
@@ -1,4 +1,24 @@
-# Protocol v1 (draft)
+# Protocol v1
+
+Murmur V2's wire protocol, `schemaVersion` **1.0**. The canonical machine-readable
+contract is [`packages/core/schema/protocol-v1.schema.json`](../packages/core/schema/protocol-v1.schema.json)
+(JSON Schema, Draft 2020-12); the `@murmurv2/core` runtime guards mirror it, and the
+[conformance suite](../packages/core/test/conformance.test.mjs) asserts the schema and
+the guards cannot drift. Versioning and forward-compatibility rules live in
+[`protocol-compatibility.md`](protocol-compatibility.md).
+
+## Wire types
+
+| Type | Purpose | Schema `$def` | Runtime guard |
+|------|---------|---------------|---------------|
+| `EnvelopeV1` | encrypted inbound message | document root (`#/$defs/EnvelopeV1`) | `isEnvelopeV1` |
+| `AckV1` | delivery acknowledgement | `#/$defs/AckV1` | — |
+| `PresenceFrameV1` | discovery announcement (public metadata) | `#/$defs/PresenceFrameV1` | `isPresenceFrameV1` |
+| `SignedPresenceFrameV1` | Ed25519-signed presence | `#/$defs/SignedPresenceFrameV1` | `isSignedPresenceFrameV1` |
+| `StreamStart` / `StreamChunk` / `StreamEnd` | chunked payload streaming | `#/$defs/Stream*` (+ `StreamFrame` union) | `isStreamStart` / `isStreamChunk` / `isStreamEnd` / `isStreamFrame` |
+
+All payloads on the wire are encrypted; the schema validates **shape**, while signature
+verification and payload decryption are runtime concerns (`@murmurv2/security`).
 
 ## Envelope lifecycle
 1. Producer builds `EnvelopeV1`
@@ -13,6 +33,41 @@
 - at-least-once delivery
 - idempotent consumers mandatory
 - per-conversation sequence ordering target
+
+## Discovery (presence)
+
+Discovery never confers trust automatically — a presence frame proves only message
+integrity, never that an `agentId` is who it claims. Trust is established out of band
+by a deliberate operator promotion.
+
+1. An agent announces a `PresenceFrameV1` — public keys, `subject`, `capabilities`,
+   `ttlMs`, ISO-8601 `ts`, and a per-announcement `nonce` — on a discovery subject.
+2. Announcements are wrapped as a `SignedPresenceFrameV1` (Ed25519 signature over the
+   canonical frame). A listener verifies the signature against the key the frame
+   advertises before folding it in (`announcePresence` / `subscribePresence` on the
+   NATS broker; verification injected from `@murmurv2/security`).
+3. Observers collect frames into a `CandidateRegistry` as **untrusted**
+   `DiscoveryCandidate`s — deduped by (`agentId`, `nonce`), expiring at `ts + ttlMs`.
+4. An operator (or an approved policy) introspects the roster with `queryCandidates`
+   and explicitly promotes one with `promoteCandidate`, which returns the nested
+   peer-config entry to wire into `peers[agentId]`. Promotion does not mutate the
+   registry; the candidate stays untrusted until the operator applies the entry.
+
+## Streaming
+
+Large payloads are sent as an ordered sequence of stream frames sharing a `streamId`.
+
+1. Producer opens with `StreamStart` — declared `chunkCount` and `totalBytes`
+   (optional `contentType`, `startedAt`).
+2. Producer emits ordered `StreamChunk`s — `chunkIndex`, **non-empty** `data`, an
+   optional per-chunk `sha256`, and `isLast`. (A zero-byte chunk is rejected:
+   `stream-chunk-data-required`.)
+3. Producer closes with `StreamEnd` — optional whole-stream `digest` / `sha256`
+   integrity tags.
+4. Receiver reassembles idempotently by `streamId` (in-memory or SQLite-durable):
+   duplicate chunks are no-ops, conflicting re-sends are rejected, integrity tags are
+   verified, and completion yields the reassembled payload. Backpressure bounds the
+   in-flight chunk and byte windows.
 
 ## Bridge mapping
 - Murmur message -> EnvelopeV1

--- a/docs/protocol-v1.md
+++ b/docs/protocol-v1.md
@@ -17,8 +17,10 @@ the guards cannot drift. Versioning and forward-compatibility rules live in
 | `SignedPresenceFrameV1` | Ed25519-signed presence | `#/$defs/SignedPresenceFrameV1` | `isSignedPresenceFrameV1` |
 | `StreamStart` / `StreamChunk` / `StreamEnd` | chunked payload streaming | `#/$defs/Stream*` (+ `StreamFrame` union) | `isStreamStart` / `isStreamChunk` / `isStreamEnd` / `isStreamFrame` |
 
-All payloads on the wire are encrypted; the schema validates **shape**, while signature
-verification and payload decryption are runtime concerns (`@murmurv2/security`).
+Envelope message payloads are encrypted on the wire; presence frames are intentionally
+**public, signed cleartext** metadata (no secret). In all cases the schema validates
+**shape**, while signature verification and payload decryption are runtime concerns
+(`@murmurv2/security`).
 
 ## Envelope lifecycle
 1. Producer builds `EnvelopeV1`


### PR DESCRIPTION
## What
Human-readable protocol spec companion to the machine-readable schema (extended in #67), now covering **all** wire types.

## Changes
- **docs/protocol-v1.md** — wire-type table (schema `$def` + runtime guard per type) + **discovery (presence)** and **streaming** lifecycle sections.
- **docs/protocol-compatibility.md** — field tables for `PresenceFrameV1`, `SignedPresenceFrameV1`, `StreamStart/Chunk/End`; versioning scope (presence + stream versioned with `EnvelopeV1`, discriminated by `presenceVersion`/`kind`); per-type validation entrypoints; explicit **runtime-only checks** section (date-time validity, signature/decryption, stream semantics).
- **README** — tick reference-deploy / conformance-suite / versioned-protocol-spec roadmap items (all shipped).

## Notes
Docs-only, no code changes. All referenced schema `$defs` verified present on main. `stream-chunk-data-required` (non-empty `data`) and `ttlMs > 0` documented to match the runtime + #67 conformance.

Review by diff. @codex please sanity-check the spec matches the schema/guards.