### PR TITLE
fix(secure-state): skip directory fsync on Windows (unsupported, blocks install)

### DIFF
--- a/scripts/secure-state.mjs
+++ b/scripts/secure-state.mjs
@@ -85,11 +85,16 @@ export const writePrivateJson = async (filePath, value) => {
     await rename(tempPath, filePath);
     await chmod(filePath, 0o600);
 
-    const dirHandle = await open(dirPath, constants.O_RDONLY | constants.O_DIRECTORY);
-    try {
-      await dirHandle.sync();
-    } finally {
-      await dirHandle.close();
+    // Windows does not support fsync on a directory handle (FlushFileBuffers
+    // returns EPERM/EINVAL). The file itself is already fsync'd above; the
+    // directory sync is a best-effort durability nicety, so skip it on win32.
+    if (process.platform !== "win32") {
+      const dirHandle = await open(dirPath, constants.O_RDONLY | constants.O_DIRECTORY);
+      try {
+        await dirHandle.sync();
+      } finally {
+        await dirHandle.close();
+      }
     }
   } catch (err) {
     if (handle) await handle.close().catch(() => {});


### PR DESCRIPTION
## Problem

Murmur cannot be installed on Windows. The first key write throws:

```
Error: EPERM: operation not permitted, fsync
    at async writePrivateJson (scripts/secure-state.mjs:90)
    at async murmur-join.mjs:68
```

`writePrivateJson` fsyncs the **parent directory handle** after the atomic
rename (durability of the rename). Windows does not support fsync on a
directory handle — `FlushFileBuffers` on a directory returns
`ERROR_ACCESS_DENIED`, surfaced by Node as `EPERM`. This aborts
`agent-config-init.mjs` / `murmur-join.mjs` on the very first key write, so the
invite/join flow never completes on Windows.

## Fix

Guard the directory fsync behind `process.platform !== 'win32'`. The key file
itself is already fsync'd above the rename (line 82), so the directory fsync is
a best-effort durability nicety, not a correctness requirement. POSIX behaviour
is byte-identical; Windows skips only the unsupported call.

## Verification

Windows 11 / Node 24.13.1, cross-host test (Mac broker ↔ Windows peer over LAN):

- Before: `murmur-join.mjs` threw `EPERM: fsync` at `secure-state.mjs:90`.
- After: join completes, `agent-config.json` is written, daemon connects, and
  bidirectional E2E delivery with `requireSigned` ACK works both ways.

No regression on POSIX (the `win32` branch is the only change) and no change to
the `secure-state.test.mjs` result count on Windows (3 failing → 3 failing);
this patch converts the hard `EPERM` crash in that suite's write test into the
pre-existing, separate Windows gaps below.

## Out of scope (heads-up)

`secure-state.mjs` has two further Windows gaps this PR intentionally does **not**
touch, because they are a larger design question:

1. POSIX mode enforcement (`chmod 0o600/0o700`, mode assertions) — Windows does
   not implement POSIX permission bits, so the `0700 dir / 0600 file` and
   `repair permissive modes` tests fail on the mode check.
2. `symlink`-rejection test needs symlink-creation privilege on Windows.

Happy to follow up on those separately if you want Windows to be a fully
supported target.

---

Context: found while testing Murmur cross-host between a Mac and a Windows box
(the same report sent on Telegram). This patch is the minimal change that
unblocks installation on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
