### PR TITLE
feat(core): optional signed authToken on EnvelopeV1

### DIFF
--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -54,9 +54,10 @@ discriminated structurally — `presenceVersion: "1.0"` for presence, `kind` for
 **`authToken` is part of the signed payload.** When present it is appended to
 `stableEnvelopePayload` in a fixed final position, so it cannot be stripped or swapped
 without invalidating the signature. When absent, the signing payload is byte-identical
-to envelopes from before the field existed (forward/backward compatible). Verification +
-enforcement is a runtime concern (`@murmurv2/federation` `verifyAuthToken` /
-`authorizeInbound`, gated by `MURMUR_ENFORCE_AUTH`), not a schema constraint.
+to envelopes from before the field existed (forward/backward compatible). Verification is a
+runtime concern (`@murmurv2/federation` `verifyAuthToken`), not a schema constraint;
+ingress enforcement (an `authorizeInbound` helper gated by `MURMUR_ENFORCE_AUTH`) is
+forthcoming in auth/authz #47 PR-D.
 
 ## AckV1
 

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -49,6 +49,14 @@ discriminated structurally — `presenceVersion: "1.0"` for presence, `kind` for
 | `traceId` | — | string | |
 | `sequence` | — | number | |
 | `parentMsgId` | — | string | |
+| `authToken` | — | string | non-empty if present; bearer (`MURMUR-AUTH:…`) |
+
+**`authToken` is part of the signed payload.** When present it is appended to
+`stableEnvelopePayload` in a fixed final position, so it cannot be stripped or swapped
+without invalidating the signature. When absent, the signing payload is byte-identical
+to envelopes from before the field existed (forward/backward compatible). Verification +
+enforcement is a runtime concern (`@murmurv2/federation` `verifyAuthToken` /
+`authorizeInbound`, gated by `MURMUR_ENFORCE_AUTH`), not a schema constraint.
 
 ## AckV1
 

--- a/docs/protocol-v1.md
+++ b/docs/protocol-v1.md
@@ -32,10 +32,11 @@ Envelope message payloads are encrypted on the wire; presence frames are intenti
 7. Retry policy moves failed messages; terminal failures go to DLQ
 
 An optional `authToken` (bearer `MURMUR-AUTH:…`) authorizes the sender. When present it
-is part of the signed payload (cannot be stripped/swapped) and a verifier may enforce it
-at ingress (`@murmurv2/federation` `authorizeInbound`, gated by `MURMUR_ENFORCE_AUTH`).
-Absent on un-authenticated envelopes, which sign byte-identically to before the field
-existed — see [`protocol-compatibility.md`](protocol-compatibility.md).
+is part of the signed payload (cannot be stripped/swapped) and can be verified with
+`@murmurv2/federation` `verifyAuthToken`; ingress enforcement (an `authorizeInbound`
+helper gated by `MURMUR_ENFORCE_AUTH`) is forthcoming in auth/authz #47 PR-D. Absent on
+un-authenticated envelopes, which sign byte-identically to before the field existed —
+see [`protocol-compatibility.md`](protocol-compatibility.md).
 
 ## Delivery model
 - at-least-once delivery

--- a/docs/protocol-v1.md
+++ b/docs/protocol-v1.md
@@ -31,6 +31,12 @@ Envelope message payloads are encrypted on the wire; presence frames are intenti
 6. Consumer emits ACK or NACK
 7. Retry policy moves failed messages; terminal failures go to DLQ
 
+An optional `authToken` (bearer `MURMUR-AUTH:…`) authorizes the sender. When present it
+is part of the signed payload (cannot be stripped/swapped) and a verifier may enforce it
+at ingress (`@murmurv2/federation` `authorizeInbound`, gated by `MURMUR_ENFORCE_AUTH`).
+Absent on un-authenticated envelopes, which sign byte-identically to before the field
+existed — see [`protocol-compatibility.md`](protocol-compatibility.md).
+
 ## Delivery model
 - at-least-once delivery
 - idempotent consumers mandatory

--- a/packages/core/schema/protocol-v1.schema.json
+++ b/packages/core/schema/protocol-v1.schema.json
@@ -33,6 +33,7 @@
         "traceId": { "type": "string" },
         "sequence": { "type": "number" },
         "parentMsgId": { "type": "string" },
+        "authToken": { "type": "string", "minLength": 1 },
         "payloadCiphertext": { "type": "string", "minLength": 1 },
         "payloadNonce": { "type": "string", "minLength": 1 },
         "signature": { "type": "string", "minLength": 1 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,10 +20,11 @@ export interface EnvelopeV1 {
   sequence?: number;
   parentMsgId?: string;
   /** Optional bearer auth token (`MURMUR-AUTH:...`) authorizing the sender. When present
-   *  it is part of the signed payload (so it can't be stripped/swapped), and a verifier
-   *  may enforce it at ingress (see @murmurv2/federation `verifyAuthToken` /
-   *  `authorizeInbound`, gated by `MURMUR_ENFORCE_AUTH`). Absent on un-authenticated
-   *  envelopes — those sign byte-identically to before this field existed. */
+   *  it is part of the signed payload (so it can't be stripped/swapped) and can be
+   *  verified with @murmurv2/federation `verifyAuthToken`. Ingress enforcement (an
+   *  `authorizeInbound` helper gated by `MURMUR_ENFORCE_AUTH`) is forthcoming in
+   *  auth/authz #47 PR-D. Absent on un-authenticated envelopes — those sign
+   *  byte-identically to before this field existed. */
   authToken?: string;
   payloadCiphertext: string;
   payloadNonce: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,12 @@ export interface EnvelopeV1 {
   traceId?: string;
   sequence?: number;
   parentMsgId?: string;
+  /** Optional bearer auth token (`MURMUR-AUTH:...`) authorizing the sender. When present
+   *  it is part of the signed payload (so it can't be stripped/swapped), and a verifier
+   *  may enforce it at ingress (see @murmurv2/federation `verifyAuthToken` /
+   *  `authorizeInbound`, gated by `MURMUR_ENFORCE_AUTH`). Absent on un-authenticated
+   *  envelopes — those sign byte-identically to before this field existed. */
+  authToken?: string;
   payloadCiphertext: string;
   payloadNonce: string;
   signature: string;
@@ -50,6 +56,10 @@ export const stableEnvelopePayload = (envelope: EnvelopeV1): string =>
     createdAt: envelope.createdAt,
     payloadCiphertext: envelope.payloadCiphertext,
     payloadNonce: envelope.payloadNonce,
+    // authToken is appended ONLY when present, in a fixed final position: envelopes
+    // without it sign byte-identically to before this field existed (back-compat),
+    // and when present it is covered by the signature so it can't be stripped/swapped.
+    ...(envelope.authToken !== undefined ? { authToken: envelope.authToken } : {}),
   });
 
 export interface DedupeStore {
@@ -1192,7 +1202,9 @@ export const isEnvelopeV1 = (v: unknown): v is EnvelopeV1 => {
     hasOptional("ttlSeconds", "number") &&
     hasOptional("traceId", "string") &&
     hasOptional("sequence", "number") &&
-    hasOptional("parentMsgId", "string")
+    hasOptional("parentMsgId", "string") &&
+    // authToken: optional, but if present must be a non-empty string (a bearer token)
+    (o.authToken === undefined || (typeof o.authToken === "string" && o.authToken.length > 0))
   );
 };
 

--- a/packages/core/test/conformance.test.mjs
+++ b/packages/core/test/conformance.test.mjs
@@ -137,6 +137,7 @@ test("schema and isEnvelopeV1 agree on every structural violation", () => {
     ["missing payloadCiphertext", without("payloadCiphertext")],
     ["missing payloadNonce", without("payloadNonce")],
     ["empty signature (unsigned)", { ...GOOD, signature: "" }],
+    ["empty authToken (present but blank)", { ...GOOD, authToken: "" }],
   ];
   for (const [label, e] of bad) {
     assert.equal(envelopeOk(e), false, `schema must reject: ${label}`);
@@ -145,7 +146,7 @@ test("schema and isEnvelopeV1 agree on every structural violation", () => {
 });
 
 test("optional fields + forward-compatible unknown fields are accepted by both", () => {
-  const e = { ...GOOD, ttlSeconds: 60, traceId: "t", sequence: 3, parentMsgId: "p", futureFieldV2: "x" };
+  const e = { ...GOOD, ttlSeconds: 60, traceId: "t", sequence: 3, parentMsgId: "p", authToken: "MURMUR-AUTH:abc", futureFieldV2: "x" };
   assert.equal(envelopeOk(e), true);
   assert.equal(isEnvelopeV1(e), true);
 });

--- a/packages/core/test/stable-envelope-payload.test.mjs
+++ b/packages/core/test/stable-envelope-payload.test.mjs
@@ -25,6 +25,16 @@ test("stableEnvelopePayload emits the exact canonical string (golden)", () => {
   );
 });
 
+test("stableEnvelopePayload appends authToken ONLY when present (back-compat for un-authed)", () => {
+  // absent → byte-identical to before the field existed (the golden above)
+  assert.ok(!stableEnvelopePayload(ENV).includes("authToken"));
+  // present → appended in a fixed FINAL position, so it is covered by the signature
+  assert.equal(
+    stableEnvelopePayload({ ...ENV, authToken: "MURMUR-AUTH:tok" }),
+    '{"schemaVersion":"1.0","msgId":"m1","conversationId":"c1","senderAgentId":"agent-a","recipients":["agent-b","agent-c"],"createdAt":"2026-06-22T00:00:00.000Z","payloadCiphertext":"ct","payloadNonce":"no","authToken":"MURMUR-AUTH:tok"}',
+  );
+});
+
 test("stableEnvelopePayload excludes the signature field (it is what gets signed)", () => {
   const signed = stableEnvelopePayload(ENV);
   const unsigned = stableEnvelopePayload({ ...ENV, signature: "" });


### PR DESCRIPTION
## What (PR-C of auth/authz #47)
Adds an optional, **signed** `authToken` (bearer `MURMUR-AUTH:…`) to `EnvelopeV1` so any transport/bridge can verify the sender's authorization uniformly at ingress (PR-D wires enforcement).

## Key design: back-compat via conditional inclusion
`stableEnvelopePayload` appends `authToken` **only when present**, in a fixed final position:
- **present** → covered by the signature (can't be stripped/swapped — your guardrail #2).
- **absent** → the signing payload is **byte-identical** to before this field existed.

So every existing signer/verifier — including the published-pinned `agent-runner` — stays interop-compatible for un-authenticated traffic with **no re-publish** needed. (Your release caveat only bites when a consumer actually *sends* authToken.)

## Changes
- `EnvelopeV1.authToken?: string`; `isEnvelopeV1` (optional, non-empty if present).
- `stableEnvelopePayload` conditional append (core, single source of truth from PR-A).
- schema `authToken {string, minLength 1}`; conformance agreement (present-nonempty accepted / empty rejected); golden test pins with-authToken string + absent-unchanged.
- docs: protocol-v1.md + protocol-compatibility.md (field, signed-payload, runtime-enforcement).

## Verification
- build PASS; core 49 (conformance 14 + golden 5); full `npm test` 0 fail incl **interop a2a 6/6 + federation 25/25** (back-compat intact); `git diff --check` clean.

Review by diff + CI. @codex PR-C as scoped; PR-D (authorizeInbound + broker-nats enforce behind MURMUR_ENFORCE_AUTH) is the last one.