### PR TITLE
feat(federation): authorizeInbound ingress authorizer (PR-D1)

### DIFF
--- a/packages/federation/src/index.ts
+++ b/packages/federation/src/index.ts
@@ -459,3 +459,60 @@ export async function verifyAuthToken(
 
   return { accepted: true };
 }
+
+/** Reject reasons for ingress authorization — the token reasons plus a missing token. */
+export type AuthorizeInboundReason = AuthTokenRejectReason | "auth-missing";
+
+export interface AuthorizeInboundOptions {
+  /** Local org used to resolve a bare wire `senderAgentId` into a full AgentAddress. */
+  localOrg: string;
+  /** This receiver's address — the token's `audience` must equal it. */
+  audience: AgentAddress;
+  /** Scopes the inbound action requires (e.g. `["murmur:send"]`). */
+  requiredScopes: string[];
+  /** The `MURMUR_ENFORCE_AUTH` gate. When false, an envelope with no `authToken` is
+   *  accepted (auth optional); when true, a missing token is rejected. */
+  enforce: boolean;
+  now?: Date | string | number;
+}
+
+export interface AuthorizeInboundResult {
+  accepted: boolean;
+  reason?: AuthorizeInboundReason;
+}
+
+/**
+ * Ingress authorization for an inbound envelope. Decodes the envelope's bearer
+ * `authToken` and verifies it against the roster, binding the token's `subject`
+ * (actor) to the envelope's `senderAgentId` — so an authority's grant can only be
+ * used by the agent it was issued for. The wire `senderAgentId` is a BARE id, while
+ * `subject` is canonical `org/agentId`, so it is parsed into an AgentAddress first
+ * (comparing the raw strings would always mismatch).
+ *
+ * `enforce=false` lets un-authenticated envelopes (no `authToken`) through; `true`
+ * rejects them. Callers MUST NOT log the token body — audit
+ * msgId/sender/audience/reason only.
+ */
+export async function authorizeInbound(
+  envelope: { senderAgentId: string; authToken?: string },
+  rosters: RosterStore,
+  options: AuthorizeInboundOptions,
+): Promise<AuthorizeInboundResult> {
+  if (envelope.authToken === undefined) {
+    return options.enforce ? { accepted: false, reason: "auth-missing" } : { accepted: true };
+  }
+  let token: SignedAuthToken;
+  let requiredSubject: AgentAddress;
+  try {
+    token = decodeAuthToken(envelope.authToken);
+    requiredSubject = parseAddress(envelope.senderAgentId, options.localOrg);
+  } catch {
+    return { accepted: false, reason: "malformed" };
+  }
+  return verifyAuthToken(token, rosters, {
+    now: options.now,
+    audience: options.audience,
+    requiredScopes: options.requiredScopes,
+    requiredSubject,
+  });
+}

--- a/packages/federation/test/federation.test.mjs
+++ b/packages/federation/test/federation.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { createKeyPair, createSigningKeyPair, signEnvelope } from "../../security/dist/src/index.js";
 import {
+  authorizeInbound,
   canonicalAuthTokenClaims,
   canonicalRoster,
   decodeAuthToken,
@@ -395,5 +396,81 @@ test("AuthToken: rejects malformed token timestamps and empty scopes before sign
   await assert.rejects(
     () => signAuthToken(authClaims({ expiresAt: "not-a-date" }), issuerSig.privateKey),
     /invalid expiresAt/,
+  );
+});
+
+// --- authorizeInbound (ingress authz; PR-D) -----------------------------------
+
+const AUD = { org: "partner", agentId: "agent-codex" }; // = authClaims() audience
+const encodedToken = (issuerSig, overrides) =>
+  signAuthToken(authClaims(overrides), issuerSig.privateKey).then(encodeAuthToken);
+
+test("authorizeInbound: enforce off lets un-authenticated envelopes through", async () => {
+  const { store } = await authStoreWithIssuer();
+  assert.deepEqual(
+    await authorizeInbound({ senderAgentId: "agent-worker" }, store, {
+      localOrg: "aimindset", audience: AUD, requiredScopes: ["murmur:send"], enforce: false,
+    }),
+    { accepted: true },
+  );
+});
+
+test("authorizeInbound: enforce on rejects a missing token", async () => {
+  const { store } = await authStoreWithIssuer();
+  assert.deepEqual(
+    await authorizeInbound({ senderAgentId: "agent-worker" }, store, {
+      localOrg: "aimindset", audience: AUD, requiredScopes: ["murmur:send"], enforce: true,
+    }),
+    { accepted: false, reason: "auth-missing" },
+  );
+});
+
+test("authorizeInbound: accepts a valid token bound to the sender", async () => {
+  const { store, issuerSig } = await authStoreWithIssuer();
+  const authToken = await encodedToken(issuerSig);
+  assert.deepEqual(
+    await authorizeInbound({ senderAgentId: "agent-worker", authToken }, store, {
+      localOrg: "aimindset", audience: AUD, requiredScopes: ["murmur:send"],
+      enforce: true, now: "2026-06-21T10:30:00.000Z",
+    }),
+    { accepted: true },
+  );
+});
+
+test("authorizeInbound: binds subject to senderAgentId (bare id parsed to AgentAddress)", async () => {
+  const { store, issuerSig } = await authStoreWithIssuer();
+  const authToken = await encodedToken(issuerSig); // subject = aimindset/agent-worker
+  // a sender other than the token's subject is rejected — the grant is bound to the actor
+  assert.deepEqual(
+    await authorizeInbound({ senderAgentId: "agent-evil", authToken }, store, {
+      localOrg: "aimindset", audience: AUD, requiredScopes: ["murmur:send"],
+      enforce: true, now: "2026-06-21T10:30:00.000Z",
+    }),
+    { accepted: false, reason: "subject-mismatch" },
+  );
+});
+
+test("authorizeInbound: rejects missing scope, audience mismatch, and a malformed token", async () => {
+  const { store, issuerSig } = await authStoreWithIssuer();
+  const authToken = await encodedToken(issuerSig);
+  assert.deepEqual(
+    await authorizeInbound({ senderAgentId: "agent-worker", authToken }, store, {
+      localOrg: "aimindset", audience: AUD, requiredScopes: ["murmur:admin"],
+      enforce: true, now: "2026-06-21T10:30:00.000Z",
+    }),
+    { accepted: false, reason: "scope-missing" },
+  );
+  assert.deepEqual(
+    await authorizeInbound({ senderAgentId: "agent-worker", authToken }, store, {
+      localOrg: "aimindset", audience: { org: "other", agentId: "x" },
+      requiredScopes: ["murmur:send"], enforce: true, now: "2026-06-21T10:30:00.000Z",
+    }),
+    { accepted: false, reason: "audience-mismatch" },
+  );
+  assert.deepEqual(
+    await authorizeInbound({ senderAgentId: "agent-worker", authToken: "MURMUR-AUTH:garbage!!" }, store, {
+      localOrg: "aimindset", audience: AUD, requiredScopes: ["murmur:send"], enforce: true,
+    }),
+    { accepted: false, reason: "malformed" },
   );
 });


### PR DESCRIPTION
## What (PR-D1 of auth/authz #47)
The pure ingress authorizer. Decodes an envelope's bearer `authToken` and verifies it against the roster, **binding the token `subject` (actor) to the envelope `senderAgentId`**. (PR-D2 wires it into broker-nats behind `MURMUR_ENFORCE_AUTH`.)

```ts
authorizeInbound(envelope, rosters, { localOrg, audience, requiredScopes, enforce, now })
  -> { accepted, reason? }
```

## Guardrails (all from your design-review)
- **Actor binding:** `senderAgentId` is bare on the wire; parsed into an AgentAddress via `localOrg` **before** comparing to `token.subject` (raw compare would always mismatch — your note).
- **Gate:** `enforce=false` → no token passes through; `enforce=true` → missing token = `auth-missing`.
- **No token logging** — pure, returns a reason; callers audit msgId/sender/audience/reason only.
- Delegates to `verifyAuthToken` (audience + requiredScopes + requiredSubject).

## Tests (federation 30/30, +5)
enforce-off pass-through · enforce-on missing→auth-missing · valid bound token accepted · different sender→**subject-mismatch** · scope-missing · audience-mismatch · garbage→malformed.

## Verification
build PASS; full `npm test` 0 fail; `git diff --check` clean. Pure helper — no transport touched.

Review by diff + CI. @codex PR-D1; PR-D2 (broker-nats enforce behind MURMUR_ENFORCE_AUTH, NACK auth-rejected:<reason>) is the final piece.