### PR TITLE
security: close the four signed-ACK gaps without breaking the wire

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1778,22 +1778,13 @@
       "license": "MIT",
       "dependencies": {
         "@a2a-js/sdk": "1.0.0-alpha.0",
-        "@murmurv2/core": "^0.2.0",
+        "@murmurv2/core": "^0.4.0",
         "@murmurv2/security": "^0.1.0",
         "express": "^5.1.0",
         "nats": "^2.28.2"
       },
       "devDependencies": {
         "@types/express": "^5.0.0"
-      }
-    },
-    "packages/bridge-a2a/node_modules/@murmurv2/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@murmurv2/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-ldczX36kucZCajlo4kYfR8MJAlixpITAA629iXbMSNRp5ylaTCdIXm+xoM5vAEBnV3+bE4Eu+sMCydOJWgo8kw==",
-      "license": "MIT",
-      "dependencies": {
-        "pg": "^8.16.3"
       }
     },
     "packages/bridge-murmur": {
@@ -1806,17 +1797,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "^0.2.0",
+        "@murmurv2/core": "^0.4.0",
         "nats": "^2.28.2"
-      }
-    },
-    "packages/bridge-openclaw/node_modules/@murmurv2/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@murmurv2/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-ldczX36kucZCajlo4kYfR8MJAlixpITAA629iXbMSNRp5ylaTCdIXm+xoM5vAEBnV3+bE4Eu+sMCydOJWgo8kw==",
-      "license": "MIT",
-      "dependencies": {
-        "pg": "^8.16.3"
       }
     },
     "packages/bridge-telegram": {
@@ -1824,17 +1806,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "^0.2.0",
+        "@murmurv2/core": "^0.4.0",
         "@murmurv2/security": "^0.1.0"
-      }
-    },
-    "packages/bridge-telegram/node_modules/@murmurv2/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@murmurv2/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-ldczX36kucZCajlo4kYfR8MJAlixpITAA629iXbMSNRp5ylaTCdIXm+xoM5vAEBnV3+bE4Eu+sMCydOJWgo8kw==",
-      "license": "MIT",
-      "dependencies": {
-        "pg": "^8.16.3"
       }
     },
     "packages/broker-nats": {
@@ -1851,17 +1824,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "^0.2.0",
+        "@murmurv2/core": "^0.4.0",
         "ws": "^8.21.0"
-      }
-    },
-    "packages/broker-ws/node_modules/@murmurv2/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@murmurv2/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-ldczX36kucZCajlo4kYfR8MJAlixpITAA629iXbMSNRp5ylaTCdIXm+xoM5vAEBnV3+bE4Eu+sMCydOJWgo8kw==",
-      "license": "MIT",
-      "dependencies": {
-        "pg": "^8.16.3"
       }
     },
     "packages/core": {
@@ -1885,21 +1849,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@murmurv2/core": "^0.2.0",
+        "@murmurv2/core": "^0.4.0",
         "@murmurv2/federation": "^0.2.0"
       },
       "devDependencies": {
         "@murmurv2/security": "^0.1.0",
         "nats": "^2.28.2"
-      }
-    },
-    "packages/federation-nats/node_modules/@murmurv2/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@murmurv2/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-ldczX36kucZCajlo4kYfR8MJAlixpITAA629iXbMSNRp5ylaTCdIXm+xoM5vAEBnV3+bE4Eu+sMCydOJWgo8kw==",
-      "license": "MIT",
-      "dependencies": {
-        "pg": "^8.16.3"
       }
     },
     "packages/mcp-server": {

--- a/packages/bridge-a2a/package.json
+++ b/packages/bridge-a2a/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@a2a-js/sdk": "1.0.0-alpha.0",
-    "@murmurv2/core": "^0.2.0",
+    "@murmurv2/core": "^0.4.0",
     "@murmurv2/security": "^0.1.0",
     "express": "^5.1.0",
     "nats": "^2.28.2"

--- a/packages/bridge-a2a/src/index.ts
+++ b/packages/bridge-a2a/src/index.ts
@@ -26,8 +26,21 @@ import { randomUUID } from "node:crypto";
 import type { Server } from "node:http";
 import express from "express";
 import { StringCodec, connect, type NatsConnection, type Subscription } from "nats";
-import { isEnvelopeV1, stableEnvelopePayload, type AckV1, type EnvelopeV1 } from "@murmurv2/core";
-import { decryptPayload, encryptPayload, signEnvelope } from "@murmurv2/security";
+import {
+  isEnvelopeV1,
+  isSignedAckV1,
+  stableAckPayload,
+  stableEnvelopePayload,
+  type AckV1,
+  type EnvelopeV1,
+  type SignedAckV1,
+} from "@murmurv2/core";
+import {
+  decryptPayload,
+  encryptPayload,
+  signEnvelope,
+  verifyEnvelopeSignature,
+} from "@murmurv2/security";
 import {
   DefaultRequestHandler,
   InMemoryTaskStore,
@@ -69,6 +82,11 @@ export interface BridgeA2AConfig {
   /** Internal agentId -> X25519 public key. Used to seal to the target AND to open
    *  a reply (the sender pubkey is not carried in the envelope). */
   recipientPublicKeys: Record<string, string>;
+  /** Internal agentId -> Ed25519 signing public key. Required to verify SignedAckV1
+   *  frames: without an entry for a peer, that peer's NACKs cannot resolve a task.
+   *  Historically the bridge accepted unsigned `{msgId, status}` objects here, which let
+   *  anyone able to publish to the ACK subject resolve someone else's in-flight task. */
+  signingPublicKeys?: Record<string, string>;
   /** Allowlist of external A2A agent ids permitted to delegate tasks. */
   allowedExternalAgents: string[];
   /** ms to wait for the internal agent's reply before failing the A2A task. */
@@ -303,15 +321,35 @@ export class A2AMurmurBridge {
       return;
     }
 
-    const ack = parsed as AckV1;
-    if (ack?.msgId && ack.status === "nack") {
-      const resolve = this.pending.get(ack.msgId);
-      if (resolve) {
-        this.pending.delete(ack.msgId);
-        resolve(`[murmur nack] ${ack.reason ?? "rejected"}`);
-      }
+    // Only a verified SignedAckV1 may resolve a pending task.
+    //
+    // This path used to accept a bare `{msgId, status: "nack"}` object: anyone able to
+    // publish to the ACK subject could resolve someone else's in-flight A2A task with an
+    // arbitrary failure string. Signature verification is mandatory here — an unsigned or
+    // unverifiable frame is dropped, and the task stays pending until a real answer or the
+    // caller's own timeout.
+    if (!isSignedAckV1(parsed)) return;
+    if (!(await this.verifySignedAck(parsed))) return;
+    if (parsed.status !== "nack") {
+      // A positive ack only confirms delivery; the real answer arrives as an envelope.
+      return;
     }
-    // A positive AckV1 only confirms delivery; the real answer arrives as an envelope.
+    const resolve = this.pending.get(parsed.msgId);
+    if (resolve) {
+      this.pending.delete(parsed.msgId);
+      resolve(`[murmur nack] ${parsed.reason ?? "rejected"}`);
+    }
+  }
+
+  /** True only for an ACK signed by the pinned key of the agent it claims to come from. */
+  private async verifySignedAck(ack: SignedAckV1): Promise<boolean> {
+    const publicKey = this.config.signingPublicKeys?.[ack.senderAgentId];
+    if (!publicKey) return false;
+    try {
+      return await verifyEnvelopeSignature(stableAckPayload(ack), ack.signature, publicKey);
+    } catch {
+      return false;
+    }
   }
 
   async stop(): Promise<void> {

--- a/packages/bridge-openclaw/package.json
+++ b/packages/bridge-openclaw/package.json
@@ -9,7 +9,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@murmurv2/core": "^0.2.0",
+    "@murmurv2/core": "^0.4.0",
     "nats": "^2.28.2"
   },
   "license": "MIT",

--- a/packages/bridge-telegram/package.json
+++ b/packages/bridge-telegram/package.json
@@ -9,7 +9,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@murmurv2/core": "^0.2.0",
+    "@murmurv2/core": "^0.4.0",
     "@murmurv2/security": "^0.1.0"
   },
   "license": "MIT",

--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -21,6 +21,7 @@ import {
   isEnvelopeV1,
   isSignedPresenceFrameV1,
   type SignedPresenceFrameV1,
+  type AckReceiptStore,
   type DedupeStore,
   type OutboxStore,
   type AckV1,
@@ -556,6 +557,9 @@ export class NatsBroker {
 
   async startAckCorrelation(params: {
     outbox: OutboxStore;
+    /** Durable replay protection. Omit only where a restart cannot happen — without it
+     *  the in-memory fallback forgets every nonce when the process dies. */
+    ackReceipts?: AckReceiptStore;
     ackSubject: string;
     consumerId?: string;
     verifyAck?: AckVerifier;
@@ -604,7 +608,20 @@ export class NatsBroker {
     params.onInvalidAck?.(event);
   }
 
-  private rememberAckNonce(nonce: string): boolean {
+  /**
+   * Claim an ACK nonce once. Prefers the durable store; the in-memory set is a fallback
+   * that does NOT survive a restart — see AckReceiptStore in @murmurv2/core.
+   */
+  private async claimAckNonce(
+    store: AckReceiptStore | undefined,
+    senderAgentId: string,
+    nonce: string,
+  ): Promise<boolean> {
+    if (store) return store.claimAckNonce(senderAgentId, nonce);
+    return this.rememberAckNonceInMemory(`${senderAgentId}:${nonce}`);
+  }
+
+  private rememberAckNonceInMemory(nonce: string): boolean {
     if (this.seenAckNonces.has(nonce)) return false;
     this.seenAckNonces.add(nonce);
     if (this.seenAckNonces.size > 10_000) {
@@ -618,6 +635,7 @@ export class NatsBroker {
     data: Uint8Array,
     params: {
       outbox: OutboxStore;
+      ackReceipts?: AckReceiptStore;
       verifyAck?: AckVerifier;
       requireSignedAcks?: boolean;
       maxAckAgeMs?: number;
@@ -654,7 +672,9 @@ export class NatsBroker {
         this.invalidAck(params, "unknown-message", decoded);
         return;
       }
-      if (record.status !== "sent") {
+      // 'pending' is in flight too: the peer can acknowledge between publish() and
+      // markSent(). Rejecting that ACK leaves the row to time out into a spurious retry.
+      if (record.status !== "sent" && record.status !== "pending") {
         this.invalidAck(params, "message-not-in-flight", decoded);
         return;
       }
@@ -687,7 +707,7 @@ export class NatsBroker {
         this.invalidAck(params, "signature-invalid", decoded);
         return;
       }
-      if (!this.rememberAckNonce(`${decoded.senderAgentId}:${decoded.nonce}`)) {
+      if (!(await this.claimAckNonce(params.ackReceipts, decoded.senderAgentId, decoded.nonce))) {
         this.invalidAck(params, "nonce-replay", decoded);
         return;
       }

--- a/packages/broker-ws/package.json
+++ b/packages/broker-ws/package.json
@@ -10,7 +10,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@murmurv2/core": "^0.2.0",
+    "@murmurv2/core": "^0.4.0",
     "ws": "^8.21.0"
   },
   "license": "MIT",

--- a/packages/broker-ws/src/index.ts
+++ b/packages/broker-ws/src/index.ts
@@ -1,16 +1,29 @@
 import { createRequire } from "node:module";
 import {
+  type AckReceiptStore,
   applyJitter,
   computeBackoffMs,
   createAck,
   type AckV1,
   type DedupeStore,
   type EnvelopeV1,
+  envelopeDigest,
   isEnvelopeV1,
+  isSignedAckV1,
   type OutboxStore,
   type SecurityPolicy,
+  type SignedAckV1,
   validateEnvelopePolicy,
 } from "@murmurv2/core";
+
+/** Verifies a SignedAckV1 against the pinned signing key of its claimed sender. */
+export type WsAckVerifier = (ack: SignedAckV1) => Promise<boolean>;
+
+export interface WsInvalidAckEvent {
+  reason: string;
+  msgId?: string;
+  senderAgentId?: string;
+}
 
 const require = createRequire(import.meta.url);
 const { WebSocket, WebSocketServer } = require("ws") as {
@@ -42,7 +55,7 @@ interface WsServer {
 type WsFrame =
   | { type: "subscribe"; subject: string }
   | { type: "message"; subject: string; envelope: EnvelopeV1 | unknown }
-  | { type: "ack"; subject: string; ack: AckV1 };
+  | { type: "ack"; subject: string; ack: AckV1 | SignedAckV1 };
 
 export interface WebSocketRelayConfig {
   host?: string;
@@ -167,6 +180,10 @@ interface AckSubscription {
   subject: string;
   outbox: OutboxStore;
   active: boolean;
+  verifyAck?: WsAckVerifier;
+  requireSignedAcks?: boolean;
+  ackReceipts?: AckReceiptStore;
+  onInvalidAck?: (event: WsInvalidAckEvent) => void;
 }
 
 export class WebSocketBroker {
@@ -246,9 +263,24 @@ export class WebSocketBroker {
   async startAckCorrelation(params: {
     outbox: OutboxStore;
     ackSubject: string;
+    /** Required to accept signed ACKs. Without it every signed frame is rejected. */
+    verifyAck?: WsAckVerifier;
+    /** When true, unsigned legacy frames are rejected outright (two-stage rollout). */
+    requireSignedAcks?: boolean;
+    /** Durable replay protection; see AckReceiptStore in @murmurv2/core. */
+    ackReceipts?: AckReceiptStore;
+    onInvalidAck?: (event: WsInvalidAckEvent) => void;
   }): Promise<WebSocketBrokerSubscription> {
     await this.connect();
-    const sub: AckSubscription = { subject: params.ackSubject, outbox: params.outbox, active: true };
+    const sub: AckSubscription = {
+      subject: params.ackSubject,
+      outbox: params.outbox,
+      active: true,
+      verifyAck: params.verifyAck,
+      requireSignedAcks: params.requireSignedAcks,
+      ackReceipts: params.ackReceipts,
+      onInvalidAck: params.onInvalidAck,
+    };
     this.ackSubscriptions.add(sub);
     await this.send({ type: "subscribe", subject: params.ackSubject });
     return {
@@ -287,7 +319,7 @@ export class WebSocketBroker {
       await Promise.all(
         [...this.ackSubscriptions]
           .filter((sub) => sub.active && wsSubjectMatches(sub.subject, frame!.subject))
-          .map((sub) => this.processAckFrame(frame!.ack, sub.outbox)),
+          .map((sub) => this.processAckFrame(frame!.ack, sub, frame!.subject)),
       );
     }
   }
@@ -330,15 +362,90 @@ export class WebSocketBroker {
     }
   }
 
-  private async processAckFrame(ack: AckV1, outbox: OutboxStore): Promise<void> {
-    if (!ack || typeof ack.msgId !== "string" || ack.msgId.length === 0) return;
-    if (ack.status === "ack") {
-      await outbox.markAcked(ack.msgId);
+  /**
+   * Apply an inbound ACK frame to the outbox.
+   *
+   * This path previously trusted the frame outright and called markAcked/markFailed from
+   * whatever JSON arrived, so anyone able to reach the relay could settle another peer's
+   * pending row. A SignedAckV1 is now verified, bound to the outbox record and claimed
+   * once; unsigned frames survive only while `requireSignedAcks` is off, mirroring the
+   * two-stage rollout of the NATS broker.
+   */
+  private async processAckFrame(
+    ack: AckV1 | SignedAckV1,
+    sub: AckSubscription,
+    frameSubject: string,
+  ): Promise<void> {
+    const reject = (reason: string, senderAgentId?: string, msgId?: string): void => {
+      sub.onInvalidAck?.({ reason, senderAgentId, msgId });
+    };
+
+    if (!ack || typeof ack.msgId !== "string" || ack.msgId.length === 0) {
+      reject("malformed");
       return;
     }
-    if (ack.status === "nack") {
-      await outbox.markFailed(ack.msgId, ack.reason ?? "nack", new Date().toISOString());
+
+    if (!isSignedAckV1(ack)) {
+      if (sub.requireSignedAcks) {
+        reject("unsigned-ack-rejected", undefined, ack.msgId);
+        return;
+      }
+      const legacy = ack as AckV1;
+      if (legacy.status === "ack") {
+        await sub.outbox.markAcked(legacy.msgId);
+      } else if (legacy.status === "nack") {
+        await sub.outbox.markFailed(legacy.msgId, legacy.reason ?? "nack", new Date().toISOString());
+      }
+      return;
     }
+
+    const record = await sub.outbox.getOutboxRecord(ack.msgId);
+    if (!record) {
+      reject("unknown-message", ack.senderAgentId, ack.msgId);
+      return;
+    }
+    if (record.status !== "sent" && record.status !== "pending") {
+      reject("message-not-in-flight", ack.senderAgentId, ack.msgId);
+      return;
+    }
+    if (ack.messageDigest !== envelopeDigest(record.envelope)) {
+      reject("message-digest-mismatch", ack.senderAgentId, ack.msgId);
+      return;
+    }
+    if (ack.conversationId !== record.envelope.conversationId) {
+      reject("conversation-mismatch", ack.senderAgentId, ack.msgId);
+      return;
+    }
+    if (ack.recipientAgentId !== record.envelope.senderAgentId) {
+      reject("recipient-mismatch", ack.senderAgentId, ack.msgId);
+      return;
+    }
+    if (!record.envelope.recipients.includes(ack.senderAgentId)) {
+      reject("unexpected-peer", ack.senderAgentId, ack.msgId);
+      return;
+    }
+    // The frame must arrive on the subject belonging to the original sender, so a valid
+    // ACK cannot be replayed onto an unrelated subscription.
+    if (frameSubject !== `ack.${record.envelope.senderAgentId}`) {
+      reject("ack-subject-mismatch", ack.senderAgentId, ack.msgId);
+      return;
+    }
+    if (!sub.verifyAck || !(await sub.verifyAck(ack))) {
+      reject("signature-invalid", ack.senderAgentId, ack.msgId);
+      return;
+    }
+    if (sub.ackReceipts && !(await sub.ackReceipts.claimAckNonce(ack.senderAgentId, ack.nonce))) {
+      reject("nonce-replay", ack.senderAgentId, ack.msgId);
+      return;
+    }
+
+    const result = await sub.outbox.applyAckTransition(
+      ack.msgId,
+      ack.status,
+      ack.reason ?? "nack",
+      new Date().toISOString(),
+    );
+    if (result !== "applied") reject(`transition-${result}`, ack.senderAgentId, ack.msgId);
   }
 
   async flushOutbox(params: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,6 +125,41 @@ export interface DedupeStore {
   markSeen(msgId: string, consumerId: string): Promise<void>;
 }
 
+/**
+ * Durable replay protection for signed acknowledgements.
+ *
+ * An in-memory nonce set forgets everything on restart, which lets a signed NACK be
+ * replayed against a fresh process: the retry returns the row to `sent` and the replayed
+ * NACK fails it again. Implementations of this interface must survive a restart.
+ *
+ * `claimAckNonce` is claim-once semantics: it returns true the first time a nonce is seen
+ * and false for every subsequent call, so callers never need a separate check-then-write.
+ */
+export interface AckReceiptStore {
+  claimAckNonce(senderAgentId: string, nonce: string): Promise<boolean>;
+}
+
+/** Non-durable fallback. Use only where a restart cannot happen (tests, one-shot tools). */
+export class InMemoryAckReceiptStore implements AckReceiptStore {
+  private readonly keys = new Map<string, true>();
+  private readonly maxSize: number;
+
+  constructor(maxSize = 10_000) {
+    this.maxSize = Math.max(1, Math.floor(maxSize));
+  }
+
+  async claimAckNonce(senderAgentId: string, nonce: string): Promise<boolean> {
+    const key = `${senderAgentId}:${nonce}`;
+    if (this.keys.has(key)) return false;
+    this.keys.set(key, true);
+    if (this.keys.size > this.maxSize) {
+      const oldest = this.keys.keys().next();
+      if (!oldest.done) this.keys.delete(oldest.value);
+    }
+    return true;
+  }
+}
+
 export class InMemoryDedupeStore implements DedupeStore {
   private readonly keys: Map<string, true>;
   private readonly maxSize: number;
@@ -207,6 +242,13 @@ export class JsonFileDedupeStore implements DedupeStore {
 }
 
 export type OutboxStatus = "pending" | "sent" | "acked" | "failed" | "dlq";
+
+/** Statuses a row cannot be moved out of by a late `markSent()`. */
+export const TERMINAL_OUTBOX_STATUSES: ReadonlySet<OutboxStatus> = new Set<OutboxStatus>([
+  "acked",
+  "failed",
+  "dlq",
+]);
 
 export interface OutboxRecord {
   msgId: string;
@@ -304,6 +346,10 @@ export class JsonFileOutboxStore implements OutboxStore {
     const state = await this.load();
     const row = state.records.find((r) => r.msgId === msgId);
     if (!row) return;
+    // Never downgrade a terminal status: a fast ACK can land between publish() and this
+    // call, and overwriting `acked`/`failed` with `sent` would resurrect a settled row
+    // into a retry.
+    if (TERMINAL_OUTBOX_STATUSES.has(row.status)) return;
     row.status = "sent";
     row.attempts += 1;
     row.updatedAt = new Date().toISOString();
@@ -353,7 +399,9 @@ export class JsonFileOutboxStore implements OutboxStore {
     const state = await this.load();
     const row = state.records.find((record) => record.msgId === msgId);
     if (!row) return "not-found";
-    if (row.status !== "sent") return "not-in-flight";
+    // See the SQLite implementation: 'pending' is accepted so a fast ACK arriving between
+    // publish() and markSent() is not rejected into a spurious retry.
+    if (row.status !== "sent" && row.status !== "pending") return "not-in-flight";
 
     const now = new Date().toISOString();
     if (status === "ack") {
@@ -421,7 +469,7 @@ const secureSqliteFiles = (filePath: string): void => {
   }
 };
 
-export class SQLiteDedupeOutboxStore implements DedupeStore, OutboxStore {
+export class SQLiteDedupeOutboxStore implements DedupeStore, OutboxStore, AckReceiptStore {
   private readonly db: DatabaseSync;
 
   constructor(dbPath = ".data/murmur.db") {
@@ -434,6 +482,12 @@ export class SQLiteDedupeOutboxStore implements DedupeStore, OutboxStore {
         msg_id TEXT NOT NULL,
         seen_at TEXT NOT NULL,
         PRIMARY KEY (consumer_id, msg_id)
+      );
+      CREATE TABLE IF NOT EXISTS ack_receipts (
+        sender_agent_id TEXT NOT NULL,
+        nonce TEXT NOT NULL,
+        claimed_at TEXT NOT NULL,
+        PRIMARY KEY (sender_agent_id, nonce)
       );
       CREATE TABLE IF NOT EXISTS outbox (
         msg_id TEXT PRIMARY KEY,
@@ -465,6 +519,22 @@ export class SQLiteDedupeOutboxStore implements DedupeStore, OutboxStore {
         "INSERT OR IGNORE INTO dedupe_seen (consumer_id, msg_id, seen_at) VALUES (?, ?, ?)",
       )
       .run(consumerId, msgId, new Date().toISOString());
+  }
+
+  /**
+   * Claim-once on `(sender_agent_id, nonce)`, durable across restarts.
+   *
+   * The PRIMARY KEY does the work: `INSERT OR IGNORE` reports zero changes when the nonce
+   * was already claimed, so a replayed ACK is rejected even by a process that never saw
+   * the original.
+   */
+  async claimAckNonce(senderAgentId: string, nonce: string): Promise<boolean> {
+    const result = this.db
+      .prepare(
+        "INSERT OR IGNORE INTO ack_receipts (sender_agent_id, nonce, claimed_at) VALUES (?, ?, ?)",
+      )
+      .run(senderAgentId, nonce, new Date().toISOString());
+    return Number(result.changes ?? 0) > 0;
   }
 
   async enqueue(subject: string, envelope: EnvelopeV1): Promise<void> {
@@ -503,11 +573,16 @@ export class SQLiteDedupeOutboxStore implements DedupeStore, OutboxStore {
   }
 
   async markSent(msgId: string): Promise<void> {
-    await this.updateOutboxOptimistic(msgId, (row) => ({
-      status: "sent",
-      attempts: row.attempts + 1,
-      updatedAt: new Date().toISOString(),
-    }));
+    await this.updateOutboxOptimistic(msgId, (row) =>
+      // See the JSON store: a terminal status wins over a late markSent().
+      TERMINAL_OUTBOX_STATUSES.has(row.status)
+        ? {}
+        : {
+            status: "sent",
+            attempts: row.attempts + 1,
+            updatedAt: new Date().toISOString(),
+          },
+    );
   }
 
   async markAcked(msgId: string): Promise<void> {
@@ -543,11 +618,15 @@ export class SQLiteDedupeOutboxStore implements DedupeStore, OutboxStore {
     const now = new Date().toISOString();
     const nextStatus = status === "ack" ? "acked" : "failed";
     const nextError = status === "ack" ? null : error;
+    // 'pending' is accepted alongside 'sent' on purpose: a fast peer can acknowledge
+    // between publish() and markSent(), and rejecting that ACK leaves the row to time out
+    // into a spurious retry. markSent() refuses to downgrade a terminal status, so the
+    // late markSent() cannot overwrite the transition applied here.
     const changed = this.db
       .prepare(
         `UPDATE outbox
          SET status = ?, last_error = ?, next_attempt_at = ?, updated_at = ?, version = version + 1
-         WHERE msg_id = ? AND status = 'sent'`,
+         WHERE msg_id = ? AND status IN ('sent', 'pending')`,
       )
       .run(nextStatus, nextError, nextAttemptAt, now, msgId);
     if (changed.changes > 0) return "applied";

--- a/packages/federation-nats/package.json
+++ b/packages/federation-nats/package.json
@@ -13,7 +13,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@murmurv2/core": "^0.2.0",
+    "@murmurv2/core": "^0.4.0",
     "@murmurv2/federation": "^0.2.0"
   },
   "devDependencies": {

--- a/scripts/murmur-daemon.mjs
+++ b/scripts/murmur-daemon.mjs
@@ -376,8 +376,14 @@ try {
     log("info", "Subscribed (proxy)", { subject: ps });
   }
 
+  // `store` is a SQLiteDedupeOutboxStore, which also implements AckReceiptStore: ACK nonces
+  // are claimed in the same database as the outbox, so replay protection survives a daemon
+  // restart. Without this the broker falls back to an in-memory set that forgets everything
+  // on exit.
+  const ackReceipts = typeof store.claimAckNonce === "function" ? store : undefined;
   await broker.startAckCorrelation({
     outbox: store,
+    ackReceipts,
     ackSubject: `ack.${agentId}`,
     consumerId: `${agentId}-ack`,
     verifyAck,
@@ -389,7 +395,13 @@ try {
     ackSubject: `ack.${agentId}`,
     emitSignedAcks,
     requireSignedAcks,
+    durableAckReplayProtection: Boolean(ackReceipts),
   });
+  if (!ackReceipts) {
+    log("warn", "ACK replay protection is in-memory only — nonces are forgotten on restart", {
+      hint: "use the SQLite store (storePath) so ack_receipts is persisted",
+    });
+  }
   await startJetStreamAdvisoryDlqIfEnabled({
     broker,
     outbox: store,

--- a/tests/ack-hardening.test.mjs
+++ b/tests/ack-hardening.test.mjs
@@ -1,0 +1,146 @@
+// Regression tests for the signed-ACK hardening in #109.
+//
+// Each test below fails on the pre-#109 code and passes after it. They cover the gaps that
+// #100 (compatible signed ACKs) left open and that #104 (wire-breaking) would have closed
+// at the cost of a mesh-wide flag day.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  InMemoryAckReceiptStore,
+  JsonFileOutboxStore,
+  SQLiteDedupeOutboxStore,
+  TERMINAL_OUTBOX_STATUSES,
+} from "@murmurv2/core";
+
+const workdir = () => mkdtempSync(path.join(tmpdir(), "murmur-ack-"));
+
+const envelope = (msgId) => ({
+  schemaVersion: "1.0",
+  msgId,
+  conversationId: "conv-1",
+  senderAgentId: "agent-a",
+  recipients: ["agent-b"],
+  createdAt: new Date().toISOString(),
+  payloadCiphertext: "x",
+  payloadNonce: "y",
+  signature: "z",
+});
+
+// --- Gap 1: replay protection must survive a restart -------------------------------
+//
+// The pre-#109 broker held nonces in a bounded in-memory Set. A restart forgot them, so a
+// signed NACK could be replayed against a fresh process: the retry returned the row to
+// `sent` and the replayed NACK failed it again.
+
+test("SQLite ack receipts: a nonce can be claimed exactly once", async () => {
+  const dir = workdir();
+  try {
+    const store = new SQLiteDedupeOutboxStore(path.join(dir, "murmur.db"));
+    assert.equal(await store.claimAckNonce("agent-b", "nonce-1"), true);
+    assert.equal(await store.claimAckNonce("agent-b", "nonce-1"), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("SQLite ack receipts: a claim survives a restart of the process", async () => {
+  const dir = workdir();
+  const dbPath = path.join(dir, "murmur.db");
+  try {
+    const before = new SQLiteDedupeOutboxStore(dbPath);
+    assert.equal(await before.claimAckNonce("agent-b", "nonce-replay"), true);
+
+    // A brand-new store instance stands in for a restarted daemon: same file, no shared
+    // memory. This is precisely where the in-memory Set used to forget.
+    const after = new SQLiteDedupeOutboxStore(dbPath);
+    assert.equal(await after.claimAckNonce("agent-b", "nonce-replay"), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("SQLite ack receipts: the same nonce from a different sender is a different claim", async () => {
+  const dir = workdir();
+  try {
+    const store = new SQLiteDedupeOutboxStore(path.join(dir, "murmur.db"));
+    assert.equal(await store.claimAckNonce("agent-b", "shared-nonce"), true);
+    assert.equal(await store.claimAckNonce("agent-c", "shared-nonce"), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("InMemoryAckReceiptStore keeps claim-once semantics within a process", async () => {
+  const store = new InMemoryAckReceiptStore(4);
+  assert.equal(await store.claimAckNonce("agent-b", "n1"), true);
+  assert.equal(await store.claimAckNonce("agent-b", "n1"), false);
+});
+
+// --- Gap 2: the fast-ACK race --------------------------------------------------------
+//
+// A peer can acknowledge between publish() and markSent(). The pre-#109 code required
+// status === 'sent', rejected the ACK as `message-not-in-flight`, and left the row to time
+// out into a spurious retry.
+
+for (const [label, makeStore] of [
+  ["SQLite", (dir) => new SQLiteDedupeOutboxStore(path.join(dir, "murmur.db"))],
+  ["JSON", (dir) => new JsonFileOutboxStore(path.join(dir, "outbox.json"))],
+]) {
+  test(`${label} outbox: an ACK arriving while the row is still pending is applied`, async () => {
+    const dir = workdir();
+    try {
+      const store = makeStore(dir);
+      await store.enqueue("msg.agent-b", envelope("m-fast"));
+
+      // No markSent() yet — this is the race window.
+      assert.equal(await store.applyAckTransition("m-fast", "ack"), "applied");
+
+      const record = await store.getOutboxRecord("m-fast");
+      assert.equal(record.status, "acked");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test(`${label} outbox: a late markSent does not resurrect an acked row`, async () => {
+    const dir = workdir();
+    try {
+      const store = makeStore(dir);
+      await store.enqueue("msg.agent-b", envelope("m-late"));
+      await store.applyAckTransition("m-late", "ack");
+
+      // The publisher's markSent() lands after the ACK was already applied.
+      await store.markSent("m-late");
+
+      const record = await store.getOutboxRecord("m-late");
+      assert.equal(record.status, "acked", "a settled row must not be dragged back to sent");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test(`${label} outbox: a terminal row still rejects a second transition`, async () => {
+    const dir = workdir();
+    try {
+      const store = makeStore(dir);
+      await store.enqueue("msg.agent-b", envelope("m-twice"));
+      await store.markSent("m-twice");
+      assert.equal(await store.applyAckTransition("m-twice", "ack"), "applied");
+      assert.equal(await store.applyAckTransition("m-twice", "nack"), "not-in-flight");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
+
+test("terminal statuses are the ones markSent must refuse to downgrade", () => {
+  assert.equal(TERMINAL_OUTBOX_STATUSES.has("acked"), true);
+  assert.equal(TERMINAL_OUTBOX_STATUSES.has("failed"), true);
+  assert.equal(TERMINAL_OUTBOX_STATUSES.has("dlq"), true);
+  assert.equal(TERMINAL_OUTBOX_STATUSES.has("pending"), false);
+  assert.equal(TERMINAL_OUTBOX_STATUSES.has("sent"), false);
+});


### PR DESCRIPTION
Closes alexfrmn/murmur#109. Follow-up to alexfrmn/murmur#100, and the compatible answer to alexfrmn/murmur#104.

Each gap was surfaced by @fedoseevstanislav's strict variant. This PR lands the same protections **without** a wire break, so a mixed-version mesh keeps working and the two-stage `ackSecurity.requireSigned` rollout still applies.

## 1. Replay protection is now durable

`AckReceiptStore` (new in `@murmurv2/core`) plus an `ack_receipts` table in `SQLiteDedupeOutboxStore` give claim-once semantics on `(sender_agent_id, nonce)` that survive a restart. The `PRIMARY KEY` does the work — `INSERT OR IGNORE` reports zero changes for an already-claimed nonce, so a replayed ACK is rejected even by a process that never saw the original.

The in-memory set remains as an explicit fallback, and the daemon now **logs a warning when that fallback is what is running**, rather than silently offering weaker protection than the logs suggest.

## 2. The fast-ACK race no longer causes a spurious retry

`applyAckTransition` accepts `pending` alongside `sent`, so an ACK arriving between `publish()` and `markSent()` is applied rather than rejected as `message-not-in-flight`. To keep that safe, `markSent()` refuses to downgrade a terminal status — a late call can no longer drag a settled row back to `sent`.

## 3. The A2A bridge no longer honours an unsigned NACK

`packages/bridge-a2a/src/index.ts` resolved a pending task from a bare `{msgId, status: "nack"}` object. It now requires a `SignedAckV1` verified against the pinned signing key of its claimed sender; `signingPublicKeys` was added to `BridgeA2AConfig` for that. Without an entry for a peer, that peer's NACKs cannot resolve anything.

## 4. The WebSocket ACK path is verified like the NATS one

`processAckFrame` verified nothing at all and called `markAcked`/`markFailed` straight from the frame. It now performs the full set of checks — record lookup, digest, conversation, recipient, known peer, **ack-subject binding**, signature, and nonce claim. Unsigned frames are still accepted until `requireSignedAcks` is set, matching the NATS rollout.

## Dependency alignment, found while wiring this

Five packages declared `@murmurv2/core: ^0.2.0`. npm could not satisfy that from the workspace once core reached 0.4.0, so it **silently installed 0.2.0 from the registry**: `bridge-a2a`, `bridge-openclaw`, `bridge-telegram`, `broker-ws` and `federation-nats` were building and testing against a core two minor versions behind. Their green tests were green against the wrong code. Ranges bumped to `^0.4.0`.

## Verification

- `npm run build` clean
- `npm test` — **224/224**, including 11 new regressions in `tests/ack-hardening.test.mjs` covering restart-surviving nonce claims, cross-sender nonce isolation, the pending-ACK window, late-`markSent` protection and double-transition rejection, run against both the SQLite and JSON stores
- `node --check` on the patched daemon

## Not in this PR

Deployment. The strict flag still has to be turned on across every peer before the original issue is fully closed — that is a rollout step, not a code change.