### PR TITLE
feat(federation): signed subject (actor) in AuthTokenClaims

### DIFF
--- a/packages/federation/src/index.ts
+++ b/packages/federation/src/index.ts
@@ -238,8 +238,14 @@ export class RosterStore {
 // ──────────────────── Auth token (roster-backed authn/authz) ────────────────────
 
 export interface AuthTokenClaims {
-  /** Agent that signs the token; its Ed25519 verify key MUST come from RosterStore. */
+  /** Agent that signs the token; its Ed25519 verify key MUST come from RosterStore.
+   *  For real authz this is an org-authority, NOT the caller (self-issued scope is
+   *  meaningless). */
   issuer: AgentAddress;
+  /** The authorized caller this token vouches for — the actor a verifier binds to the
+   *  message sender (`subject === envelope.senderAgentId`). Without this an authority
+   *  token granting `murmur:send` would not be bound to WHICH agent may send. */
+  subject: AgentAddress;
   /** Intended recipient/service of the token. */
   audience: AgentAddress;
   /** Permission strings such as `murmur:send` or `murmur:reply`. */
@@ -264,11 +270,15 @@ export type AuthTokenRejectReason =
   | "not-yet-valid"
   | "expired"
   | "audience-mismatch"
+  | "subject-mismatch"
   | "scope-missing";
 
 export interface AuthTokenVerifyOptions {
   now?: Date | string | number;
   audience?: AgentAddress;
+  /** Require the token's `subject` (actor) to equal this address — the caller binds it
+   *  to the message sender, e.g. `requiredSubject = envelope.senderAgentId`. */
+  requiredSubject?: AgentAddress;
   requiredScopes?: string[];
 }
 
@@ -315,6 +325,7 @@ function normalizeAuthClaims(claims: AuthTokenClaims): AuthTokenClaims {
   }
   return {
     issuer: parseAddress(formatAddress(claims.issuer), claims.issuer.org),
+    subject: parseAddress(formatAddress(claims.subject), claims.subject.org),
     audience: parseAddress(formatAddress(claims.audience), claims.audience.org),
     scopes: normalizeScopes(claims.scopes),
     issuedAt: claims.issuedAt,
@@ -325,12 +336,15 @@ function normalizeAuthClaims(claims: AuthTokenClaims): AuthTokenClaims {
 
 /**
  * Canonical auth-token signing input. Scopes are sorted/deduped so permission order
- * does not affect signatures; issuer/audience are canonical `org/agentId` strings.
+ * does not affect signatures; issuer/subject/audience are canonical `org/agentId`
+ * strings. `subject` is signed too, so it can't be swapped to re-point an authority's
+ * grant at a different actor.
  */
 export function canonicalAuthTokenClaims(claims: AuthTokenClaims): string {
   const normalized = normalizeAuthClaims(claims);
   return JSON.stringify({
     issuer: formatAddress(normalized.issuer),
+    subject: formatAddress(normalized.subject),
     audience: formatAddress(normalized.audience),
     scopes: normalized.scopes,
     issuedAt: normalized.issuedAt,
@@ -430,6 +444,10 @@ export async function verifyAuthToken(
 
   if (options.audience && formatAddress(options.audience) !== formatAddress(normalized.audience)) {
     return { accepted: false, reason: "audience-mismatch" };
+  }
+
+  if (options.requiredSubject && formatAddress(options.requiredSubject) !== formatAddress(normalized.subject)) {
+    return { accepted: false, reason: "subject-mismatch" };
   }
 
   if (options.requiredScopes?.length) {

--- a/packages/federation/test/federation.test.mjs
+++ b/packages/federation/test/federation.test.mjs
@@ -272,7 +272,10 @@ async function authStoreWithIssuer() {
 
 function authClaims(overrides = {}) {
   return {
+    // issuer's verify key is the one registered in the roster by authStoreWithIssuer
+    // (it plays the authority role here); subject is the distinct actor it vouches for.
     issuer: { org: "aimindset", agentId: "agent-jarvis" },
+    subject: { org: "aimindset", agentId: "agent-worker" },
     audience: { org: "partner", agentId: "agent-codex" },
     scopes: ["murmur:send", "murmur:reply"],
     issuedAt: "2026-06-21T10:00:00.000Z",
@@ -312,6 +315,42 @@ test("AuthToken: canonical claims are scope-order independent", () => {
   assert.equal(
     canonicalAuthTokenClaims(authClaims({ scopes: ["murmur:reply", "murmur:send"] })),
     canonicalAuthTokenClaims(authClaims({ scopes: ["murmur:send", "murmur:reply"] })),
+  );
+});
+
+test("AuthToken: binds subject (actor) — requiredSubject matches, mismatch/tamper rejected", async () => {
+  const { store, issuerSig } = await authStoreWithIssuer();
+  const token = await signAuthToken(authClaims(), issuerSig.privateKey);
+  // the bound actor is accepted
+  assert.deepEqual(
+    await verifyAuthToken(token, store, {
+      now: "2026-06-21T10:30:00.000Z",
+      requiredSubject: { org: "aimindset", agentId: "agent-worker" },
+    }),
+    { accepted: true },
+  );
+  // a different actor is rejected — the authority's grant is bound to agent-worker only
+  assert.deepEqual(
+    await verifyAuthToken(token, store, {
+      now: "2026-06-21T10:30:00.000Z",
+      requiredSubject: { org: "aimindset", agentId: "agent-evil" },
+    }),
+    { accepted: false, reason: "subject-mismatch" },
+  );
+  // subject is in the signed payload — swapping it invalidates the signature
+  assert.deepEqual(
+    await verifyAuthToken(
+      { ...token, subject: { org: "aimindset", agentId: "agent-evil" } },
+      store,
+      { now: "2026-06-21T10:30:00.000Z" },
+    ),
+    { accepted: false, reason: "signature-invalid" },
+  );
+  // a token missing subject is malformed
+  const { subject, ...noSubject } = token;
+  assert.deepEqual(
+    await verifyAuthToken(noSubject, store, { now: "2026-06-21T10:30:00.000Z" }),
+    { accepted: false, reason: "malformed" },
   );
 });
 


### PR DESCRIPTION
## What (PR-B of auth/authz #47)
Adds a required, **signed** `subject: AgentAddress` (the authorized caller/actor) to `AuthTokenClaims`.

## Why
Per @codex design-review: the model had `issuer`/`audience`/`scopes` but **no actor binding** — an org-authority token granting `murmur:send` wasn't bound to *which* agent may send (self-issued scope is meaningless). `subject` ties the grant to a specific actor; in PR-D `authorizeInbound` will enforce `requiredSubject = envelope.senderAgentId`.

## Changes (federation/src/index.ts)
- `AuthTokenClaims.subject` (required).
- `canonicalAuthTokenClaims` signs `subject` (after `issuer`) — can't be swapped without breaking the signature.
- `normalizeAuthClaims` normalizes + requires it (missing → `malformed`).
- `verifyAuthToken`: new `requiredSubject` option + `subject-mismatch` reject reason.

## Compatibility
Breaking to the **still-unwired** token model — no production tokens exist (model was coded+tested, never enforced). No runtime/transport touched.

## Verification
- build PASS; **federation 25/25** (+1 subject test: match accepted / mismatch → subject-mismatch / tampered → signature-invalid / missing → malformed); full `npm test` 0 fail; `git diff --check` clean.

Review by diff + CI. @codex PR-B as scoped; PR-C (authToken in EnvelopeV1 + signed payload) next.