### PR TITLE
fix(outbox): let a failed row finish its retry — version CAS instead of a status list

### DIFF
--- a/packages/broker-nats/src/index.ts
+++ b/packages/broker-nats/src/index.ts
@@ -853,7 +853,7 @@ export class NatsBroker {
 
       try {
         await this.publish(rec.subject, rec.envelope, params.policy);
-        await params.outbox.markSent(rec.msgId);
+        await params.outbox.markSent(rec.msgId, rec.version);
         if (params.ackWindow) {
           inFlightChunks += 1;
           inFlightBytes += nextChunkBytes;

--- a/packages/broker-ws/src/index.ts
+++ b/packages/broker-ws/src/index.ts
@@ -466,7 +466,7 @@ export class WebSocketBroker {
     for (const rec of due) {
       try {
         await this.publish(rec.subject, rec.envelope, params.policy);
-        await params.outbox.markSent(rec.msgId);
+        await params.outbox.markSent(rec.msgId, rec.version);
       } catch (err) {
         const nextAttemptNum = rec.attempts + 1;
         const reason = err instanceof Error ? err.message : "publish-failed";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -243,10 +243,25 @@ export class JsonFileDedupeStore implements DedupeStore {
 
 export type OutboxStatus = "pending" | "sent" | "acked" | "failed" | "dlq";
 
-/** Statuses a row cannot be moved out of by a late `markSent()`. */
+/**
+ * Statuses a row can never be moved out of: the message is settled for good.
+ *
+ * `failed` is deliberately NOT here. A failed row is *scheduled for retry*, not
+ * settled — `claimDue()` selects it on purpose. Listing it as terminal made the
+ * retry unable to complete: claimDue re-selected the row, publish succeeded,
+ * markSent() refused to touch it, so status stayed `failed`, `attempts` never
+ * grew (no DLQ), `nextAttemptAt` stayed in the past (immediate re-claim), and
+ * the returning ACK was rejected as message-not-in-flight. An infinite loop with
+ * no way to settle it short of a manual dlq (#113).
+ *
+ * The race that put it here — a fast ACK landing between publish() and markSent(),
+ * where a late markSent() would drag the settled row back into flight — is handled
+ * by the `expectedVersion` compare-and-swap on markSent() instead. That guards the
+ * row against *any* concurrent transition, not just the two statuses someone
+ * remembered to enumerate.
+ */
 export const TERMINAL_OUTBOX_STATUSES: ReadonlySet<OutboxStatus> = new Set<OutboxStatus>([
   "acked",
-  "failed",
   "dlq",
 ]);
 
@@ -268,7 +283,16 @@ export interface OutboxStore {
   claimDue(limit?: number): Promise<OutboxRecord[]>;
   listInFlight?(): Promise<OutboxRecord[]>;
   getOutboxRecord(msgId: string): Promise<OutboxRecord | undefined>;
-  markSent(msgId: string): Promise<void>;
+  /**
+   * Move a claimed row into flight.
+   *
+   * Pass the `version` the row carried when `claimDue()` returned it: the update is
+   * then applied only while the row is untouched, so an ACK/NACK that landed between
+   * publish() and this call keeps its verdict instead of being overwritten with
+   * `sent`. Omitting it keeps the old best-effort behaviour (settled rows are still
+   * protected) and is only appropriate outside the claim → publish → mark path.
+   */
+  markSent(msgId: string, expectedVersion?: number): Promise<void>;
   markAcked(msgId: string): Promise<void>;
   markFailed(msgId: string, error: string, nextAttemptAt: string): Promise<void>;
   markDlq(msgId: string, error: string): Promise<void>;
@@ -342,14 +366,15 @@ export class JsonFileOutboxStore implements OutboxStore {
     return state.records.find((record) => record.msgId === msgId);
   }
 
-  async markSent(msgId: string): Promise<void> {
+  async markSent(msgId: string, expectedVersion?: number): Promise<void> {
     const state = await this.load();
     const row = state.records.find((r) => r.msgId === msgId);
     if (!row) return;
-    // Never downgrade a terminal status: a fast ACK can land between publish() and this
-    // call, and overwriting `acked`/`failed` with `sent` would resurrect a settled row
-    // into a retry.
+    // A settled row is never dragged back into flight.
     if (TERMINAL_OUTBOX_STATUSES.has(row.status)) return;
+    // Compare-and-swap against the version claimDue() handed out: if anything moved the
+    // row since (a fast ACK/NACK between publish() and this call), that verdict wins.
+    if (expectedVersion !== undefined && (row.version ?? 1) !== expectedVersion) return;
     row.status = "sent";
     row.attempts += 1;
     row.updatedAt = new Date().toISOString();
@@ -572,17 +597,28 @@ export class SQLiteDedupeOutboxStore implements DedupeStore, OutboxStore, AckRec
     return this.getOutboxRow(msgId);
   }
 
-  async markSent(msgId: string): Promise<void> {
-    await this.updateOutboxOptimistic(msgId, (row) =>
-      // See the JSON store: a terminal status wins over a late markSent().
-      TERMINAL_OUTBOX_STATUSES.has(row.status)
-        ? {}
-        : {
-            status: "sent",
-            attempts: row.attempts + 1,
-            updatedAt: new Date().toISOString(),
-          },
-    );
+  async markSent(msgId: string, expectedVersion?: number): Promise<void> {
+    // Single statement, so the guard and the write cannot be split by a concurrent
+    // transition. A settled row (acked/dlq) is never dragged back into flight, and when
+    // the caller passes the version claimDue() handed out, an ACK/NACK that landed
+    // between publish() and this call keeps its verdict — see the JSON store.
+    const terminal = [...TERMINAL_OUTBOX_STATUSES];
+    const placeholders = terminal.map(() => "?").join(", ");
+    this.db
+      .prepare(
+        `UPDATE outbox
+         SET status = 'sent', attempts = attempts + 1, updated_at = ?, version = version + 1
+         WHERE msg_id = ?
+           AND status NOT IN (${placeholders})
+           AND (? IS NULL OR version = ?)`,
+      )
+      .run(
+        new Date().toISOString(),
+        msgId,
+        ...terminal,
+        expectedVersion ?? null,
+        expectedVersion ?? null,
+      );
   }
 
   async markAcked(msgId: string): Promise<void> {

--- a/tests/ack-hardening.test.mjs
+++ b/tests/ack-hardening.test.mjs
@@ -137,10 +137,16 @@ for (const [label, makeStore] of [
   });
 }
 
-test("terminal statuses are the ones markSent must refuse to downgrade", () => {
+// `failed` was originally listed here too, to stop a late markSent() from overwriting a
+// NACK that arrived mid-publish. It also stopped the ordinary retry of a failed row from
+// ever completing (#113) — claimDue() selects `failed` by design. The row-level guard for
+// that race is the expectedVersion compare-and-swap on markSent(), covered by the two
+// tests above and by tests/outbox-failed-retry-settles.test.mjs; this set now means only
+// "settled for good".
+test("terminal statuses are the ones a row can never leave", () => {
   assert.equal(TERMINAL_OUTBOX_STATUSES.has("acked"), true);
-  assert.equal(TERMINAL_OUTBOX_STATUSES.has("failed"), true);
   assert.equal(TERMINAL_OUTBOX_STATUSES.has("dlq"), true);
+  assert.equal(TERMINAL_OUTBOX_STATUSES.has("failed"), false, "failed is retryable, not settled");
   assert.equal(TERMINAL_OUTBOX_STATUSES.has("pending"), false);
   assert.equal(TERMINAL_OUTBOX_STATUSES.has("sent"), false);
 });

--- a/tests/outbox-failed-retry-settles.test.mjs
+++ b/tests/outbox-failed-retry-settles.test.mjs
@@ -1,0 +1,83 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { JsonFileOutboxStore, SQLiteDedupeOutboxStore } from "../packages/core/dist/src/index.js";
+
+const envelopeFor = (msgId) => ({
+  schemaVersion: "1.0",
+  msgId,
+  conversationId: "conv-1",
+  senderAgentId: "agent.a",
+  recipients: ["agent.b"],
+  createdAt: new Date().toISOString(),
+  payloadCiphertext: Buffer.from("x").toString("base64"),
+  payloadNonce: "nonce",
+  signature: "sig",
+});
+
+const stores = [
+  ["SQLiteDedupeOutboxStore", () => new SQLiteDedupeOutboxStore(join(mkdtempSync(join(tmpdir(), "murmur-outbox-")), "murmur.db"))],
+  ["JsonFileOutboxStore", () => new JsonFileOutboxStore(join(mkdtempSync(join(tmpdir(), "murmur-outbox-")), "outbox.json"))],
+];
+
+for (const [label, makeStore] of stores) {
+  // #113: claimDue() selects `failed` rows on purpose, so the retry has to be able to
+  // finish. While `failed` counted as terminal, markSent() refused the claimed row:
+  // status stayed `failed`, attempts never grew (so maxAttempts/DLQ never fired),
+  // nextAttemptAt stayed in the past, and the row was re-claimed on every flush.
+  test(`${label}: a retried failed row reaches sent and can settle`, async () => {
+    const store = makeStore();
+    const envelope = envelopeFor("msg-retry");
+
+    await store.enqueue("agent.b", envelope);
+    await store.markFailed(envelope.msgId, "publish-failed", new Date(Date.now() - 1000).toISOString());
+
+    const [claimed] = await store.claimDue(10);
+    assert.equal(claimed.status, "failed");
+
+    await store.markSent(claimed.msgId, claimed.version);
+
+    const afterSend = await store.getOutboxRecord(envelope.msgId);
+    assert.equal(afterSend.status, "sent");
+    assert.equal(afterSend.attempts, claimed.attempts + 1, "attempts must grow, or DLQ never fires");
+
+    // The returning ACK is now accepted instead of bouncing as message-not-in-flight.
+    assert.equal(await store.applyAckTransition(envelope.msgId, "ack"), "applied");
+    assert.equal((await store.getOutboxRecord(envelope.msgId)).status, "acked");
+    assert.equal((await store.claimDue(10)).length, 0);
+  });
+
+  // The race #109 fixed, re-checked against the version guard that replaced the
+  // status list: an ACK/NACK landing between publish() and markSent() must win.
+  test(`${label}: a verdict that lands mid-publish is not overwritten by a late markSent`, async () => {
+    const store = makeStore();
+    const envelope = envelopeFor("msg-race");
+
+    await store.enqueue("agent.b", envelope);
+    const [claimed] = await store.claimDue(10);
+
+    // ...publish() is in flight here; the peer NACKs before markSent() runs.
+    assert.equal(await store.applyAckTransition(envelope.msgId, "nack", "peer-said-no"), "applied");
+    await store.markSent(claimed.msgId, claimed.version);
+
+    const row = await store.getOutboxRecord(envelope.msgId);
+    assert.equal(row.status, "failed", "the late markSent must not drag the row back into flight");
+    assert.equal(row.lastError, "peer-said-no");
+  });
+
+  test(`${label}: a settled row is never resurrected, with or without a version`, async () => {
+    const store = makeStore();
+    const envelope = envelopeFor("msg-settled");
+
+    await store.enqueue("agent.b", envelope);
+    const [claimed] = await store.claimDue(10);
+    await store.markAcked(envelope.msgId);
+
+    await store.markSent(claimed.msgId, claimed.version);
+    await store.markSent(claimed.msgId);
+
+    assert.equal((await store.getOutboxRecord(envelope.msgId)).status, "acked");
+  });
+}


### PR DESCRIPTION
Closes #113, reported by @lichtpfad with 766 log lines over two msgIds.

## What was wrong

`failed` is a *scheduled retry*, not a settled row — `claimDue()` selects
`status IN ('pending','failed')` on purpose. #109 put `failed` into
`TERMINAL_OUTBOX_STATUSES`, so the retry could never complete:

1. `claimDue()` re-selects the failed row
2. `publish()` succeeds
3. `markSent()` sees a terminal status and refuses -> status stays `failed`,
   `attempts` never grows (so `maxAttempts`/DLQ never fires), `nextAttemptAt`
   stays in the past
4. next flush re-claims it immediately -> loop
5. the returning ACK hits `applyAckTransition`, which requires `sent`/`pending`,
   and bounces as `message-not-in-flight`

Nothing short of a manual `dlq` could settle the row.

## Why not just drop `failed` from the set

Because that alone reopens the race #109 closed: a fast ACK/NACK can land between
`publish()` and `markSent()`, and the late `markSent()` would drag the settled row back
into flight. @lichtpfad flagged exactly this and deliberately did not send a one-line PR.

The guard belongs on the row, not on a hand-maintained list of statuses. `claimDue()`
already hands out the row `version`; the flush loop now passes it to
`markSent(msgId, expectedVersion)`, and the update applies only while the row is
untouched. That covers *any* concurrent transition, not just the statuses someone
remembered to enumerate. `TERMINAL_OUTBOX_STATUSES` goes back to meaning "settled for
good": `acked`, `dlq`.

`markSent`'s second argument is optional, so out-of-band callers keep working; both
brokers (NATS and WS) pass the version on the claim -> publish -> mark path.

## Tests

`tests/outbox-failed-retry-settles.test.mjs`, both store implementations:

- a retried failed row reaches `sent`, `attempts` grows, the ACK is applied — **fails on
  current main**, for both stores
- a NACK landing mid-publish is not overwritten by the late `markSent` (the #109 race,
  now guarded by the version)
- a settled row is never resurrected, with or without a version

The `ack-hardening` assertion that enumerated the set's contents is rewritten to state the
new rule; the behaviour it protected is covered by the version-CAS tests above.