### PR TITLE
fix(mcp): select the inbox by direction, not by a LIKE on the agent's own name

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -960,6 +960,36 @@ export class SQLiteMessageStore {
     return rows;
   }
 
+  /**
+   * Inbound messages for this agent, newest first.
+   *
+   * The store is per-agent, so every inbound row in it is already addressed to this
+   * agent: `direction` is the whole filter. Do NOT express an inbox as a
+   * `searchMessages()` call — that is a LIKE query, and a message whose text happens
+   * not to mention the agent's own name is then silently absent from the result while
+   * the sender sees the delivery acked (#114).
+   */
+  async listInbound(limit = 20): Promise<LocalMessageRecord[]> {
+    const rows = this.db
+      .prepare(
+        `SELECT
+           id,
+           conversation_id as conversationId,
+           msg_id as msgId,
+           direction,
+           sender,
+           text,
+           created_at as createdAt,
+           transport
+         FROM local_messages
+         WHERE direction = 'inbound'
+         ORDER BY created_at DESC, rowid DESC
+         LIMIT ?`,
+      )
+      .all(limit) as unknown as LocalMessageRecord[];
+    return rows;
+  }
+
   async searchMessages(query: string, limit = 50): Promise<LocalMessageRecord[]> {
     const q = `%${query}%`;
     const rows = this.db

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -310,12 +310,12 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
 
     const limit = Number(args.limit ?? 20);
     const effectiveLimit = Number.isFinite(limit) ? limit : 20;
-    // Search inbound messages for this agent
-    const messages = await store.searchMessages(agentConfig.agentId, effectiveLimit * 5);
-    // Filter to only inbound messages
-    const inbound = messages
-      .filter((m) => m.direction === "inbound")
-      .slice(0, effectiveLimit);
+    // Select by direction, not by a text search for the agent's own name: this store
+    // belongs to one agent, so every inbound row in it is addressed to that agent.
+    // The old searchMessages(agentId) form was a LIKE over text/sender/conversationId
+    // and silently returned count:0 for any message that did not spell out the agent's
+    // name — delivered, acked, present in local_messages, invisible to the inbox (#114).
+    const inbound = await store.listInbound(effectiveLimit);
     return { messages: inbound.map(asMessage), count: inbound.length };
   }
 

--- a/tests/message-store-inbox.test.mjs
+++ b/tests/message-store-inbox.test.mjs
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SQLiteMessageStore } from "../packages/core/dist/src/index.js";
+
+const withStore = () => {
+  const dir = mkdtempSync(join(tmpdir(), "murmur-inbox-"));
+  const store = new SQLiteMessageStore(join(dir, "murmur.db"));
+  return { store, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+};
+
+const append = (store, { direction, sender, text, at }) =>
+  store.append({
+    conversationId: "peer:task:test",
+    msgId: `${direction}-${text.slice(0, 8)}-${at}`,
+    direction,
+    sender,
+    text,
+    createdAt: at,
+  });
+
+test("listInbound returns delivered inbound messages that never mention the agent", async () => {
+  const { store, cleanup } = withStore();
+  try {
+    // The regression from #114: none of these three spell out the receiving agent's
+    // name, which is the normal case for a reply.
+    await append(store, { direction: "inbound", sender: "agent-peer", text: "done, deployed", at: "2026-08-26T22:00:00.000Z" });
+    await append(store, { direction: "inbound", sender: "agent-peer", text: "logs look clean", at: "2026-08-26T22:01:00.000Z" });
+    await append(store, { direction: "outbound", sender: "agent-claude", text: "check the logs", at: "2026-08-26T22:02:00.000Z" });
+
+    const inbound = await store.listInbound(20);
+
+    assert.equal(inbound.length, 2);
+    assert.ok(inbound.every((m) => m.direction === "inbound"));
+    assert.deepEqual(inbound.map((m) => m.text), ["logs look clean", "done, deployed"]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("the old searchMessages(agentId) form is what dropped them", async () => {
+  const { store, cleanup } = withStore();
+  try {
+    await append(store, { direction: "inbound", sender: "agent-peer", text: "done, deployed", at: "2026-08-26T22:00:00.000Z" });
+
+    // Guards the reason for the fix rather than the fix itself: a LIKE over
+    // text/sender/conversationId cannot see a message that does not name the agent,
+    // and the tool reported count:0 while the sender saw the message acked.
+    const viaSearch = await store.searchMessages("agent-claude", 100);
+    assert.equal(viaSearch.length, 0);
+
+    const viaInbox = await store.listInbound(20);
+    assert.equal(viaInbox.length, 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test("listInbound honours the limit and returns newest first", async () => {
+  const { store, cleanup } = withStore();
+  try {
+    for (let i = 0; i < 5; i += 1) {
+      await append(store, {
+        direction: "inbound",
+        sender: "agent-peer",
+        text: `msg ${i}`,
+        at: `2026-08-26T22:0${i}:00.000Z`,
+      });
+    }
+
+    const inbound = await store.listInbound(2);
+
+    assert.equal(inbound.length, 2);
+    assert.deepEqual(inbound.map((m) => m.text), ["msg 4", "msg 3"]);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
Closes #114, reported by @lichtpfad from a Mac/Windows cross-host run.

## What was wrong

`murmur_inbox` asked the store for messages matching the agent's own id:

```ts
const messages = await store.searchMessages(agentConfig.agentId, effectiveLimit * 5);
const inbound = messages.filter((m) => m.direction === "inbound").slice(0, effectiveLimit);
```

`searchMessages` is `WHERE text LIKE ? OR sender LIKE ? OR conversation_id LIKE ?`. A
reply that does not happen to spell out the receiving agent's name matches nothing, so
the tool answers `count:0` while the row sits in `local_messages` and the sender sees the
delivery `acked`. Reported numbers: claude 4 inbound -> 0, codex 3 -> 1 (the one
containing the word "codex"), automata 2 -> 0.

This is the worst possible failure shape for autonomous work: no error, no retry, the
sender believes the message landed and the receiver never sees it.

## What this does

The store belongs to one agent, so every inbound row in it is already addressed to that
agent — `direction` is the whole filter. Adds `SQLiteMessageStore.listInbound(limit)` and
uses it. `searchMessages` keeps its meaning for the `search_messages` tool.

## Tests

`tests/message-store-inbox.test.mjs` — inbound messages that never mention the agent are
returned; the old `searchMessages(agentId)` form is asserted to return 0 for the same row,
so the reason for the fix stays documented; limit and ordering.