### PR TITLE
feat(broker-nats): ingress auth enforcement (PR-D2 — final auth #47)

### DIFF
--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -49,6 +49,16 @@ export interface BrokerConfig {
 export type MessageHandler = (envelope: EnvelopeV1) => Promise<void>;
 export type BrokerSubscription = Subscription | { unsubscribe(): void | Promise<void> };
 
+/**
+ * Optional ingress authorizer. Returns whether an inbound envelope is allowed before
+ * it reaches the consumer's `onMessage`. INJECTED (not imported) so broker-nats stays
+ * free of a @murmurv2/federation dependency — the daemon wires `authorizeInbound` here
+ * only when `MURMUR_ENFORCE_AUTH` is on (default OFF → no authorize hook → no
+ * enforcement). A rejected envelope is NACKed `auth-rejected:<reason>` and never
+ * delivered. The hook MUST NOT log the token body.
+ */
+export type InboundAuthorizer = (envelope: EnvelopeV1) => Promise<{ accepted: boolean; reason?: string }>;
+
 export interface BrokerStatusEvent {
   type: string;
   data?: unknown;
@@ -248,6 +258,7 @@ export class NatsBroker {
       dedupe: DedupeStore;
       onMessage: MessageHandler;
       maxPoisonAttempts?: number;
+      authorize?: InboundAuthorizer;
     },
   ): Promise<"ack" | "retry"> {
     let msgId = "unknown";
@@ -265,6 +276,20 @@ export class NatsBroker {
       if (isDup) {
         await this.publishAck(ackSubject, createAck(decoded.msgId, params.consumerId, "ack", "duplicate-ignored"));
         return "ack";
+      }
+
+      // Ingress authorization (PR-D2). Only enforced when an authorizer is wired
+      // (daemon does so when MURMUR_ENFORCE_AUTH is on). A rejected envelope is
+      // terminal: NACK auth-rejected:<reason>, never delivered, not retried.
+      if (params.authorize) {
+        const authz = await params.authorize(decoded);
+        if (!authz.accepted) {
+          await this.publishAck(
+            ackSubject,
+            createAck(decoded.msgId, params.consumerId, "nack", `auth-rejected:${authz.reason ?? "denied"}`),
+          );
+          return "ack";
+        }
       }
 
       await params.onMessage(decoded);
@@ -362,6 +387,9 @@ export class NatsBroker {
     dedupe: DedupeStore;
     onMessage: MessageHandler;
     maxPoisonAttempts?: number;
+    /** Optional ingress authorizer; when set, envelopes are authorized before delivery
+     *  (wire @murmurv2/federation authorizeInbound here behind MURMUR_ENFORCE_AUTH). */
+    authorize?: InboundAuthorizer;
   }): Promise<BrokerSubscription> {
     await this.connect();
 

--- a/tests/broker-auth-enforce.test.mjs
+++ b/tests/broker-auth-enforce.test.mjs
@@ -1,0 +1,109 @@
+// PR-D2: broker-nats ingress auth enforcement. Verifies the injected `authorize`
+// hook gates delivery — without touching a live NATS server (fake nc, same pattern as
+// broker-ack-subject.test.mjs). The authorizer itself (authorizeInbound) is unit-tested
+// in @murmurv2/federation; this proves the WIRING: reject -> NACK auth-rejected, never
+// delivered; accept -> delivered + ack; no authorizer -> pass-through (default OFF).
+import test from "node:test";
+import assert from "node:assert/strict";
+import { StringCodec } from "nats";
+import { NatsBroker } from "../packages/broker-nats/dist/src/index.js";
+
+const sc = StringCodec();
+
+const envelope = {
+  schemaVersion: "1.0",
+  msgId: "msg-auth",
+  conversationId: "conv-auth",
+  senderAgentId: "agent-sender",
+  recipients: ["agent-receiver"],
+  createdAt: new Date().toISOString(),
+  payloadCiphertext: Buffer.from("x").toString("base64"),
+  payloadNonce: "nonce",
+  signature: "sig",
+  authToken: "MURMUR-AUTH:tok",
+};
+
+function harness() {
+  const published = [];
+  const fakeSub = {
+    async *[Symbol.asyncIterator]() {
+      yield { data: sc.encode(JSON.stringify(envelope)) };
+    },
+  };
+  const fakeNc = {
+    subscribe() {
+      return fakeSub;
+    },
+    publish(subject, data) {
+      published.push({ subject, body: JSON.parse(sc.decode(data)) });
+    },
+    async drain() {},
+  };
+  const dedupe = { async seen() { return false; }, async markSeen() {} };
+  const broker = new NatsBroker({ url: "nats://example.invalid" });
+  broker.nc = fakeNc;
+  return { broker, dedupe, published };
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 20));
+
+test("authorize reject -> NACK auth-rejected:<reason>, onMessage NOT called", async () => {
+  const { broker, dedupe, published } = harness();
+  let delivered = false;
+  await broker.subscribeWithAck({
+    subject: "msg.agent-receiver",
+    consumerId: "agent-receiver",
+    dedupe,
+    onMessage: async () => { delivered = true; },
+    authorize: async () => ({ accepted: false, reason: "subject-mismatch" }),
+  });
+  await settle();
+  assert.equal(delivered, false, "a rejected envelope must never reach onMessage");
+  assert.equal(published.length, 1);
+  assert.equal(published[0].subject, "ack.agent-sender");
+  assert.equal(published[0].body.status, "nack");
+  assert.equal(published[0].body.reason, "auth-rejected:subject-mismatch");
+});
+
+test("authorize accept -> delivered + ack", async () => {
+  const { broker, dedupe, published } = harness();
+  let delivered = false;
+  await broker.subscribeWithAck({
+    subject: "msg.agent-receiver",
+    consumerId: "agent-receiver",
+    dedupe,
+    onMessage: async () => { delivered = true; },
+    authorize: async () => ({ accepted: true }),
+  });
+  await settle();
+  assert.equal(delivered, true);
+  assert.equal(published[0].body.status, "ack");
+});
+
+test("no authorizer -> pass-through (enforcement OFF by default)", async () => {
+  const { broker, dedupe, published } = harness();
+  let delivered = false;
+  await broker.subscribeWithAck({
+    subject: "msg.agent-receiver",
+    consumerId: "agent-receiver",
+    dedupe,
+    onMessage: async () => { delivered = true; },
+  });
+  await settle();
+  assert.equal(delivered, true);
+  assert.equal(published[0].body.status, "ack");
+});
+
+test("authorize reject reason defaults to 'denied' when omitted", async () => {
+  const { broker, dedupe, published } = harness();
+  await broker.subscribeWithAck({
+    subject: "msg.agent-receiver",
+    consumerId: "agent-receiver",
+    dedupe,
+    onMessage: async () => {},
+    authorize: async () => ({ accepted: false }),
+  });
+  await settle();
+  assert.equal(published[0].body.status, "nack");
+  assert.equal(published[0].body.reason, "auth-rejected:denied");
+});


### PR DESCRIPTION
## What (PR-D2 — the final piece of auth/authz #47)
Wires authorization into the broker's per-message delivery path.

## Design: dependency-free injection
broker-nats does **not** import @murmurv2/federation. `subscribeWithAck` accepts an optional `InboundAuthorizer` hook; the **daemon** wires `authorizeInbound` (PR-D1) into it when `MURMUR_ENFORCE_AUTH` is on. Default OFF → no hook → no enforcement → fully back-compat.

## Enforcement (processEnvelopeFrame)
After dedup, before `onMessage`: if an authorizer is wired and **rejects**, the envelope is terminal — `NACK auth-rejected:<reason>`, `onMessage` is **never** called, and it is acked (not retried — auth failure isn't transient). Hook returns only `{accepted, reason}`; never logs the token body.

## Tests (`tests/broker-auth-enforce.test.mjs`, fake-nc, no live NATS)
reject → NACK `auth-rejected:<reason>` + not delivered · accept → delivered + ack · no authorizer → pass-through · reason defaults to `denied`.

## Completes auth #47
PR-A (centralize payload) → PR-B (subject) → PR-C (envelope authToken) → PR-D1 (authorizeInbound) → **PR-D2 (broker enforce)**.

## Verification
build PASS; test:unit 68/68 (+4); full `npm test` 0 fail incl interop (a2a 6/6, federation 30/30); `git diff --check` clean.

Review by diff + CI. @codex final auth PR. Daemon wiring (read MURMUR_ENFORCE_AUTH + construct authorizeInbound with the agent's roster/identity/audience) can be a tiny follow-up or part of your daemon-deploy lane.