### PR TITLE
fix(codex-wake): keep seeded thread usable — carry cwd, keep path, skip resume

### DIFF
--- a/scripts/codex-app-server-wake.mjs
+++ b/scripts/codex-app-server-wake.mjs
@@ -125,10 +125,12 @@ export const readFinalAnswerFromSessionLog = (sessionPath, turnId) => {
   return "";
 };
 
-export const buildThreadStartParams = (binding = null) => ({
-  model: binding?.model ?? null,
+export const buildThreadStartParams = (binding = null, peer = null) => ({
+  model: binding?.model ?? peer?.model ?? null,
   modelProvider: null,
-  cwd: null,
+  // A seeded thread must inherit the peer's working directory, otherwise Codex starts
+  // in `/` with no project instructions, wrong workspace roots and wrong permissions.
+  cwd: peer?.cwd ?? null,
   runtimeWorkspaceRoots: null,
   approvalPolicy: null,
   approvalsReviewer: null,
@@ -531,28 +533,34 @@ export const createCodexAppServerInjector = ({ Client = CodexAppServerClient, lo
       return client.request("turn/start", turnParams(threadId));
     };
 
+    // A thread seeded in this call has no rollout file until its first turn, so
+    // `thread/resume` can only fail on it — and that failure is what used to leave
+    // `threadPath` null and silently disable the session-log completion fallback.
+    const seedThread = async (reason) => {
+      const started = await client.request("thread/start", buildThreadStartParams(threadStartBinding, peer));
+      const seededId = started?.thread?.id;
+      if (!seededId) throw new Error(`codex-app-server-thread-start-missing:${payload.from}`);
+      threadPath = started?.thread?.path || threadPath;
+      peer.threadId = seededId;
+      log("info", `Codex app-server wake thread ${reason}`, { msgId: payload.msgId, threadId: seededId, socketPath, threadPath });
+      return seededId;
+    };
+
     let threadId = peer?.threadId;
+    let seededHere = false;
     if (!threadId) {
-      const started = await client.request("thread/start", buildThreadStartParams(threadStartBinding));
-      threadId = started?.thread?.id;
-      if (!threadId) throw new Error(`codex-app-server-thread-start-missing:${payload.from}`);
-      peer.threadId = threadId;
-      log("info", "Codex app-server wake thread seeded", { msgId: payload.msgId, threadId, socketPath });
+      threadId = await seedThread("seeded");
+      seededHere = true;
     }
 
     let result;
     try {
-      if (shouldResumeThread) await resumeThread(threadId);
+      if (shouldResumeThread && !seededHere) await resumeThread(threadId);
       result = await startTurn(threadId);
     } catch (err) {
       const e = err instanceof Error ? err : new Error(String(err));
       if (!e.message.startsWith("codex-app-server-error:thread not found:")) throw e;
-      const started = await client.request("thread/start", buildThreadStartParams(threadStartBinding));
-      threadId = started?.thread?.id;
-      if (!threadId) throw new Error(`codex-app-server-thread-start-missing:${payload.from}`);
-      peer.threadId = threadId;
-      log("info", "Codex app-server wake thread re-seeded", { msgId: payload.msgId, threadId, socketPath });
-      if (shouldResumeThread) await resumeThread(threadId);
+      threadId = await seedThread("re-seeded");
       result = await startTurn(threadId);
     }
     log("info", "Codex app-server wake completed", { msgId: payload.msgId, threadId, socketPath });

--- a/scripts/wake-monitor.mjs
+++ b/scripts/wake-monitor.mjs
@@ -21,6 +21,9 @@ export const normalizeWakeConfig = (config = {}) => {
       if (typeof value.dataDir === "string" && value.dataDir.trim()) normalized.dataDir = value.dataDir.trim();
       if (typeof value.storePath === "string" && value.storePath.trim()) normalized.storePath = value.storePath.trim();
       if (value.relayFinalToMurmur === true) normalized.relayFinalToMurmur = true;
+      // Without this the injector's `peer.resume === false` opt-out is unreachable
+      // from a real config: normalization used to drop the field entirely.
+      if (typeof value.resume === "boolean") normalized.resume = value.resume;
       if (Number.isFinite(Number(value.replyTimeoutMs))) normalized.replyTimeoutMs = Number(value.replyTimeoutMs);
       return [agentId, normalized];
     }),

--- a/tests/codex-app-server-wake.test.mjs
+++ b/tests/codex-app-server-wake.test.mjs
@@ -78,6 +78,66 @@ test("normalizeWakeConfig preserves Codex reply relay peer settings", () => {
   });
 });
 
+test("normalizeWakeConfig preserves the explicit resume opt-out", () => {
+  const config = normalizeWakeConfig({
+    wake: {
+      peers: {
+        "agent-jarvis": {
+          mode: "codex_app_server",
+          socketPath: "/tmp/codex.sock",
+          threadId: "thread-1",
+          resume: false,
+        },
+      },
+    },
+  });
+
+  assert.equal(config.peers["agent-jarvis"].resume, false);
+});
+
+test("buildThreadStartParams carries peer cwd and model into thread/start", () => {
+  const params = buildThreadStartParams(null, { cwd: "/work/project", model: "gpt-5.6-sol" });
+
+  assert.equal(params.cwd, "/work/project");
+  assert.equal(params.model, "gpt-5.6-sol");
+});
+
+test("Codex app-server injector keeps the seeded thread path and skips resume", async () => {
+  const calls = [];
+  class FakeClient {
+    async request(method, params) {
+      calls.push({ method, params });
+      if (method === "thread/start") {
+        return { thread: { id: "fresh-thread", path: "/tmp/rollout-fresh.jsonl" } };
+      }
+      return {};
+    }
+
+    async startTurnAndWaitForFinal(params, options) {
+      calls.push({ method: "turn/start:wait", params, options });
+      return { finalText: "", turnId: "turn-1" };
+    }
+  }
+
+  const peer = {
+    mode: "codex_app_server",
+    socketPath: "/tmp/codex.sock",
+    cwd: "/work/project",
+    relayFinalToMurmur: true,
+    murmurRoot: "/work/murmur",
+    dataDir: "/work/.data",
+    storePath: "/work/.data/murmur.db",
+  };
+  const injector = createCodexAppServerInjector({ Client: FakeClient });
+
+  await injector(payload, peer);
+
+  // A thread created right here has no rollout file yet: resuming it can only fail.
+  assert.deepEqual(calls.map((call) => call.method), ["thread/start", "turn/start:wait"]);
+  assert.equal(calls[0].params.cwd, "/work/project");
+  assert.equal(calls[1].options.sessionPath, "/tmp/rollout-fresh.jsonl");
+});
+
 test("buildTurnStartRequest builds Codex turn/start params", () => {
   const request = buildTurnStartRequest({
     id: 7,


### PR DESCRIPTION
Fixes the root cause behind #96. Found while running Murmur on a small personal mesh (two Claude Code agents + Codex) — thanks for the project.

## Problem

A thread seeded inside the wake call has no rollout file until its first turn, so `thread/resume` always fails on it with `no rollout found`. That failure leaves `threadPath` null, which silently disables the session-log completion fallback — the only path that actually completes a turn on Codex CLI 0.145. Codex answers, the answer sits in the session JSONL, and the daemon times out without relaying anything.

Observed on a live mesh: with an explicit `threadId` the reply relays in 10–15s via `source: "session-log"`; without it every message ends in `codex-app-server-turn-completion-timeout`.

## Changes

- `buildThreadStartParams` carries peer `cwd`/`model` into `thread/start`. Previously a seeded thread started with `cwd: null` — verified on a live session: `session_meta.cwd == "/"`, so no project instructions, wrong workspace roots and permissions. After the fix the same probe returns the configured project directory.
- The `thread/start` response `path` is kept as `threadPath`; it used to be discarded, and `threadPath` was only ever taken from `thread/resume`.
- A freshly seeded thread is no longer resumed. Seed and re-seed share one code path.
- `normalizeWakeConfig` preserves the `resume` flag — it dropped the field entirely, making the injector's `peer.resume === false` opt-out unreachable from real config.

## Tests

Three new tests, each red before the change:

- `normalizeWakeConfig preserves the explicit resume opt-out`
- `buildThreadStartParams carries peer cwd and model into thread/start`
- `Codex app-server injector keeps the seeded thread path and skips resume` — covers the untested gap: `relayFinalToMurmur` **with** no `threadId`.

`node --test tests/codex-app-server-wake.test.mjs` → 19/19 pass.

Full `npm test`: 88/89. The single failure (`collectPrometheusSnapshot`, `ERR_DLOPEN_FAILED` on an unbuilt `better-sqlite3` native module) reproduces identically on unmodified `main` — unrelated.

Also verified end-to-end after the change with `threadId` removed from the config: the reply relays normally and Codex now runs in the configured working directory.

## Not addressed here

Deliberately out of scope, all listed in #96: single-WebSocket transport for start/resume/turn, cursor advancing on failed wakes (silent message loss), per-conversation threads, relay idempotency, head-of-line blocking in `WakeMonitor.drain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)