### PR TITLE
fix(codex-channel): resolve package modules via MURMUR_ROOT so synced channel server starts

### DIFF
--- a/scripts/codex-murmur-channel-autostart.sh
+++ b/scripts/codex-murmur-channel-autostart.sh
@@ -17,7 +17,7 @@ THREAD_ID="${CODEX_THREAD_ID:-${CODEX_SESSION_ID:-}}"
 
 log() {
   mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
-  printf '[%s] %s\n' "$(date -Is)" "$*" >>"$LOG_FILE" 2>/dev/null || true
+  printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >>"$LOG_FILE" 2>/dev/null || true
 }
 
 warn() {

--- a/scripts/murmur-mcp-channel-server.mjs
+++ b/scripts/murmur-mcp-channel-server.mjs
@@ -4,12 +4,6 @@ import path from "node:path";
 import { createInterface } from "node:readline";
 import { homedir } from "node:os";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { NatsBroker } from "../packages/broker-nats/dist/src/index.js";
-import { SQLiteDedupeOutboxStore } from "../packages/core/dist/src/index.js";
-import {
-  decryptPayload,
-  verifyEnvelopeSignature,
-} from "../packages/security/dist/src/index.js";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
@@ -69,6 +63,13 @@ const configPath = path.join(dataDir, "agent-config.json");
 const config = JSON.parse(readFileSync(configPath, "utf8"));
 const dbPath = process.env.MURMUR_STORE_PATH ?? path.join(dataDir, "murmur.db");
 const murmurRoot = process.env.MURMUR_ROOT || repoRoot;
+// Static relative imports break when this file is synced to ~/.codex/mcp-channel-server,
+// so package modules resolve through MURMUR_ROOT like lease.mjs below.
+const packageModuleUrl = (name) =>
+  pathToFileURL(path.join(murmurRoot, "packages", name, "dist", "src", "index.js")).href;
+const { NatsBroker } = await import(packageModuleUrl("broker-nats"));
+const { SQLiteDedupeOutboxStore } = await import(packageModuleUrl("core"));
+const { decryptPayload, verifyEnvelopeSignature } = await import(packageModuleUrl("security"));
 const leaseDbPath = process.env.MURMUR_LEASE_DB || path.join(dataDir, "lease.db");
 const leaseModuleUrl =
   process.env.MURMUR_LEASE_MODULE_URL || pathToFileURL(path.join(murmurRoot, "scripts", "lease.mjs")).href;


### PR DESCRIPTION
## Problem

`scripts/codex-murmur-channel-autostart.sh` syncs `murmur-mcp-channel-server.mjs` out of the repo into `~/.codex/mcp-channel-server/index.mjs`. The server's **static** relative imports (`../packages/broker-nats/dist/...`, `core`, `security`) then resolve against `~/.codex/`, where no `packages/` tree exists. MCP `initialize` closes the connection and Codex refuses to start:

```
Fatal error: Failed to initialize session: required MCP servers failed to initialize:
murmur-channel: handshaking with MCP server failed: connection closed: initialize response
```

## Fix

- Resolve `broker-nats` / `core` / `security` through **dynamic `await import()`** rooted at `MURMUR_ROOT`, mirroring the existing `lease.mjs` pattern — so the file works from any location it's synced to.
- Use a POSIX `date -u +%Y-%m-%dT%H:%M:%SZ` timestamp in the autostart log (macOS `date` has no `-Is`).

Verified: full MCP handshake (`initialize` → `tools/list`) succeeds from the synced `~/.codex/mcp-channel-server/index.mjs`, and the `mac-alex ↔ ws-povalyaev` channel comes up clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)