### PR TITLE
test(mcp): de-flake C2 long-poll-timeout with injectable clock

### DIFF
--- a/tests/mcp-request-reply.test.mjs
+++ b/tests/mcp-request-reply.test.mjs
@@ -82,14 +82,27 @@ test("C: a wake signal resolves the reply faster than the poll interval", async 
 });
 
 test("C2: without a signal the same long-poll setup times out", async () => {
+  // Mirror of C but with no wake signal. Uses the injectable clock/sleep so the
+  // result is deterministic: with real timers, sleep(remaining) can undershoot the
+  // deadline by a hair, letting the loop re-check the store right at the boundary and
+  // return reply("never") — that re-check is harmless in production but made this test
+  // flaky (`tests/mcp-request-reply.test.mjs:84`). A fake clock that advances exactly
+  // by each requested sleep consumes the whole deadline in one wait, so the long poll
+  // never re-checks before timing out.
   let calls = 0;
+  let clock = 0;
   const res = await waitForReply({
     checkStore: async () => (++calls >= 2 ? reply("never") : null),
-    pollMs: 10_000,
+    pollMs: 10_000, // a pure poll would never re-check within the deadline
     graceMs: 5,
-    deadline: Date.now() + 150, // shorter than poll interval → only one check
+    deadline: 150, // shorter than poll interval → only the initial check fits
+    now: () => clock,
+    sleep: async (ms) => {
+      clock += ms;
+    },
   });
   assert.equal(res, null);
+  assert.equal(calls, 1); // only the initial check; no signal → no early re-poll
 });
 
 // --- D: lost-wakeup safety (signal fires DURING the store check) --------------


### PR DESCRIPTION
## Problem
CI flaked on `tests/mcp-request-reply.test.mjs:84` — *C2: without a signal the same long-poll setup times out*. It expected a timeout (`res === null`) but intermittently got `reply('never')`.

## Root cause (test bug, not impl)
`waitForReply` caps each wait at `min(pollMs, remaining)` (request-reply.ts:67). With real timers, `sleep(remaining)` can undershoot the deadline by a hair → the loop re-enters → a **second** `checkStore()` runs right at the boundary → returns `reply('never')`. That boundary re-check is **harmless/correct in production** (finding a just-arrived reply is the point), so the impl is fine; the test's real-timer assumption was fragile.

## Fix
Use the deps' **injectable `now()`/`sleep()`** (already documented as 'Injectable clock/sleep (tests)'): a fake clock that advances by each requested sleep consumes the whole 150ms deadline in a single wait, so the long poll deterministically never re-checks before timing out. Preserves the test's intent (contrast with C, where a signal accelerates) and adds `assert.equal(calls, 1)`.

## Verification
- Ran the file **20×**: 0 failures (was intermittent on CI).
- Full `npm test` green; `git diff --check` clean. Test-only change.

@codex please confirm the root-cause read (boundary re-check harmless) + the fix.