### PR TITLE
fix(wake): per-session lock and cursor so every session wakes, not just one

### DIFF
--- a/scripts/murmur-coldidle-watch.sh
+++ b/scripts/murmur-coldidle-watch.sh
@@ -7,21 +7,57 @@
 #     exits when a new inbound Murmur message arrives so the Claude Code harness
 #     re-invokes the session (background-task completion = wake).
 #
-# Shares the SAME cursor (~/.murmur-wake-cursor) as the hook => a message wakes once.
+# Cursor is shared with the Stop-hook wake-drain-claude.sh => a message wakes once
+# PER SESSION: both default to a cursor keyed by CLAUDE_CODE_SESSION_ID (see below).
 # Re-arm after each fire (launch again in background).
 set -uo pipefail
 
 DB="${MURMUR_DB:-/opt/lifecoach/murmur/.data/murmur.db}"
-CURSOR="${MURMUR_WAKE_CURSOR:-$HOME/.murmur-wake-cursor}"
 INTERVAL="${MURMUR_WATCH_INTERVAL:-20}"
-LOCK="${MURMUR_WATCH_LOCK:-$HOME/.murmur-coldidle-watch.lock}"
 LOCK_WAIT="${MURMUR_WATCH_LOCK_WAIT:-21600}"   # 6ч — дольше любой разумной сессии
+
+# ── ключ сессии: свой пост у каждой сессии ───────────────────────────────
+# WHY (замер 26.08.2026): общий lock + общий курсор давали ОДИН живой watcher
+# на весь хост. При семи параллельных сессиях входящее будило держателя поста —
+# случайную сессию, а не ту, где лежит контекст переписки. Остальные спали на flock
+# и не просыпались никогда: за 23-26.08 из 24 сессий watcher реально сторожил 13,
+# а на посту в каждый момент стояла ровно одна. Теперь каждая сессия сторожит СЕБЯ.
+# Цена — N запросов `SELECT MAX(rowid)` раз в 20с вместо одного; для sqlite это ничто.
+# Явные MURMUR_WATCH_LOCK / MURMUR_WAKE_CURSOR по-прежнему перекрывают дефолт.
+SESSION_KEY="${MURMUR_WAKE_SESSION_KEY:-${CLAUDE_CODE_SESSION_ID:-}}"
+SESSION_KEY="${SESSION_KEY:0:8}"
+if [ -n "$SESSION_KEY" ]; then
+  CURSOR="${MURMUR_WAKE_CURSOR:-$HOME/.murmur-wake-cursor-$SESSION_KEY}"
+  LOCK="${MURMUR_WATCH_LOCK:-$HOME/.murmur-coldidle-watch-$SESSION_KEY.lock}"
+else
+  # Не в сессии Claude Code (ручной запуск, cron, чужой харнесс) — легаси-пути.
+  CURSOR="${MURMUR_WAKE_CURSOR:-$HOME/.murmur-wake-cursor}"
+  LOCK="${MURMUR_WATCH_LOCK:-$HOME/.murmur-coldidle-watch.lock}"
+fi
 
 [ -r "$DB" ] || { echo "watcher: DB not readable: $DB" >&2; exit 1; }
 
-# ── single-flight: опрашивать БД должен РОВНО ОДИН watcher ──────────────────
-# WHY: армится на КАЖДОМ jarvis-start, а сессий параллельно 6-11 → набиралось по
-# несколько инстансов, и каждый долбил sqlite раз в 20с по одному и тому же курсору.
+# ── seed-to-tip на первом запуске ────────────────────────────────────────
+# БЕЗ ЭТОГО per-session курсор сломал бы всё: файла нет → last=0 → первый же цикл
+# видит ВСЮ историю входящих как «новое» и мгновенно будит сессию тысячами старых
+# сообщений. Новая сессия сторожит С МОМЕНТА СВОЕГО СТАРТА.
+if [ ! -f "$CURSOR" ]; then
+  seed="$(sqlite3 "$DB" \
+    "SELECT COALESCE(MAX(rowid), 0) FROM local_messages WHERE direction='inbound';" \
+    2>/dev/null || echo 0)"
+  case "$seed" in ''|*[!0-9]*) seed=0 ;; esac
+  seed_tmp="${CURSOR}.$$"
+  if printf '%s\n' "$seed" > "$seed_tmp" 2>/dev/null; then
+    mv "$seed_tmp" "$CURSOR" 2>/dev/null || rm -f "$seed_tmp"
+  fi
+  echo "watcher: курсор засеян на rowid=$seed ($CURSOR)"
+fi
+
+# ── single-flight В ПРЕДЕЛАХ СЕССИИ: один watcher на один lock ───────────
+# WHY: армится на КАЖДОМ jarvis-start, а внутри одной сессии скилл могут позвать
+# повторно (ре-арм после срабатывания, /clear, ручной повтор) → дубли по одному
+# и тому же курсору. С 26.08 lock per-session, поэтому ЧУЖИЕ сессии друг друга
+# больше не блокируют — очередь на flock здесь только из своих.
 # Держатель lock работает; лишние НЕ выходят сразу (мгновенный exit = завершение
 # background-задачи = ложный re-invoke сессии), а спят на flock в ядре: 0 CPU, 0
 # запросов к БД. Когда держатель отстреливается по wake — очередной подхватывает

--- a/scripts/wake-drain-claude.sh
+++ b/scripts/wake-drain-claude.sh
@@ -10,14 +10,42 @@
 # Dedup is cursor-based (last drained rowid), so a message wakes exactly once.
 #
 # Env:
-#   MURMUR_DB         path to the agent daemon DB (default: jarvis store)
-#   MURMUR_WAKE_CURSOR file holding the last-drained rowid (per session/agent)
+#   MURMUR_DB               path to the agent daemon DB (default: jarvis store)
+#   MURMUR_WAKE_CURSOR      file holding the last-drained rowid (per session/agent)
+#   MURMUR_WAKE_SESSION_KEY overrides the session key used to build the default cursor
 set -uo pipefail
 
-DB="${MURMUR_DB:-/opt/lifecoach/mur-mur-v2/.data/murmur.db}"
-CURSOR="${MURMUR_WAKE_CURSOR:-$HOME/.murmur-wake-cursor}"
+DB="${MURMUR_DB:-/opt/lifecoach/murmur/.data/murmur.db}"
+
+# ── ключ сессии: свой курсор у каждой сессии ─────────────────────────────
+# WHY (26.08.2026): общий курсор на всех означает, что первая же сессия, дошедшая
+# до Stop-хука, продвигает его до тика — и остальные не видят сообщения вообще.
+# Пробуждение получал случайный, а не тот, кому сообщение адресовано. Тот же дефект
+# чинится в murmur-coldidle-watch.sh; ключ у них ОДИН, поэтому хук и watcher одной
+# сессии по-прежнему делят курсор и будят её ровно один раз.
+SESSION_KEY="${MURMUR_WAKE_SESSION_KEY:-${CLAUDE_CODE_SESSION_ID:-}}"
+SESSION_KEY="${SESSION_KEY:0:8}"
+if [ -n "$SESSION_KEY" ]; then
+  CURSOR="${MURMUR_WAKE_CURSOR:-$HOME/.murmur-wake-cursor-$SESSION_KEY}"
+else
+  CURSOR="${MURMUR_WAKE_CURSOR:-$HOME/.murmur-wake-cursor}"
+fi
 
 [ -r "$DB" ] || exit 0
+
+# ── seed-to-tip: первый запуск в новой сессии НЕ вываливает всю историю ──
+if [ ! -f "$CURSOR" ]; then
+  seed="$(sqlite3 "$DB" \
+    "SELECT COALESCE(MAX(rowid), 0) FROM local_messages WHERE direction='inbound';" \
+    2>/dev/null || echo 0)"
+  case "$seed" in ''|*[!0-9]*) seed=0 ;; esac
+  mkdir -p "$(dirname "$CURSOR")" 2>/dev/null || true
+  seed_tmp="${CURSOR}.$$"
+  if printf '%s\n' "$seed" > "$seed_tmp" 2>/dev/null; then
+    mv "$seed_tmp" "$CURSOR" 2>/dev/null || rm -f "$seed_tmp"
+  fi
+  exit 0
+fi
 
 last="$(cat "$CURSOR" 2>/dev/null || printf '0\n')"
 case "$last" in ''|*[!0-9]*) last=0 ;; esac

--- a/tests/wake-drain-claude.test.mjs
+++ b/tests/wake-drain-claude.test.mjs
@@ -23,7 +23,7 @@ function withDb() {
       text TEXT
     );
   `);
-  return { db, dbPath, cursorPath };
+  return { db, dbPath, cursorPath, dir };
 }
 
 function insertMessage(db, { msgId, direction = "inbound", sender = "agent-jarvis", text = "hello" }) {
@@ -33,30 +33,51 @@ function insertMessage(db, { msgId, direction = "inbound", sender = "agent-jarvi
   `).run(msgId, sender, direction, text);
 }
 
-function drain({ dbPath, cursorPath }) {
+function drain({ dbPath, cursorPath }, extraEnv = {}) {
   return spawnSync(script, [], {
     env: {
       ...process.env,
       MURMUR_DB: dbPath,
       MURMUR_WAKE_CURSOR: cursorPath,
+      ...extraEnv,
     },
     encoding: "utf8",
   });
 }
 
-test("Claude wake drain exits 0 when there are no new inbound messages", () => {
+// A session that has never drained has no cursor file. Seeding it to the current
+// tip is what makes the per-session cursor usable at all: without it the first
+// drain of every new session would replay the whole inbound history as "new".
+test("Claude wake drain seeds the cursor to the tip on first run and stays silent", () => {
   const ctx = withDb();
-  insertMessage(ctx.db, { msgId: "outbound-1", direction: "outbound", text: "ignore me" });
+  insertMessage(ctx.db, { msgId: "inbound-old-1", text: "history one" });
+  insertMessage(ctx.db, { msgId: "inbound-old-2", text: "history two" });
 
   const result = drain(ctx);
 
   assert.equal(result.status, 0);
   assert.equal(result.stderr, "");
-  assert.equal(fs.existsSync(ctx.cursorPath), false);
+  assert.equal(fs.readFileSync(ctx.cursorPath, "utf8").trim(), "2");
+});
+
+test("Claude wake drain exits 0 when there are no new inbound messages", () => {
+  const ctx = withDb();
+  insertMessage(ctx.db, { msgId: "outbound-1", direction: "outbound", text: "ignore me" });
+
+  const seed = drain(ctx);
+  assert.equal(seed.status, 0);
+  assert.equal(fs.readFileSync(ctx.cursorPath, "utf8").trim(), "0");
+
+  const result = drain(ctx);
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, "");
 });
 
 test("Claude wake drain emits new inbound rows and advances the cursor", () => {
   const ctx = withDb();
+  drain(ctx); // seed at an empty tip
+
   insertMessage(ctx.db, { msgId: "inbound-1", text: "first\nline" });
   insertMessage(ctx.db, { msgId: "outbound-1", direction: "outbound", text: "ignore me" });
   insertMessage(ctx.db, { msgId: "inbound-2", sender: "agent-peer", text: "second" });
@@ -73,6 +94,8 @@ test("Claude wake drain emits new inbound rows and advances the cursor", () => {
 
 test("Claude wake drain cursor dedup prevents repeat wakes", () => {
   const ctx = withDb();
+  drain(ctx); // seed
+
   insertMessage(ctx.db, { msgId: "inbound-1", text: "first" });
 
   const first = drain(ctx);
@@ -82,4 +105,42 @@ test("Claude wake drain cursor dedup prevents repeat wakes", () => {
   assert.equal(second.status, 0);
   assert.equal(second.stderr, "");
   assert.equal(fs.readFileSync(ctx.cursorPath, "utf8").trim(), "1");
+});
+
+// The point of the per-session cursor: one inbound message must wake EVERY live
+// session, not just whichever one reached the hook first. With a shared cursor
+// the second session below would see nothing.
+test("Claude wake drain keeps a separate cursor per session key", () => {
+  const ctx = withDb();
+  const dirA = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-wake-home-a-"));
+  const dirB = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-wake-home-b-"));
+
+  // No explicit MURMUR_WAKE_CURSOR: the script must derive it from the session key.
+  const drainAs = (home, sessionKey) =>
+    spawnSync(script, [], {
+      env: {
+        ...process.env,
+        MURMUR_DB: ctx.dbPath,
+        MURMUR_WAKE_CURSOR: "",
+        HOME: home,
+        CLAUDE_CODE_SESSION_ID: sessionKey,
+      },
+      encoding: "utf8",
+    });
+
+  assert.equal(drainAs(dirA, "aaaaaaaa-1111").status, 0); // seed session A
+  assert.equal(drainAs(dirB, "bbbbbbbb-2222").status, 0); // seed session B
+
+  insertMessage(ctx.db, { msgId: "inbound-1", text: "one message, two sessions" });
+
+  const wokeA = drainAs(dirA, "aaaaaaaa-1111");
+  const wokeB = drainAs(dirB, "bbbbbbbb-2222");
+
+  assert.equal(wokeA.status, 2, "session A must wake");
+  assert.equal(wokeB.status, 2, "session B must wake on the same message");
+  assert.match(wokeA.stderr, /one message, two sessions/);
+  assert.match(wokeB.stderr, /one message, two sessions/);
+
+  assert.ok(fs.existsSync(path.join(dirA, ".murmur-wake-cursor-aaaaaaaa")));
+  assert.ok(fs.existsSync(path.join(dirB, ".murmur-wake-cursor-bbbbbbbb")));
 });


### PR DESCRIPTION
## Problem

The cold-idle watcher and the Stop-hook drain both defaulted to **one lock and one cursor per host**:

- `~/.murmur-coldidle-watch.lock`
- `~/.murmur-wake-cursor`

With several Claude Code sessions running side by side this means only the lock holder polls the database. Every other watcher sleeps on `flock` and never wakes its own session, so an inbound message wakes a random session instead of the one holding the conversation. The shared cursor compounds it: whichever session drains first advances it to the tip, and the message is gone for the rest.

Measured on the deployment 2026-08-26 with seven live sessions: over 23-26.08, 24 sessions ran the start skill, 13 actually launched a watcher, and exactly one stood post at any moment.

## Change

Both scripts derive their defaults from `CLAUDE_CODE_SESSION_ID` (overridable with `MURMUR_WAKE_SESSION_KEY`), so every session gets its own lock and its own cursor. `flock` still prevents duplicate instances, now within a single session. Explicit `MURMUR_WATCH_LOCK` / `MURMUR_WAKE_CURSOR` still win, and a run outside Claude Code falls back to the legacy shared paths.

A per-session cursor does not exist on first run, which would make the first poll treat the entire inbound history as new. Both scripts therefore seed the cursor to the current tip on first run — a session watches from its own start.

`wake-drain-claude.sh` also picks up the daemon path already used by the deployed copy (`/opt/lifecoach/murmur`), replacing the stale `mur-mur-v2` symlink default.

## Cost

N sessions each run one `SELECT MAX(rowid)` every 20s instead of a single poller. On SQLite that is nothing; the original single-flight work was aimed at duplicate instances **within** one session, and `flock` still covers that.

## Verification

Two watchers with different session ids:

- run concurrently, neither blocks on the other's lock;
- each seeds its cursor to the live tip (no history dump);
- a single injected inbound row wakes **both**, exactly once each, with the correct count.