### PR TITLE
release: 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Pending
+- **Auth enforcement end-to-end** — the broker ingress hook + `authorizeInbound` exist; the daemon does not yet wire them (so `MURMUR_ENFORCE_AUTH` is not enforced end-to-end). Requires daemon roster/identity wiring + token provisioning.
+- **npm republish @ 0.2.0** — `@murmurv2/core` (and dependents) export new API this release (`stableEnvelopePayload`, `EnvelopeV1.authToken`, stream guards, `authorizeInbound`, `InboundAuthorizer`); consumers importing them need a republished core (published `0.1.0` predates them).
+
+## [2.3.0] - 2026-06-22
+
+### Added
+
+- **Agent discovery — complete.** Presence frames + candidate registry (ttl expiry, dedupe, out-of-order guard); signed presence with NATS `announcePresence`/`subscribePresence`; operator promote-flow (`queryCandidates` + `promoteCandidate`) returning the live nested peer-config entry. Trust is always an **explicit operator promotion** — candidates are never auto-trusted.
+- **Message streaming — complete.** Stream frames (`stream.start`/`chunk`/`end`), UTF-8-safe chunking, in-memory + durable SQLite reassembly (out-of-order, idempotent, conflict-reject), backpressure (chunk + byte windows), sha256 per-chunk/whole-stream integrity, and an ACK-window.
+- **Auth/authz enforcement mechanism** — `signAuthToken`/`verifyAuthToken` now carry a signed **`subject`** (actor); `EnvelopeV1` gains an optional, signed **`authToken`** (bearer `MURMUR-AUTH:…`, appended to the canonical payload only when present → byte-identical back-compat when absent); `@murmurv2/federation` `authorizeInbound` verifies it and binds `subject === senderAgentId`; `@murmurv2/broker-nats` enforces at ingress via an injected `InboundAuthorizer` hook behind `MURMUR_ENFORCE_AUTH` (default OFF, NACK `auth-rejected:<reason>`, never delivered). *Daemon end-to-end wiring pending (see Unreleased).*
+- **Conformance suite — extended to every wire type.** `PresenceFrameV1`, `SignedPresenceFrameV1`, `StreamStart`/`StreamChunk`/`StreamEnd` (+ a discriminated `StreamFrame` `oneOf`) added to `protocol-v1.schema.json` and to schema↔runtime-guard agreement matrices; new structural guards `isStreamStart`/`isStreamChunk`/`isStreamEnd`/`isStreamFrame`.
+- **Versioned protocol spec.** `docs/protocol-v1.md` (prose lifecycle for envelope, discovery, streaming) + `docs/protocol-compatibility.md` (field tables + per-type validation entrypoints + runtime-only-checks boundary) covering all wire types.
+
+### Changed
+
+- **`stableEnvelopePayload` centralized** into `@murmurv2/core` as the single canonical signing form (was byte-identically copy-pasted across 7 sites: mcp-server, daemon, bridge-a2a, shell-send, demos, agent-runner example, federation live test). Golden-locked by test.
+
+### Fixed
+
+- De-flaked the `mcp-request-reply` C2 long-poll-timeout test (real-timer boundary race → injectable fake clock).
+
+### Validated
+
+- **Real cross-host A2A.** A fresh Murmur agent deployed on Phoenix/agent-hq over the **published** `@murmurv2/*` packages connected to the live broker over Tailscale and exchanged **bidirectional** encrypt/verify/ACK messages with JARVIS — exercising the mesh across real hosts and network (closes the "real mesh deploy" mechanism gate; a second real partner *org* for federation remains an external gate).
+
 ## [2.2.0] - 2026-06-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,18 +47,18 @@ A **murmuration** is one of nature's most extraordinary phenomena — thousands 
 
 ---
 
-## What's New in v2.2
+## What's New in v2.3
 
-- **Published on npm.** All packages are public under the [`@murmurv2`](https://www.npmjs.com/org/murmurv2) scope (MIT) — `npm install @murmurv2/core` (and the rest). See [Install](#install).
-- **WebSocket transport adapter.** `@murmurv2/broker-ws` — relay + broker client with envelope delivery, ACK correlation, dedupe, and invalid-envelope NACKs (browser/edge deployment pending).
-- **Roster-backed auth tokens.** Signed audience/scope/time-windowed tokens verified against the federation roster (no embedded trust root) — `@murmurv2/federation`.
-- **Machine-readable protocol schema + conformance suite.** Draft 2020-12 JSON Schema for `EnvelopeV1`/`AckV1` (`@murmurv2/core/schema`) + a compatibility matrix; conformance tests keep the schema and the runtime guard in lock-step.
-- **Durable JetStream transport (opt-in).** Turn on at-least-once durability with NATS JetStream — finite redelivery (`max_deliver`), explicit ACK, dead-letter on exhaustion — while keeping the SQLite outbox as the transactional source of truth. Default-OFF; set `MURMUR_JETSTREAM=1` to enable.
-- **Federation (live-proven in isolation; no real partner yet).** `org/agentId` addressing, an Ed25519-signed key directory, a `fed.*` NATS leaf-node/account contract, a `RosterStore` (pinned-key trust + monotonic-version replay guard), and an account-config renderer. Proven end-to-end against a **real local NATS mesh** — cross-org sealed+signed delivery on isolated accounts, the same over a **leaf-node topology** (org-per-server), and least-privilege publish/subscribe boundaries. Still **not wired to a second real partner org** (the only remaining gate).
-- **A2A bridge (live client round-trip; mock internal counterpart).** A bridge against the industry-standard [A2A protocol](https://a2aproject.github.io/A2A/). A **real `@a2a-js/sdk` client → bridge → NATS → reply** round-trip is proven over HTTP (against a mock internal agent), and Agent-Card transport discovery is fixed. Still **not connected to a real remote A2A agent**.
-- **Native wake.** This repo ships **live-session** wake — Claude asyncRewake, Codex app-server UDS, self-healing thread re-seed (`WakeMonitor`). **Always-on wake into a *dead* session** is provided by an **out-of-repo cold-start sidecar in the reference Codex deployment** (spawn-on-inbound → fresh `codex exec` per message batch, under a linger-enabled systemd user service); a repo-shipped version and the strict no-live-session proof are still pending.
+- **Agent discovery — complete.** Presence frames + candidate registry, signed presence over NATS (`announcePresence`/`subscribePresence`), and an operator promote-flow (`queryCandidates` + `promoteCandidate`). Trust is always an **explicit operator promotion** — candidates are never auto-trusted.
+- **Message streaming — complete.** Chunked stream frames with out-of-order, idempotent, durable SQLite reassembly, backpressure (chunk + byte windows), and sha256 integrity.
+- **Auth/authz enforcement.** A signed **`subject`** (actor) in auth tokens, an optional signed **`authToken`** on `EnvelopeV1` (covered by the signature; byte-identical back-compat when absent), `authorizeInbound` (binds `subject === senderAgentId`), and broker ingress enforcement behind `MURMUR_ENFORCE_AUTH` (default-OFF). *Daemon end-to-end wiring is the remaining step.*
+- **Conformance + versioned protocol spec — all wire types.** The Draft 2020-12 schema and the schema↔runtime-guard agreement matrices now cover envelope, ack, presence, and stream frames; `docs/protocol-v1.md` + `docs/protocol-compatibility.md` document them.
+- **Validated: real cross-host A2A.** A fresh agent on a remote host (over the published `@murmurv2/*` packages) exchanged bidirectional encrypt/verify/ACK traffic with the mesh over the live broker — agent-to-agent across real hosts and network.
+- **Single canonical signing payload.** `stableEnvelopePayload` is now one export in `@murmurv2/core` (was copy-pasted across 7 sites), golden-locked by test.
 
-See [CHANGELOG.md](CHANGELOG.md) for the full list.
+> npm packages re-publish at `0.2.0` for the new core/federation/broker-nats API is the gated next step; the published `0.1.0` predates it.
+
+See [CHANGELOG.md](CHANGELOG.md) for the full list (incl. v2.2: npm publish, WebSocket adapter, roster auth tokens, JetStream durability, federation, A2A bridge, native wake).
 
 ## Install
 
@@ -471,17 +471,17 @@ See [protocol-v1.md](docs/protocol-v1.md) for the full specification.
 
 ### In Progress
 - [ ] **Federation (v2.1)** — addressing + Ed25519 signed key directory + `fed.*` contract + account-config renderer + `RosterStore` (pinned-key trust + monotonic-version replay guard) are **live-proven against a real local NATS mesh**: cross-org sealed+signed delivery on isolated accounts, the same over a **leaf-node topology** (org-per-server), and least-privilege pub/sub permission boundaries (`integration/` smokes, cross-verified). Remaining gate: **not yet wired to a second real partner org**
-- [ ] **A2A interop bridge (v2.1)** — a **real `@a2a-js/sdk` client → bridge → NATS → reply round-trip is proven** over HTTP (against a mock internal agent), and Agent-Card transport discovery is fixed. Remaining gate: **not yet connected to a real remote A2A agent**
+- [ ] **A2A interop bridge (v2.1)** — a **real `@a2a-js/sdk` client → bridge → NATS → reply round-trip is proven** over HTTP (against a mock internal agent), and Agent-Card transport discovery is fixed. Agent-to-agent **over the Murmur mesh** is separately proven **cross-host** (a fresh remote agent on published npm did bidirectional encrypt/verify/ACK with the mesh over the live broker). Remaining gate: the A2A *protocol* bridge against a **real remote A2A agent**
 - [ ] **Always-on wake (dead session) (v2.1)** — a cold-start spawn-on-inbound sidecar (fresh `codex exec` per batch, exactly-once, linger-enabled systemd user service) exists in the **reference Codex deployment, outside this repo**; a repo-shipped version and the strict no-live-session proof remain pending
-- [ ] **Auth/authz token model** — roster-backed signed tokens with audience/scope/time verification are coded and unit-tested; remaining gate: wire token enforcement into live transports/bridges
+- [ ] **Auth/authz enforcement** — token model (roster-backed, audience/scope/time + signed `subject` actor), optional signed `EnvelopeV1.authToken`, `authorizeInbound` (binds `subject === senderAgentId`), and broker ingress enforcement behind `MURMUR_ENFORCE_AUTH` (default-OFF, NACK `auth-rejected:<reason>`) are **shipped**; remaining gate: wire it into the daemon (read the flag + build the authorizer from the roster) so it enforces end-to-end
 - [ ] **WebSocket transport adapter** — relay + broker client are coded and unit-tested for envelope delivery, ACK correlation, dedupe, and invalid-envelope NACKs; remaining gate: browser/edge deployment examples and hardening
 - [x] Prometheus metrics exporter — outbox depth, delivery latency, error rates
 - [x] **npm package publishing** — all 12 `@murmurv2/*` packages published public on npm (MIT); `security` + `observability` @ `0.1.1` (declared `@noble/*` / `better-sqlite3` runtime deps), the rest @ `0.1.0`
 - [x] **NATS native request-reply** — wake-accelerated `murmur_request`: a read-only ephemeral NATS tap returns the reply as soon as it lands; the SQLite store-poll stays the durable fallback and the daemon stays source of truth for decrypt
 
 ### Planned (next wave)
-- [ ] **Message streaming** — *PR1 merged:* pure core stream frames (start/chunk/end), UTF-8-safe chunking, in-memory reassembler (out-of-order + idempotent + conflict-reject), backpressure predicate (chunk + byte windows). PR2: NATS wiring + durable reassembly + sha256 integrity
-- [ ] **Agent discovery protocol** — *PR1 merged:* presence frames + candidate registry (ttl expiry, dedupe, out-of-order guard). Trust stays an explicit operator promote — candidates are never auto-trusted. PR2: NATS announce/listen (`announcePresence` / `subscribePresence`) + signed presence frames. PR3: operator promote-flow + a query/roster API
+- [x] **Message streaming** — stream frames (start/chunk/end), UTF-8-safe chunking, in-memory + durable SQLite reassembly (out-of-order, idempotent, conflict-reject), backpressure (chunk + byte windows), sha256 integrity, ACK-window
+- [x] **Agent discovery protocol** — presence frames + candidate registry (ttl expiry, dedupe, out-of-order guard), signed presence over NATS (`announcePresence`/`subscribePresence`), operator promote-flow (`queryCandidates`/`promoteCandidate`). Trust stays an explicit operator promotion — candidates are never auto-trusted
 - [x] Reference deployment examples — docker-compose (`deploy/docker-compose.messaging.yml`) + Kubernetes manifests (`deploy/kubernetes/`)
 - [x] Conformance test suite — schema↔guard agreement matrices for every wire type (`packages/core/test/conformance.test.mjs`); port the fixtures to check a third-party implementation
 - [x] Versioned protocol spec — machine-readable schema (`protocol-v1.schema.json`) + prose ([`docs/protocol-v1.md`](docs/protocol-v1.md)) + compatibility matrix ([`docs/protocol-compatibility.md`](docs/protocol-compatibility.md)) covering envelope, ack, presence, and stream frames

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mur-mur-v2",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mur-mur-v2",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "workspaces": [
         "packages/*"
       ],
@@ -1778,7 +1778,7 @@
       "license": "MIT",
       "dependencies": {
         "@a2a-js/sdk": "1.0.0-alpha.0",
-        "@murmurv2/core": "^0.1.0",
+        "@murmurv2/core": "^0.2.0",
         "@murmurv2/security": "^0.1.0",
         "express": "^5.1.0",
         "nats": "^2.28.2"
@@ -1797,7 +1797,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "^0.1.0",
+        "@murmurv2/core": "^0.2.0",
         "nats": "^2.28.2"
       }
     },
@@ -1806,16 +1806,16 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "^0.1.0",
+        "@murmurv2/core": "^0.2.0",
         "@murmurv2/security": "^0.1.0"
       }
     },
     "packages/broker-nats": {
       "name": "@murmurv2/broker-nats",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "^0.1.0",
+        "@murmurv2/core": "^0.2.0",
         "nats": "^2.28.2"
       }
     },
@@ -1824,13 +1824,13 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "^0.1.0",
+        "@murmurv2/core": "^0.2.0",
         "ws": "^8.21.0"
       }
     },
     "packages/core": {
       "name": "@murmurv2/core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "pg": "^8.16.3"
@@ -1838,7 +1838,7 @@
     },
     "packages/federation": {
       "name": "@murmurv2/federation",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@murmurv2/security": "^0.1.0"
@@ -1849,8 +1849,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "^0.1.0",
-        "@murmurv2/federation": "^0.1.0"
+        "@murmurv2/core": "^0.2.0",
+        "@murmurv2/federation": "^0.2.0"
       },
       "devDependencies": {
         "@murmurv2/security": "^0.1.0",
@@ -1862,8 +1862,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@murmurv2/broker-nats": "^0.1.0",
-        "@murmurv2/core": "^0.1.0",
+        "@murmurv2/broker-nats": "^0.2.0",
+        "@murmurv2/core": "^0.2.0",
         "@murmurv2/security": "^0.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mur-mur-v2",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Reliable secure multi-agent messaging core",
   "workspaces": [
     "packages/*"

--- a/packages/bridge-a2a/package.json
+++ b/packages/bridge-a2a/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "1.0.0-alpha.0",
-    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/core": "^0.2.0",
     "@murmurv2/security": "^0.1.0",
     "express": "^5.1.0",
     "nats": "^2.28.2"
@@ -33,5 +33,5 @@
     "dist/src",
     "LICENSE"
   ],
-  "description": "Murmur V2 to A2A protocol bridge (alpha) — terminates @a2a-js/sdk and re-wraps tasks as E2E Murmur envelopes."
+  "description": "Murmur V2 to A2A protocol bridge (alpha) \u2014 terminates @a2a-js/sdk and re-wraps tasks as E2E Murmur envelopes."
 }

--- a/packages/bridge-openclaw/package.json
+++ b/packages/bridge-openclaw/package.json
@@ -9,7 +9,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/core": "^0.2.0",
     "nats": "^2.28.2"
   },
   "license": "MIT",

--- a/packages/bridge-telegram/package.json
+++ b/packages/bridge-telegram/package.json
@@ -9,7 +9,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/core": "^0.2.0",
     "@murmurv2/security": "^0.1.0"
   },
   "license": "MIT",

--- a/packages/broker-nats/package.json
+++ b/packages/broker-nats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurv2/broker-nats",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -9,7 +9,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/core": "^0.2.0",
     "nats": "^2.28.2"
   },
   "license": "MIT",
@@ -25,5 +25,5 @@
     "dist/src",
     "LICENSE"
   ],
-  "description": "Murmur V2 NATS broker — core pub/sub with optional JetStream durability (finite redelivery + DLQ)."
+  "description": "Murmur V2 NATS broker \u2014 core pub/sub with optional JetStream durability (finite redelivery + DLQ)."
 }

--- a/packages/broker-ws/package.json
+++ b/packages/broker-ws/package.json
@@ -10,7 +10,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/core": "^0.2.0",
     "ws": "^8.21.0"
   },
   "license": "MIT",
@@ -26,5 +26,5 @@
     "dist/src",
     "LICENSE"
   ],
-  "description": "Murmur V2 WebSocket broker adapter — local relay and browser/edge-friendly transport semantics."
+  "description": "Murmur V2 WebSocket broker adapter \u2014 local relay and browser/edge-friendly transport semantics."
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurv2/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -26,5 +26,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "description": "Murmur V2 core — EnvelopeV1/AckV1 wire types, SQLite outbox + dedupe stores, machine-readable protocol schema."
+  "description": "Murmur V2 core \u2014 EnvelopeV1/AckV1 wire types, SQLite outbox + dedupe stores, machine-readable protocol schema."
 }

--- a/packages/federation-nats/package.json
+++ b/packages/federation-nats/package.json
@@ -13,8 +13,8 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@murmurv2/core": "^0.1.0",
-    "@murmurv2/federation": "^0.1.0"
+    "@murmurv2/core": "^0.2.0",
+    "@murmurv2/federation": "^0.2.0"
   },
   "devDependencies": {
     "@murmurv2/security": "^0.1.0",
@@ -33,5 +33,5 @@
     "dist/src",
     "LICENSE"
   ],
-  "description": "Murmur V2 federation NATS contract — fed.* subjects + account-config renderer for cross-org leaf-node meshes."
+  "description": "Murmur V2 federation NATS contract \u2014 fed.* subjects + account-config renderer for cross-org leaf-node meshes."
 }

--- a/packages/federation/package.json
+++ b/packages/federation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@murmurv2/federation",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -25,5 +25,5 @@
     "dist/src",
     "LICENSE"
   ],
-  "description": "Murmur V2 federation — org/agent addressing, Ed25519 signed roster + RosterStore, roster-backed auth tokens."
+  "description": "Murmur V2 federation \u2014 org/agent addressing, Ed25519 signed roster + RosterStore, roster-backed auth tokens."
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -9,8 +9,8 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@murmurv2/broker-nats": "^0.1.0",
-    "@murmurv2/core": "^0.1.0",
+    "@murmurv2/broker-nats": "^0.2.0",
+    "@murmurv2/core": "^0.2.0",
     "@murmurv2/security": "^0.1.0"
   },
   "license": "MIT",
@@ -26,5 +26,5 @@
     "dist/src",
     "LICENSE"
   ],
-  "description": "Murmur V2 MCP server — 7 tools for agent-to-agent messaging over the Model Context Protocol."
+  "description": "Murmur V2 MCP server \u2014 7 tools for agent-to-agent messaging over the Model Context Protocol."
 }


### PR DESCRIPTION
## Release 2.3.0 (repo-level)
Cuts the next release for everything shipped since 2.2.0 (#66–#74 + cross-host A2A validation).

### Versions
- root `2.2.0 → 2.3.0`
- `@murmurv2/core`, `@murmurv2/federation`, `@murmurv2/broker-nats` → **0.2.0** (new public API: `stableEnvelopePayload`, `EnvelopeV1.authToken`, stream guards, `authorizeInbound`, `InboundAuthorizer`)
- **cascaded all workspace dep ranges** on those three to `^0.2.0` — required because `^0.1.0` would not accept `0.2.0`, so workspace resolution + CI `npm ci` stay consistent (verified: `npm install` re-links `@murmurv2/core@0.2.0 → ./packages/core`).

### Docs
- **CHANGELOG [2.3.0]** — discovery complete · streaming complete · auth/authz enforcement mechanism · conformance (all wire types) · versioned protocol spec · centralized `stableEnvelopePayload` · de-flake · **Validated: real cross-host A2A**. : daemon auth end-to-end + npm republish @ 0.2.0.
- **README** — What's New in v2.3 + Roadmap (streaming + discovery → delivered; auth = mechanism shipped, daemon wiring remaining; A2A cross-host note).

### Gated (NOT in this PR)
- **npm republish @ 0.2.0** is OTP-gated to Alex — it fixes the consumer caveat (published `core@0.1.0` predates the new exports). Repo is prepped; publish is the separate step.

### Verification
build PASS; full `npm test` 0 fail (unit 68, core 49, federation 30, a2a 6, broker-ws 4, federation-nats 10); `git diff --check` clean.

Review by diff + CI. @codex release-prep as scoped (bump only changed-API pkgs + range cascade). PR-D3 (daemon auth wiring) next.