### PR TITLE
Secure dashboard rendering and authenticated ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,32 @@ See `docs/wake-native.md`.
 
 ---
 
+## Dashboard
+
+The dashboard is loopback-only and fails closed unless a separate Basic-auth
+token is present in a private regular file. Create the token once:
+
+```bash
+install -d -m 0700 ~/.config/murmur
+umask 077
+openssl rand -hex 32 > ~/.config/murmur/dashboard-token
+chmod 0600 ~/.config/murmur/dashboard-token
+node dashboard/server.mjs
+```
+
+Open `http://127.0.0.1:4280/` and use username `murmur` with the generated token
+as the password. Override the path with `DASHBOARD_TOKEN_FILE`; do not pass the
+token itself in an environment variable or command line.
+
+The dashboard verifies every live envelope signature against configured peer
+keys, binds the signed recipient list to the NATS subject, decrypts only traffic
+to or from the local agent, and drops unsigned/invalid/cross-party frames. Its
+historical feed comes from the daemon's verified local store. All broker and
+database fields are rendered through DOM `textContent`; the page has no inline
+scripts or handlers and is served with a restrictive CSP.
+
+---
+
 ## Deployment
 
 ### Systemd (recommended)

--- a/dashboard/dashboard.css
+++ b/dashboard/dashboard.css
@@ -1,0 +1,75 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  background: #0a0e17; color: #c9d1d9;
+  font-family: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+  font-size: 13px; height: 100vh; display: flex; flex-direction: column;
+}
+header {
+  background: #161b22; border-bottom: 1px solid #30363d;
+  padding: 12px 20px; display: flex; align-items: center; gap: 20px;
+}
+header h1 { font-size: 16px; color: #58a6ff; font-weight: 600; }
+.status-badge { padding: 3px 10px; border-radius: 12px; font-size: 11px; font-weight: 600; }
+.status-connected { background: #0d1117; border: 1px solid #238636; color: #3fb950; }
+.status-disconnected { background: #0d1117; border: 1px solid #da3633; color: #f85149; }
+.stats { display: flex; gap: 15px; margin-left: auto; color: #8b949e; font-size: 12px; }
+.stats span { color: #58a6ff; }
+.container { display: flex; flex: 1; overflow: hidden; }
+.sidebar {
+  width: 240px; background: #0d1117; border-right: 1px solid #30363d;
+  padding: 15px; overflow-y: auto;
+}
+.sidebar h3 {
+  color: #8b949e; font-size: 11px; text-transform: uppercase;
+  margin-bottom: 10px; letter-spacing: 1px;
+}
+.agent-item {
+  padding: 8px 10px; margin-bottom: 4px; border-radius: 6px;
+  display: flex; align-items: center; gap: 8px; cursor: pointer;
+  background: #161b22; border: 1px solid #21262d;
+  color: inherit; font: inherit; text-align: left; width: 100%;
+}
+.agent-item.self { border-color: #238636; }
+.agent-item.active { background: #1f2937; border-color: #58a6ff; }
+.agent-item:hover { background: #1c2128; }
+.agent-dot { width: 8px; height: 8px; border-radius: 50%; }
+.agent-dot.online { background: #3fb950; box-shadow: 0 0 6px #3fb950; }
+.agent-dot.offline { background: #484f58; }
+.agent-name { flex: 1; font-size: 12px; }
+.agent-name.self { color: #3fb950; }
+.feed { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+.feed-header {
+  padding: 10px 20px; background: #161b22; border-bottom: 1px solid #30363d;
+  display: flex; align-items: center; gap: 10px;
+}
+.feed-header h2 { font-size: 13px; color: #8b949e; }
+.pulse { width: 8px; height: 8px; border-radius: 50%; background: #f0883e; animation: pulse 2s infinite; }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+.messages {
+  flex: 1; overflow-y: auto; padding: 10px 20px;
+  display: flex; flex-direction: column-reverse;
+}
+.msg {
+  padding: 10px 14px; margin-bottom: 6px; border-radius: 6px;
+  border-left: 3px solid #30363d; background: #0d1117;
+  animation: fadeIn 0.3s ease;
+}
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-5px); }
+  to { opacity: 1; }
+}
+.msg.inbound { border-left-color: #3fb950; }
+.msg.outbound { border-left-color: #58a6ff; }
+.msg.error { border-left-color: #f85149; }
+.msg.historical { opacity: 0.6; }
+.filtered-out { display: none; }
+.msg-header { display: flex; gap: 10px; align-items: center; margin-bottom: 4px; }
+.msg-route { font-size: 12px; font-weight: 600; }
+.msg-route .from { color: #f0883e; }
+.msg-route .to { color: #58a6ff; }
+.msg-route .arrow { color: #484f58; }
+.msg-time { color: #484f58; font-size: 11px; margin-left: auto; }
+.msg-crypto { font-size: 11px; }
+.msg-text { color: #c9d1d9; line-height: 1.5; word-break: break-word; white-space: pre-wrap; }
+.empty-state { text-align: center; padding: 60px 20px; color: #484f58; }
+.empty-state .icon { font-size: 48px; margin-bottom: 10px; }

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -1,258 +1,39 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Murmur V2 — Agent Mesh Observatory</title>
-<style>
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { 
-    background: #0a0e17; color: #c9d1d9; 
-    font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace; 
-    font-size: 13px; height: 100vh; display: flex; flex-direction: column;
-  }
-  header {
-    background: #161b22; border-bottom: 1px solid #30363d;
-    padding: 12px 20px; display: flex; align-items: center; gap: 20px;
-  }
-  header h1 { font-size: 16px; color: #58a6ff; font-weight: 600; }
-  .status-badge { 
-    padding: 3px 10px; border-radius: 12px; font-size: 11px; font-weight: 600;
-  }
-  .status-connected { background: #0d1117; border: 1px solid #238636; color: #3fb950; }
-  .status-disconnected { background: #0d1117; border: 1px solid #da3633; color: #f85149; }
-  .stats { display: flex; gap: 15px; margin-left: auto; color: #8b949e; font-size: 12px; }
-  .stats span { color: #58a6ff; }
-  
-  .container { display: flex; flex: 1; overflow: hidden; }
-  
-  .sidebar {
-    width: 240px; background: #0d1117; border-right: 1px solid #30363d;
-    padding: 15px; overflow-y: auto;
-  }
-  .sidebar h3 { color: #8b949e; font-size: 11px; text-transform: uppercase; margin-bottom: 10px; letter-spacing: 1px; }
-  .agent-item {
-    padding: 8px 10px; margin-bottom: 4px; border-radius: 6px;
-    display: flex; align-items: center; gap: 8px;
-    background: #161b22; border: 1px solid #21262d;
-  }
-  .agent-item.self { border-color: #238636; }
-  .agent-item.active { background: #1f2937; border-color: #58a6ff; }
-  .agent-item:hover { background: #1c2128; }
-  .agent-dot { width: 8px; height: 8px; border-radius: 50%; }
-  .agent-dot.online { background: #3fb950; box-shadow: 0 0 6px #3fb950; }
-  .agent-dot.offline { background: #484f58; }
-  .agent-name { flex: 1; font-size: 12px; }
-  .agent-name.self { color: #3fb950; }
-  
-  .feed {
-    flex: 1; display: flex; flex-direction: column; overflow: hidden;
-  }
-  .feed-header {
-    padding: 10px 20px; background: #161b22; border-bottom: 1px solid #30363d;
-    display: flex; align-items: center; gap: 10px;
-  }
-  .feed-header h2 { font-size: 13px; color: #8b949e; }
-  .pulse { width: 8px; height: 8px; border-radius: 50%; background: #f0883e; animation: pulse 2s infinite; }
-  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
-  
-  .messages {
-    flex: 1; overflow-y: auto; padding: 10px 20px;
-    display: flex; flex-direction: column-reverse;
-  }
-  .msg {
-    padding: 10px 14px; margin-bottom: 6px; border-radius: 6px;
-    border-left: 3px solid #30363d; background: #0d1117;
-    animation: fadeIn 0.3s ease;
-  }
-  @keyframes fadeIn { from { opacity: 0; transform: translateY(-5px); } to { opacity: 1; } }
-  .msg.inbound { border-left-color: #3fb950; }
-  .msg.outbound { border-left-color: #58a6ff; }
-  .msg.error { border-left-color: #f85149; }
-  .msg.historical { opacity: 0.6; }
-  .msg-header { display: flex; gap: 10px; align-items: center; margin-bottom: 4px; }
-  .msg-route { font-size: 12px; font-weight: 600; }
-  .msg-route .from { color: #f0883e; }
-  .msg-route .to { color: #58a6ff; }
-  .msg-route .arrow { color: #484f58; }
-  .msg-time { color: #484f58; font-size: 11px; margin-left: auto; }
-  .msg-crypto { font-size: 11px; }
-  .msg-text { color: #c9d1d9; line-height: 1.5; word-break: break-word; white-space: pre-wrap; }
-  .msg-text.truncated::after { content: '...'; color: #484f58; }
-  
-  .empty-state { 
-    text-align: center; padding: 60px 20px; color: #484f58; 
-  }
-  .empty-state .icon { font-size: 48px; margin-bottom: 10px; }
-</style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Murmur — Agent Mesh Observatory</title>
+  <link rel="stylesheet" href="/dashboard.css">
 </head>
 <body>
-<header>
-  <h1>🔮 Murmur V2 — Agent Mesh Observatory</h1>
-  <div id="connStatus" class="status-badge status-disconnected">● Disconnected</div>
-  <div class="stats">
-    Messages: <span id="statMsgs">0</span> &nbsp;|&nbsp;
-    Agents: <span id="statAgents">0</span> &nbsp;|&nbsp;
-    Uptime: <span id="statUptime">0s</span>
-  </div>
-</header>
-<div class="container">
-  <div class="sidebar">
-    <h3>🤖 Agents in Mesh</h3>
-    <div id="agentList"></div>
-  </div>
-  <div class="feed">
-    <div class="feed-header">
-      <div class="pulse"></div>
-      <h2>Live Agent Event Stream</h2>
+  <header>
+    <h1>🔮 Murmur — Agent Mesh Observatory</h1>
+    <div id="connStatus" class="status-badge status-disconnected">● Disconnected</div>
+    <div class="stats">
+      Messages: <span id="statMsgs">0</span> &nbsp;|&nbsp;
+      Agents: <span id="statAgents">0</span> &nbsp;|&nbsp;
+      Uptime: <span id="statUptime">0s</span>
     </div>
-    <div class="messages" id="messages">
-      <div class="empty-state">
-        <div class="icon">📡</div>
-        <p>Waiting for agent activity...</p>
+  </header>
+  <div class="container">
+    <aside class="sidebar">
+      <h3>🤖 Agents in Mesh</h3>
+      <div id="agentList"></div>
+    </aside>
+    <main class="feed">
+      <div class="feed-header">
+        <div class="pulse"></div>
+        <h2>Authenticated Agent Event Stream</h2>
       </div>
-    </div>
-  </div>
-</div>
-
-<script>
-const msgContainer = document.getElementById('messages');
-const agentList = document.getElementById('agentList');
-const connStatus = document.getElementById('connStatus');
-const statMsgs = document.getElementById('statMsgs');
-const statAgents = document.getElementById('statAgents');
-const statUptime = document.getElementById('statUptime');
-
-let ws;
-let msgCount = 0;
-let agents = [];
-let selfAgent = '';
-let seenAgents = new Set();
-let reconnectDelay = 1000;
-let filterAgent = null;
-
-function connect() {
-  const proto = location.protocol === "https:" ? "wss:" : "ws:";
-  const wsUrl = `${proto}//${location.host}${location.pathname.replace(/\/[^/]*$/, '')}/ws`;
-  ws = new WebSocket(wsUrl);
-  
-  ws.onopen = () => {
-    connStatus.className = 'status-badge status-connected';
-    connStatus.textContent = '● Connected';
-    reconnectDelay = 1000;
-  };
-  
-  ws.onclose = () => {
-    connStatus.className = 'status-badge status-disconnected';
-    connStatus.textContent = '● Disconnected';
-    setTimeout(connect, reconnectDelay);
-    reconnectDelay = Math.min(reconnectDelay * 2, 30000);
-  };
-  
-  ws.onmessage = (e) => {
-    const data = JSON.parse(e.data);
-    
-    if (data.type === 'init') {
-      selfAgent = data.self;
-      agents = data.agents;
-      renderAgents();
-      return;
-    }
-    
-    if (data.type === 'stats') {
-      statMsgs.textContent = data.totalMessages;
-      statAgents.textContent = data.agents?.length || 0;
-      const secs = Math.floor(data.uptimeMs / 1000);
-      const mins = Math.floor(secs / 60);
-      const hrs = Math.floor(mins / 60);
-      statUptime.textContent = hrs > 0 ? `${hrs}h ${mins%60}m` : `${mins}m ${secs%60}s`;
-      return;
-    }
-    
-    if (data.type === 'message' || data.type === 'error') {
-      addMessage(data);
-    }
-  };
-}
-
-function renderAgents() {
-  agentList.innerHTML = agents.map(a => {
-    const isSelf = a === selfAgent;
-    const isOnline = seenAgents.has(a) || isSelf;
-    const active = filterAgent === a ? 'active' : '';
-    return `<div class="agent-item ${isSelf ? 'self' : ''} ${active}" onclick="toggleFilter('${a}')" style="cursor:pointer">
-      <div class="agent-dot ${isOnline ? 'online' : 'offline'}"></div>
-      <div class="agent-name ${isSelf ? 'self' : ''}">${a}${isSelf ? ' (me)' : ''}</div>
-    </div>`;
-  }).join('');
-}
-
-function toggleFilter(agent) {
-  filterAgent = filterAgent === agent ? null : agent;
-  renderAgents();
-  // Show/hide messages based on filter
-  document.querySelectorAll('#messages .msg').forEach(el => {
-    if (!filterAgent) {
-      el.style.display = '';
-    } else {
-      const route = el.querySelector('.msg-route')?.textContent || '';
-      el.style.display = route.includes(filterAgent) ? '' : 'none';
-    }
-  });
-}
-
-function addMessage(data) {
-  // Remove empty state
-  const empty = msgContainer.querySelector('.empty-state');
-  if (empty) empty.remove();
-  
-  msgCount++;
-  if (data.from) seenAgents.add(data.from);
-  renderAgents();
-  
-  const dir = data.direction || (data.to === selfAgent ? 'inbound' : 'outbound');
-  const cls = data.type === 'error' ? 'error' : dir;
-  const hist = data.historical ? 'historical' : '';
-  
-  const crypto = data.encrypted 
-    ? (data.decrypted ? '🔐✅' : '🔐❌') 
-    : '📨';
-  
-  const time = data.ts ? new Date(data.ts).toLocaleTimeString() : '';
-  const text = (data.text || '').slice(0, 500);
-  
-  const el = document.createElement('div');
-  el.className = `msg ${cls} ${hist}`;
-  el.innerHTML = `
-    <div class="msg-header">
-      <div class="msg-route">
-        <span class="from">${data.from || '?'}</span>
-        <span class="arrow"> → </span>
-        <span class="to">${data.to || '?'}</span>
+      <div class="messages" id="messages">
+        <div class="empty-state">
+          <div class="icon">📡</div>
+          <p>Waiting for authenticated agent activity...</p>
+        </div>
       </div>
-      <span class="msg-crypto">${crypto}</span>
-      <span class="msg-time">${time}</span>
-    </div>
-    <div class="msg-text">${escHtml(text)}</div>
-  `;
-  
-  // Apply filter
-  if (filterAgent && !`${data.from} ${data.to}`.includes(filterAgent)) {
-    el.style.display = 'none';
-  }
-  msgContainer.prepend(el);
-  
-  // Keep max 200 messages
-  while (msgContainer.children.length > 200) {
-    msgContainer.lastChild.remove();
-  }
-}
-
-function escHtml(s) {
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-}
-
-connect();
-</script>
+    </main>
+  </div>
+  <script type="module" src="/dashboard.js"></script>
 </body>
 </html>

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1,0 +1,107 @@
+import { createAgentItem, createMessageElement, validAgentId } from "/render.mjs";
+
+const msgContainer = document.getElementById("messages");
+const agentList = document.getElementById("agentList");
+const connStatus = document.getElementById("connStatus");
+const statMsgs = document.getElementById("statMsgs");
+const statAgents = document.getElementById("statAgents");
+const statUptime = document.getElementById("statUptime");
+
+let ws;
+let agents = [];
+let selfAgent = "";
+let seenAgents = new Set();
+let reconnectDelay = 1000;
+let filterAgent = null;
+
+const safeCount = (value) => Number.isSafeInteger(value) && value >= 0 ? value : 0;
+
+function toggleFilter(agent) {
+  filterAgent = filterAgent === agent ? null : agent;
+  renderAgents();
+  document.querySelectorAll("#messages .msg").forEach((node) => {
+    node.classList.toggle(
+      "filtered-out",
+      Boolean(filterAgent && node.dataset.from !== filterAgent && node.dataset.to !== filterAgent),
+    );
+  });
+}
+
+function renderAgents() {
+  const fragment = document.createDocumentFragment();
+  for (const agent of agents) {
+    fragment.append(createAgentItem(document, {
+      agent,
+      isSelf: agent === selfAgent,
+      isOnline: seenAgents.has(agent) || agent === selfAgent,
+      isActive: filterAgent === agent,
+      onToggle: toggleFilter,
+    }));
+  }
+  agentList.replaceChildren(fragment);
+}
+
+function addMessage(data) {
+  if (data?.authenticated !== true) return;
+  const empty = msgContainer.querySelector(".empty-state");
+  if (empty) empty.remove();
+
+  if (validAgentId(data.from)) seenAgents.add(data.from);
+  renderAgents();
+
+  const node = createMessageElement(document, data);
+  if (filterAgent && node.dataset.from !== filterAgent && node.dataset.to !== filterAgent) {
+    node.classList.add("filtered-out");
+  }
+  msgContainer.prepend(node);
+
+  while (msgContainer.children.length > 200) msgContainer.lastChild.remove();
+}
+
+function onFrame(event) {
+  let data;
+  try {
+    data = JSON.parse(event.data);
+  } catch {
+    return;
+  }
+
+  if (data?.type === "init") {
+    selfAgent = validAgentId(data.self) ? data.self : "";
+    agents = Array.isArray(data.agents) ? [...new Set(data.agents.filter(validAgentId))] : [];
+    renderAgents();
+    return;
+  }
+
+  if (data?.type === "stats") {
+    statMsgs.textContent = String(safeCount(data.totalMessages));
+    statAgents.textContent = String(Array.isArray(data.agents) ? data.agents.filter(validAgentId).length : 0);
+    const secs = Math.floor(safeCount(data.uptimeMs) / 1000);
+    const mins = Math.floor(secs / 60);
+    const hrs = Math.floor(mins / 60);
+    statUptime.textContent = hrs > 0 ? `${hrs}h ${mins % 60}m` : `${mins}m ${secs % 60}s`;
+    return;
+  }
+
+  if (data?.type === "message") addMessage(data);
+}
+
+function connect() {
+  const proto = location.protocol === "https:" ? "wss:" : "ws:";
+  const base = location.pathname.replace(/\/[^/]*$/, "");
+  ws = new WebSocket(`${proto}//${location.host}${base}/ws`);
+  ws.addEventListener("open", () => {
+    connStatus.className = "status-badge status-connected";
+    connStatus.textContent = "● Connected";
+    reconnectDelay = 1000;
+  });
+  ws.addEventListener("close", () => {
+    connStatus.className = "status-badge status-disconnected";
+    connStatus.textContent = "● Disconnected";
+    setTimeout(connect, reconnectDelay);
+    reconnectDelay = Math.min(reconnectDelay * 2, 30000);
+  });
+  ws.addEventListener("message", onFrame);
+}
+
+connect();

--- a/dashboard/http-security.mjs
+++ b/dashboard/http-security.mjs
@@ -1,0 +1,56 @@
+import { timingSafeEqual } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+
+export const SECURITY_HEADERS = Object.freeze({
+  "Content-Security-Policy": "default-src 'none'; script-src 'self'; style-src 'self'; connect-src 'self'; img-src 'self'; font-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; object-src 'none'",
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Cross-Origin-Resource-Policy": "same-origin",
+  "Referrer-Policy": "no-referrer",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Cache-Control": "no-store",
+});
+
+export function loadDashboardToken(tokenFile) {
+  const stat = statSync(tokenFile);
+  if (!stat.isFile()) throw new Error("dashboard token path is not a regular file");
+  if ((stat.mode & 0o077) !== 0) throw new Error("dashboard token file is accessible by group or others");
+  const token = readFileSync(tokenFile, "utf8").trim();
+  if (!/^[A-Za-z0-9_-]{32,}$/.test(token)) {
+    throw new Error("dashboard token must be at least 32 URL-safe characters");
+  }
+  return token;
+}
+
+const secureEqual = (left, right) => {
+  if (typeof left !== "string" || typeof right !== "string") return false;
+  const a = Buffer.from(left);
+  const b = Buffer.from(right);
+  return a.length === b.length && timingSafeEqual(a, b);
+};
+
+export function isAuthorizedHeader(header, token) {
+  if (typeof header !== "string" || !header.startsWith("Basic ")) return false;
+  try {
+    const decoded = Buffer.from(header.slice(6), "base64").toString("utf8");
+    const separator = decoded.indexOf(":");
+    if (separator < 0) return false;
+    const username = decoded.slice(0, separator);
+    const password = decoded.slice(separator + 1);
+    return secureEqual(username, "murmur") && secureEqual(password, token);
+  } catch {
+    return false;
+  }
+}
+
+export function isSameOriginWebSocket(request) {
+  const origin = request.headers.origin;
+  if (origin === undefined) return true;
+  try {
+    const parsed = new URL(origin);
+    return (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      parsed.host === request.headers.host;
+  } catch {
+    return false;
+  }
+}

--- a/dashboard/message-security.mjs
+++ b/dashboard/message-security.mjs
@@ -1,0 +1,68 @@
+import { isEnvelopeV1, stableEnvelopePayload } from "../packages/core/dist/src/index.js";
+import { decryptPayload, verifyEnvelopeSignature } from "../packages/security/dist/src/index.js";
+import { validAgentId } from "./render.mjs";
+
+const rejected = (reason) => ({ accepted: false, reason });
+
+export async function authenticateEnvelope(raw, subject, config) {
+  let envelope;
+  try {
+    envelope = JSON.parse(raw);
+  } catch {
+    return rejected("invalid-json");
+  }
+
+  if (!isEnvelopeV1(envelope)) return rejected("unsigned-or-invalid-envelope");
+  if (!validAgentId(envelope.senderAgentId)) return rejected("invalid-sender-id");
+  if (typeof subject !== "string" || !subject.startsWith("msg.")) return rejected("invalid-subject");
+
+  const subjectRecipient = subject.slice(4);
+  if (!validAgentId(subjectRecipient) || !envelope.recipients.includes(subjectRecipient)) {
+    return rejected("recipient-subject-mismatch");
+  }
+
+  const outbound = envelope.senderAgentId === config.agentId;
+  if (!outbound && subjectRecipient !== config.agentId) return rejected("not-local-traffic");
+
+  const peerId = outbound ? subjectRecipient : envelope.senderAgentId;
+  const peer = config.peers?.[peerId];
+  if (!peer?.signing?.publicKey || !peer?.encryption?.publicKey) return rejected("unknown-peer");
+
+  const signingPublicKey = outbound ? config.keys?.signing?.publicKey : peer.signing.publicKey;
+  if (typeof signingPublicKey !== "string") return rejected("missing-signing-key");
+
+  try {
+    const valid = await verifyEnvelopeSignature(
+      stableEnvelopePayload(envelope),
+      envelope.signature,
+      signingPublicKey,
+    );
+    if (!valid) return rejected("signature-invalid");
+
+    const plaintext = await decryptPayload(
+      {
+        ciphertext: envelope.payloadCiphertext,
+        nonce: envelope.payloadNonce,
+        senderPublicKey: peer.encryption.publicKey,
+      },
+      config.keys.encryption.privateKey,
+    );
+
+    return {
+      accepted: true,
+      event: {
+        type: "message",
+        from: envelope.senderAgentId,
+        to: subjectRecipient,
+        text: plaintext.slice(0, 1000),
+        ts: envelope.createdAt,
+        msgId: envelope.msgId,
+        encrypted: true,
+        authenticated: true,
+        direction: outbound ? "outbound" : "inbound",
+      },
+    };
+  } catch {
+    return rejected("verification-or-decryption-failed");
+  }
+}

--- a/dashboard/render.mjs
+++ b/dashboard/render.mjs
@@ -1,0 +1,59 @@
+const AGENT_ID = /^[A-Za-z0-9][A-Za-z0-9._:@/-]{0,127}$/;
+
+export const validAgentId = (value) => typeof value === "string" && AGENT_ID.test(value);
+
+const text = (value, fallback = "?", max = 500) =>
+  typeof value === "string" ? value.slice(0, max) : fallback;
+
+const element = (document, tag, className, value) => {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (value !== undefined) node.textContent = value;
+  return node;
+};
+
+export function createAgentItem(document, { agent, isSelf, isOnline, isActive, onToggle }) {
+  if (!validAgentId(agent)) throw new TypeError("invalid agent id");
+
+  const item = element(document, "button", "agent-item");
+  item.type = "button";
+  if (isSelf) item.classList.add("self");
+  if (isActive) item.classList.add("active");
+  item.dataset.agent = agent;
+
+  item.append(element(document, "span", `agent-dot ${isOnline ? "online" : "offline"}`));
+  item.append(element(document, "span", `agent-name${isSelf ? " self" : ""}`, `${agent}${isSelf ? " (me)" : ""}`));
+  item.addEventListener("click", () => onToggle(agent));
+  return item;
+}
+
+export function createMessageElement(document, data) {
+  const from = validAgentId(data?.from) ? data.from : "unknown";
+  const to = validAgentId(data?.to) ? data.to : "unknown";
+  const direction = data?.direction === "inbound" ? "inbound" : "outbound";
+  const kind = data?.type === "error" ? "error" : direction;
+  const root = element(document, "article", `msg ${kind}${data?.historical === true ? " historical" : ""}`);
+  root.dataset.from = from;
+  root.dataset.to = to;
+
+  const header = element(document, "div", "msg-header");
+  const route = element(document, "div", "msg-route");
+  route.append(element(document, "span", "from", from));
+  route.append(element(document, "span", "arrow", " → "));
+  route.append(element(document, "span", "to", to));
+  header.append(route);
+
+  const authenticated = data?.authenticated === true;
+  const crypto = data?.encrypted === true ? (authenticated ? "🔐✅" : "🔐❌") : (authenticated ? "✅" : "⚠️");
+  header.append(element(document, "span", "msg-crypto", crypto));
+
+  let displayTime = "";
+  if (typeof data?.ts === "string") {
+    const parsed = new Date(data.ts);
+    if (!Number.isNaN(parsed.valueOf())) displayTime = parsed.toLocaleTimeString();
+  }
+  header.append(element(document, "span", "msg-time", displayTime));
+  root.append(header);
+  root.append(element(document, "div", "msg-text", text(data?.text, "", 500)));
+  return root;
+}

--- a/dashboard/server.mjs
+++ b/dashboard/server.mjs
@@ -1,240 +1,185 @@
 #!/usr/bin/env node
-/**
- * Murmur V2 Observability Dashboard — Backend
- * 
- * Subscribes to NATS wildcard msg.> and ack.>
- * Decrypts messages when possible
- * Streams events to browser via WebSocket
- * Serves static dashboard.html
- * 
- * Usage: node dashboard/server.mjs
- * Env: NATS_URL, NATS_TOKEN, DATA_DIR, DASHBOARD_PORT
- */
+/** Authenticated, signature-verifying Murmur observability dashboard. */
 
 import { createServer } from "node:http";
-import { readFile, readdir } from "node:fs/promises";
-import { WebSocketServer } from "ws";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { WebSocketServer } from "ws";
 import { connect, StringCodec } from "nats";
-import { x25519 } from "@noble/curves/ed25519";
-import { xchacha20poly1305 } from "@noble/ciphers/chacha";
-import { createHash } from "node:crypto";
 import Database from "better-sqlite3";
+import { SECURITY_HEADERS, isAuthorizedHeader, isSameOriginWebSocket, loadDashboardToken } from "./http-security.mjs";
+import { authenticateEnvelope } from "./message-security.mjs";
+import { validAgentId } from "./render.mjs";
 
 const PORT = Number(process.env.DASHBOARD_PORT) || 4280;
 const NATS_URL = process.env.NATS_URL || "nats://localhost:4222";
 const NATS_TOKEN = process.env.NATS_TOKEN;
-const DATA_DIR = process.env.DATA_DIR || path.join(path.dirname(new URL(import.meta.url).pathname), "..", ".data");
-const DASHBOARD_DIR = path.dirname(new URL(import.meta.url).pathname);
+const DASHBOARD_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = process.env.DATA_DIR || path.join(DASHBOARD_DIR, "..", ".data");
+const TOKEN_FILE = process.env.DASHBOARD_TOKEN_FILE || path.join(homedir(), ".config", "murmur", "dashboard-token");
 
-// Load agent config
 let config;
+let dashboardToken;
 try {
   config = JSON.parse(await readFile(path.join(DATA_DIR, "agent-config.json"), "utf8"));
-} catch (e) {
-  console.error("[dashboard] Cannot load agent-config.json:", e.message);
+  dashboardToken = loadDashboardToken(TOKEN_FILE);
+} catch (error) {
+  console.error(`[dashboard] Refusing to start: ${error.message}`);
   process.exit(1);
 }
 
-// Crypto helpers
-const fromB64 = (s) => new Uint8Array(Buffer.from(s, "base64"));
-const deriveSymmetricKey = (shared) => new Uint8Array(createHash("sha256").update(shared).digest());
-
-function tryDecrypt(envelope) {
-  try {
-    const senderId = envelope.senderAgentId;
-    const peer = config.peers[senderId];
-    if (!peer) return { decrypted: false, text: `[encrypted from ${senderId}]` };
-
-    const senderPubKey = fromB64(peer.encryption.publicKey);
-    const myPrivKey = fromB64(config.keys.encryption.privateKey);
-    const shared = x25519.getSharedSecret(myPrivKey, senderPubKey);
-    const key = deriveSymmetricKey(shared);
-    const nonce = fromB64(envelope.payloadNonce);
-    const ciphertext = fromB64(envelope.payloadCiphertext);
-    const cipher = xchacha20poly1305(key, nonce);
-    const plaintext = new TextDecoder().decode(cipher.decrypt(ciphertext));
-    return { decrypted: true, text: plaintext };
-  } catch (e) {
-    return { decrypted: false, text: `[decrypt failed: ${e.message}]` };
-  }
+const agents = [config.agentId, ...Object.keys(config.peers || {})];
+if (!agents.every(validAgentId)) {
+  console.error("[dashboard] Refusing to start: invalid agent identifier in configuration");
+  process.exit(1);
 }
 
-// Load message history from SQLite
+const staticFiles = new Map([
+  ["/", ["dashboard.html", "text/html; charset=utf-8"]],
+  ["/index.html", ["dashboard.html", "text/html; charset=utf-8"]],
+  ["/dashboard.css", ["dashboard.css", "text/css; charset=utf-8"]],
+  ["/dashboard.js", ["dashboard.js", "text/javascript; charset=utf-8"]],
+  ["/render.mjs", ["render.mjs", "text/javascript; charset=utf-8"]],
+]);
+
+const write = (res, status, contentType, body, extra = {}) => {
+  res.writeHead(status, { ...SECURITY_HEADERS, "Content-Type": contentType, ...extra });
+  res.end(body);
+};
+
+const unauthorized = (res) => write(
+  res,
+  401,
+  "application/json; charset=utf-8",
+  JSON.stringify({ error: "authentication required" }),
+  { "WWW-Authenticate": 'Basic realm="Murmur dashboard", charset="UTF-8"' },
+);
+
+const authorized = (req) => isAuthorizedHeader(req.headers.authorization, dashboardToken);
+
 function loadHistory(limit = 50) {
   try {
-    const dbPath = path.join(DATA_DIR, "murmur.db");
-    const db = new Database(dbPath, { readonly: true });
+    const db = new Database(path.join(DATA_DIR, "murmur.db"), { readonly: true });
     const rows = db.prepare(`
-      SELECT conversation_id, msg_id, direction, sender, text, created_at, transport 
-      FROM local_messages 
-      ORDER BY rowid DESC 
+      SELECT conversation_id, msg_id, direction, sender, text, created_at, transport
+      FROM local_messages
+      ORDER BY rowid DESC
       LIMIT ?
     `).all(limit);
     db.close();
     return rows.reverse();
-  } catch (e) {
-    console.warn("[dashboard] Cannot load history:", e.message);
+  } catch (error) {
+    console.warn("[dashboard] Cannot load history:", error.message);
     return [];
   }
 }
 
-// HTTP server — serves dashboard.html
+const historyEvent = (row) => {
+  const from = validAgentId(row.sender) ? row.sender : "unknown";
+  const inferredTo = row.direction === "inbound" ? config.agentId : row.conversation_id?.split(":")?.[1];
+  const to = validAgentId(inferredTo) ? inferredTo : "unknown";
+  return {
+    type: "message",
+    from,
+    to,
+    text: typeof row.text === "string" ? row.text.slice(0, 500) : "",
+    ts: typeof row.created_at === "string" ? row.created_at : "",
+    msgId: typeof row.msg_id === "string" ? row.msg_id : "",
+    encrypted: false,
+    authenticated: true,
+    direction: row.direction === "inbound" ? "inbound" : "outbound",
+    historical: true,
+    provenance: "verified-local-store",
+  };
+};
+
 const httpServer = createServer(async (req, res) => {
-  if (req.url === "/3d" || req.url === "/3d/") {
+  if (!authorized(req)) return unauthorized(res);
+
+  const pathname = new URL(req.url || "/", "http://localhost").pathname;
+  if (staticFiles.has(pathname)) {
+    const [filename, contentType] = staticFiles.get(pathname);
     try {
-      const html = await readFile(path.join(DASHBOARD_DIR, "3d.html"), "utf8");
-      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-      res.end(html);
+      return write(res, 200, contentType, await readFile(path.join(DASHBOARD_DIR, filename)));
     } catch {
-      res.writeHead(404);
-      res.end("3d.html not found");
+      return write(res, 404, "text/plain; charset=utf-8", "Not found");
     }
-  } else if (req.url === "/" || req.url === "/index.html") {
-    try {
-      const html = await readFile(path.join(DASHBOARD_DIR, "dashboard.html"), "utf8");
-      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-      res.end(html);
-    } catch {
-      res.writeHead(404);
-      res.end("dashboard.html not found");
-    }
-  } else if (req.url === "/api/agents") {
-    const agents = [config.agentId, ...Object.keys(config.peers)];
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ agents, self: config.agentId }));
-  } else if (req.url === "/api/history") {
-    const history = loadHistory(100);
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(history));
-  } else {
-    res.writeHead(404);
-    res.end("Not found");
   }
+
+  if (pathname === "/api/agents") {
+    return write(res, 200, "application/json; charset=utf-8", JSON.stringify({ agents, self: config.agentId }));
+  }
+
+  if (pathname === "/api/history") {
+    return write(res, 200, "application/json; charset=utf-8", JSON.stringify(loadHistory(100).map(historyEvent)));
+  }
+
+  return write(res, 404, "text/plain; charset=utf-8", "Not found");
 });
 
-// WebSocket server
-const wss = new WebSocketServer({ server: httpServer });
+const wss = new WebSocketServer({ noServer: true });
 const clients = new Set();
+
+httpServer.on("upgrade", (req, socket, head) => {
+  const pathname = new URL(req.url || "/", "http://localhost").pathname;
+  if (pathname !== "/ws" || !authorized(req) || !isSameOriginWebSocket(req)) {
+    socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+  wss.handleUpgrade(req, socket, head, (ws) => wss.emit("connection", ws, req));
+});
 
 wss.on("connection", (ws) => {
   clients.add(ws);
-  console.log(`[dashboard] Client connected (${clients.size} total)`);
-
-  // Send agent list
-  ws.send(JSON.stringify({
-    type: "init",
-    self: config.agentId,
-    agents: [config.agentId, ...Object.keys(config.peers)],
-    ts: new Date().toISOString(),
-  }));
-
-  // Send history
-  const history = loadHistory(50);
-  for (const row of history) {
-    ws.send(JSON.stringify({
-      type: "message",
-      from: row.sender,
-      to: row.direction === "inbound" ? config.agentId : row.conversation_id?.split(":")?.[1] || "unknown",
-      text: row.text?.slice(0, 500),
-      ts: row.created_at,
-      msgId: row.msg_id,
-      encrypted: false, // already decrypted in store
-      direction: row.direction,
-      historical: true,
-    }));
-  }
-
-  ws.on("close", () => {
-    clients.delete(ws);
-    console.log(`[dashboard] Client disconnected (${clients.size} total)`);
-  });
+  ws.send(JSON.stringify({ type: "init", self: config.agentId, agents, ts: new Date().toISOString() }));
+  for (const row of loadHistory(50)) ws.send(JSON.stringify(historyEvent(row)));
+  ws.on("close", () => clients.delete(ws));
 });
 
 function broadcast(data) {
   const json = JSON.stringify(data);
-  for (const ws of clients) {
-    if (ws.readyState === 1) ws.send(json);
-  }
+  for (const ws of clients) if (ws.readyState === 1) ws.send(json);
 }
 
-// NATS subscription — listen to all agent messages
 const sc = StringCodec();
-let nc;
-let msgCount = 0;
+let authenticatedCount = 0;
+let rejectedCount = 0;
 const startTime = Date.now();
 
 try {
-  nc = await connect({ servers: NATS_URL, token: NATS_TOKEN });
+  const nc = await connect({ servers: NATS_URL, token: NATS_TOKEN });
   console.log(`[dashboard] NATS connected: ${NATS_URL}`);
-
-  // Subscribe to all msg.* subjects
   const sub = nc.subscribe("msg.>");
-  console.log(`[dashboard] Subscribed to msg.>`);
 
   (async () => {
-    for await (const m of sub) {
-      msgCount++;
-      try {
-        const raw = sc.decode(m.data);
-        const envelope = JSON.parse(raw);
-
-        if (envelope.payloadCiphertext) {
-          // Encrypted envelope
-          const { decrypted, text } = tryDecrypt(envelope);
-          broadcast({
-            type: "message",
-            from: envelope.senderAgentId || "unknown",
-            to: (envelope.recipients || [])[0] || m.subject.replace("msg.", ""),
-            text: text.slice(0, 1000),
-            ts: envelope.createdAt || new Date().toISOString(),
-            msgId: envelope.msgId,
-            encrypted: true,
-            decrypted,
-            direction: m.subject === `msg.${config.agentId}` ? "inbound" : "outbound",
-          });
-        } else if (envelope.payload) {
-          // Plain message
-          broadcast({
-            type: "message",
-            from: envelope.from || "unknown",
-            to: envelope.to || m.subject.replace("msg.", ""),
-            text: (envelope.payload || "").slice(0, 1000),
-            ts: envelope.ts || new Date().toISOString(),
-            msgId: envelope.msgId,
-            encrypted: false,
-            decrypted: true,
-            direction: m.subject === `msg.${config.agentId}` ? "inbound" : "outbound",
-          });
-        }
-      } catch (e) {
-        broadcast({
-          type: "error",
-          text: `Parse error: ${e.message}`,
-          ts: new Date().toISOString(),
-        });
+    for await (const message of sub) {
+      const result = await authenticateEnvelope(sc.decode(message.data), message.subject, config);
+      if (result.accepted) {
+        authenticatedCount += 1;
+        broadcast(result.event);
+      } else {
+        rejectedCount += 1;
+        console.warn(`[dashboard] Rejected broker frame: ${result.reason}`);
       }
     }
   })();
 
-  // Periodic stats
-  setInterval(() => {
-    broadcast({
-      type: "stats",
-      totalMessages: msgCount,
-      activeClients: clients.size,
-      uptimeMs: Date.now() - startTime,
-      agents: [config.agentId, ...Object.keys(config.peers)],
-      ts: new Date().toISOString(),
-    });
-  }, 5000);
-
-} catch (e) {
-  console.error(`[dashboard] NATS failed: ${e.message}`);
+  setInterval(() => broadcast({
+    type: "stats",
+    totalMessages: authenticatedCount,
+    rejectedMessages: rejectedCount,
+    activeClients: clients.size,
+    uptimeMs: Date.now() - startTime,
+    agents,
+    ts: new Date().toISOString(),
+  }), 5000);
+} catch (error) {
+  console.error(`[dashboard] NATS failed: ${error.message}`);
 }
 
 httpServer.listen(PORT, "127.0.0.1", () => {
-  console.log(`[dashboard] 🚀 http://localhost:${PORT}`);
-  console.log(`[dashboard] WebSocket: ws://localhost:${PORT}`);
-  console.log(`[dashboard] Agents: ${config.agentId}, ${Object.keys(config.peers).join(", ")}`);
+  console.log(`[dashboard] Authenticated dashboard listening on http://127.0.0.1:${PORT}`);
 });

--- a/tests/dashboard-security.test.mjs
+++ b/tests/dashboard-security.test.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { stableEnvelopePayload } from "../packages/core/dist/src/index.js";
+import {
+  createKeyPair,
+  createSigningKeyPair,
+  encryptPayload,
+  signEnvelope,
+} from "../packages/security/dist/src/index.js";
+import { SECURITY_HEADERS, isAuthorizedHeader, loadDashboardToken } from "../dashboard/http-security.mjs";
+import { authenticateEnvelope } from "../dashboard/message-security.mjs";
+import { createAgentItem, createMessageElement } from "../dashboard/render.mjs";
+
+const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+class FakeClassList {
+  constructor(node) { this.node = node; }
+  add(...names) {
+    const values = new Set(this.node.className.split(/\s+/).filter(Boolean));
+    for (const name of names) values.add(name);
+    this.node.className = [...values].join(" ");
+  }
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = tagName;
+    this.className = "";
+    this.textContent = "";
+    this.children = [];
+    this.dataset = {};
+    this.listeners = new Map();
+    this.classList = new FakeClassList(this);
+  }
+  append(...children) { this.children.push(...children); }
+  addEventListener(name, callback) { this.listeners.set(name, callback); }
+}
+
+const fakeDocument = { createElement: (tag) => new FakeElement(tag) };
+const findClass = (node, name) => {
+  if (node.className.split(/\s+/).includes(name)) return node;
+  for (const child of node.children) {
+    const found = findClass(child, name);
+    if (found) return found;
+  }
+  return undefined;
+};
+
+test("dashboard sources have no HTML parser or inline script/event-handler sinks", async () => {
+  const html = await readFile(path.join(repoRoot, "dashboard", "dashboard.html"), "utf8");
+  const js = await readFile(path.join(repoRoot, "dashboard", "dashboard.js"), "utf8");
+  const render = await readFile(path.join(repoRoot, "dashboard", "render.mjs"), "utf8");
+  const combined = `${html}\n${js}\n${render}`;
+
+  assert.doesNotMatch(combined, /\b(innerHTML|outerHTML|insertAdjacentHTML)\b/);
+  assert.doesNotMatch(html, /\son[a-z]+\s*=/i);
+  assert.doesNotMatch(html, /<script(?![^>]+\bsrc=)[^>]*>/i);
+  assert.match(html, /<script type="module" src="\/dashboard\.js"><\/script>/);
+});
+
+test("CSP forbids inline script, handlers, objects, framing, and external defaults", () => {
+  const csp = SECURITY_HEADERS["Content-Security-Policy"];
+  assert.match(csp, /default-src 'none'/);
+  assert.match(csp, /script-src 'self'/);
+  assert.doesNotMatch(csp, /script-src[^;]*'unsafe-inline'/);
+  assert.match(csp, /object-src 'none'/);
+  assert.match(csp, /frame-ancestors 'none'/);
+});
+
+test("renderer assigns hostile message text as literal textContent", () => {
+  const payload = `"><img src=x onerror="globalThis.pwned=1"><script>pwned()</script>`;
+  const node = createMessageElement(fakeDocument, {
+    type: "message",
+    from: `bad' onclick='pwned()`,
+    to: `</span><script>pwned()</script>`,
+    text: payload,
+    authenticated: true,
+    encrypted: true,
+    direction: "inbound",
+  });
+
+  assert.equal(findClass(node, "msg-text").textContent, payload);
+  assert.equal(findClass(node, "from").textContent, "unknown");
+  assert.equal(findClass(node, "to").textContent, "unknown");
+  assert.equal(node.children.length, 2);
+});
+
+test("agent renderer rejects invalid identifiers and attaches a real listener", () => {
+  assert.throws(() => createAgentItem(fakeDocument, {
+    agent: `x' onclick='pwned()`,
+    onToggle: () => {},
+  }), /invalid agent id/);
+
+  let toggled;
+  const node = createAgentItem(fakeDocument, {
+    agent: "agent-safe",
+    isSelf: true,
+    isOnline: true,
+    isActive: false,
+    onToggle: (agent) => { toggled = agent; },
+  });
+  node.listeners.get("click")();
+  assert.equal(toggled, "agent-safe");
+  assert.equal(findClass(node, "agent-name").textContent, "agent-safe (me)");
+});
+
+test("dashboard token loader enforces private mode and Basic auth", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "murmur-dashboard-auth-"));
+  const tokenFile = path.join(dir, "token");
+  const token = "dashboard_token_0123456789_ABCDEFGHIJ";
+  await writeFile(tokenFile, `${token}\n`, { mode: 0o600 });
+  await chmod(tokenFile, 0o600);
+
+  assert.equal(loadDashboardToken(tokenFile), token);
+  const header = `Basic ${Buffer.from(`murmur:${token}`).toString("base64")}`;
+  assert.equal(isAuthorizedHeader(header, token), true);
+  assert.equal(isAuthorizedHeader(header, `${token}x`), false);
+  assert.equal(isAuthorizedHeader(undefined, token), false);
+
+  await chmod(tokenFile, 0o644);
+  assert.throws(() => loadDashboardToken(tokenFile), /group or others/);
+});
+
+async function fixture() {
+  const localEncryption = await createKeyPair();
+  const peerEncryption = await createKeyPair();
+  const localSigning = await createSigningKeyPair();
+  const peerSigning = await createSigningKeyPair();
+  const encrypted = await encryptPayload("literal <script>not code</script>", localEncryption.publicKey, peerEncryption.privateKey);
+  const envelope = {
+    schemaVersion: "1.0",
+    msgId: "msg-1",
+    conversationId: "agent-peer:agent-local",
+    senderAgentId: "agent-peer",
+    recipients: ["agent-local"],
+    createdAt: "2026-08-11T12:00:00.000Z",
+    payloadCiphertext: encrypted.ciphertext,
+    payloadNonce: encrypted.nonce,
+    signature: "",
+  };
+  envelope.signature = await signEnvelope(stableEnvelopePayload(envelope), peerSigning.privateKey);
+  return {
+    envelope,
+    config: {
+      agentId: "agent-local",
+      keys: { encryption: localEncryption, signing: localSigning },
+      peers: { "agent-peer": { encryption: peerEncryption, signing: peerSigning } },
+    },
+  };
+}
+
+test("only signed, recipient-bound, local envelopes become authenticated events", async () => {
+  const { envelope, config } = await fixture();
+  const accepted = await authenticateEnvelope(JSON.stringify(envelope), "msg.agent-local", config);
+  assert.equal(accepted.accepted, true);
+  assert.equal(accepted.event.authenticated, true);
+  assert.equal(accepted.event.text, "literal <script>not code</script>");
+
+  const unsigned = await authenticateEnvelope(JSON.stringify({ from: "agent-peer", payload: "hello" }), "msg.agent-local", config);
+  assert.deepEqual(unsigned, { accepted: false, reason: "unsigned-or-invalid-envelope" });
+
+  const tampered = { ...envelope, msgId: "tampered" };
+  assert.equal((await authenticateEnvelope(JSON.stringify(tampered), "msg.agent-local", config)).accepted, false);
+  assert.deepEqual(
+    await authenticateEnvelope(JSON.stringify(envelope), "msg.someone-else", config),
+    { accepted: false, reason: "recipient-subject-mismatch" },
+  );
+});


### PR DESCRIPTION
## Summary

Hardens the optional Murmur dashboard against DOM XSS, unauthenticated browser access, and unsigned/spoofed live NATS messages.

- renders every untrusted field through DOM `textContent`; removes `innerHTML`, inline scripts, and inline event handlers
- serves a strict CSP plus clickjacking, MIME-sniffing, referrer, opener, resource, and cache protections
- requires Basic authentication backed by a private server-local token file for HTTP and WebSocket access
- verifies envelope schema, signature, NATS subject/recipient binding, local traffic direction, and known peer identity before a live message reaches the UI
- decrypts only verified local inbound or self-originated outbound envelopes
- treats local SQLite history as authenticated daemon-store provenance and labels it accordingly
- keeps the listener loopback-only and rejects unsafe agent identifiers

## Deployment note

The dashboard now fails closed unless `DASHBOARD_TOKEN_FILE` exists (default: `~/.config/murmur/dashboard-token`), contains at least 32 URL-safe characters, and has no group/other permission bits. This dashboard is inactive in the current audited deployment, so the PR does not interrupt the running Murmur agents.

## Verification

- `npm run build`
- `npm test` (all suites passed: 191 Node tests plus Python/smoke stages)
- `node --test tests/dashboard-security.test.mjs` (6/6)
- `git diff --check`
- credential-pattern scan over every changed file
- sanitized compatibility check against three live configurations: 11/11 agent and peer identifiers accepted; no values were printed

Tracks fedoseevstanislav/ops#742.
