### PR TITLE
fix(wake): finish the node port — per-session cursor, honest faults, no private paths

### DIFF
--- a/docs/wake-native.md
+++ b/docs/wake-native.md
@@ -26,14 +26,23 @@ Register it out-of-the-box in the agent's `.claude/settings.json`:
 
 Env:
 
-- `MURMUR_DB`: daemon SQLite store path.
-- `MURMUR_WAKE_CURSOR`: per-session cursor file.
+- `MURMUR_DB`: daemon SQLite store path (default `.data/murmur.db`, relative to the
+  working directory — set it explicitly when the hook runs from elsewhere).
+- `MURMUR_WAKE_CURSOR`: cursor file. Defaults to one file **per session**,
+  `~/.murmur-wake-cursor-<session>`.
+- `MURMUR_WAKE_SESSION_KEY`: overrides the session key (first 8 chars of
+  `CLAUDE_CODE_SESSION_ID` otherwise).
 
 Drain semantics:
 
 - Only `local_messages.direction='inbound'` rows are surfaced.
-- The cursor advances to the current max inbound `rowid` after a non-empty
-  drain, so repeated hook invocations do not double-wake the same message.
+- One cursor per session, so a message wakes **every** live session rather than only
+  whichever one reached the hook first. Within a session the hook and the cold-idle
+  watcher share the key, so it still wakes exactly once.
+- The first run in a new session seeds the cursor to the current tip and stays silent:
+  without that, a fresh session would replay the whole inbound history as "new".
+- The cursor advances to the last **reported** `rowid`, never to the table's tip: a row
+  inserted mid-drain would otherwise be stepped over and never wake anyone.
 - Cursor writes use a temporary file plus rename where the filesystem allows it.
 
 ### Windows / no `sqlite3` CLI — `wake-drain-claude.mjs`
@@ -57,9 +66,15 @@ Run it under `node --no-warnings` and register the same way:
 }
 ```
 
-Same env as the shell version (`MURMUR_DB`, `MURMUR_WAKE_CURSOR`) plus
-`MURMUR_WAKE_LOCK`, `MURMUR_WAKE_MAX_SECONDS`, `MURMUR_WAKE_POLL_MS`. Pass
-`--once` for a single non-polling check (e.g. a PostToolUse hook).
+Same env and the same per-session cursor as the shell version (`MURMUR_DB`,
+`MURMUR_WAKE_CURSOR`, `MURMUR_WAKE_SESSION_KEY`) plus `MURMUR_WAKE_LOCK`,
+`MURMUR_WAKE_MAX_SECONDS`, `MURMUR_WAKE_POLL_MS`. Pass `--once` for a single
+non-polling check (e.g. a PostToolUse hook). Requires Node with `node:sqlite`
+(22.5+).
+
+A fault — no store, an unreadable store, no `node:sqlite` — prints one line to stderr
+and exits `0`. Exiting non-zero would wake the session with a false alarm; exiting
+silently is the failure this port exists to remove, so it does neither.
 
 ## Codex CLI - App-Server WS-over-UDS
 

--- a/scripts/murmur-coldidle-watch.sh
+++ b/scripts/murmur-coldidle-watch.sh
@@ -12,7 +12,7 @@
 # Re-arm after each fire (launch again in background).
 set -uo pipefail
 
-DB="${MURMUR_DB:-/opt/lifecoach/murmur/.data/murmur.db}"
+DB="${MURMUR_DB:-.data/murmur.db}"
 INTERVAL="${MURMUR_WATCH_INTERVAL:-20}"
 LOCK_WAIT="${MURMUR_WATCH_LOCK_WAIT:-21600}"   # 6ч — дольше любой разумной сессии
 

--- a/scripts/murmur-to-acp-producer.sh
+++ b/scripts/murmur-to-acp-producer.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-exec /usr/bin/env python3 /opt/lifecoach/mur-mur-v2/scripts/murmur-to-acp-producer.py "$@"
+exec /usr/bin/env python3 "${MURMUR_HOME:-$(cd "$(dirname "$0")/.." && pwd)}/scripts/murmur-to-acp-producer.py" "$@"

--- a/scripts/wake-drain-claude.mjs
+++ b/scripts/wake-drain-claude.mjs
@@ -26,8 +26,13 @@
 // Run under `node --no-warnings` to suppress the node:sqlite ExperimentalWarning
 // so it does not leak into the wake system-reminder.
 //
+// A fault never exits non-zero (that would wake the session with a false alarm) and never
+// exits silently either — the reason goes to stderr and the exit code stays 0.
+//
 // Env (all optional; same contract as wake-drain-claude.sh plus lock/poll knobs):
-//   MURMUR_DB               daemon SQLite store path
+//   MURMUR_DB               daemon SQLite store path (default: .data/murmur.db)
+//   MURMUR_WAKE_SESSION_KEY overrides the key used to build the default cursor/lock names
+//                           (defaults to CLAUDE_CODE_SESSION_ID, first 8 chars)
 //   MURMUR_WAKE_CURSOR      file holding the last-drained inbound rowid
 //   MURMUR_WAKE_LOCK        single-poller lock file
 //   MURMUR_WAKE_MAX_SECONDS poll lifetime in seconds (default 1200)
@@ -42,9 +47,16 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 const HOME = homedir();
-const DB = process.env.MURMUR_DB || "/opt/lifecoach/mur-mur-v2/.data/murmur.db";
-const CURSOR = process.env.MURMUR_WAKE_CURSOR || join(HOME, ".murmur-wake-cursor");
-const LOCK = process.env.MURMUR_WAKE_LOCK || join(HOME, ".murmur-wake-lock");
+const DB = process.env.MURMUR_DB || ".data/murmur.db";
+
+// Session key: one cursor and one lock per Claude Code session. A shared cursor means
+// the first session to reach the hook advances it past the message and every other live
+// session — including the one holding the conversation — never sees it (see
+// murmur-coldidle-watch.sh for the measurement that produced this).
+const SESSION_KEY = (process.env.MURMUR_WAKE_SESSION_KEY || process.env.CLAUDE_CODE_SESSION_ID || "").slice(0, 8);
+const suffix = SESSION_KEY ? `-${SESSION_KEY}` : "";
+const CURSOR = process.env.MURMUR_WAKE_CURSOR || join(HOME, `.murmur-wake-cursor${suffix}`);
+const LOCK = process.env.MURMUR_WAKE_LOCK || join(HOME, `.murmur-wake-lock${suffix}`);
 const MAX_SECONDS = Number(process.env.MURMUR_WAKE_MAX_SECONDS || 1200);
 const POLL_MS = Number(process.env.MURMUR_WAKE_POLL_MS || 10000);
 const ONCE = process.argv.includes("--once");
@@ -92,8 +104,11 @@ function newRows(db, since) {
   ).all(since);
 }
 
-function emitAndExit(rows, maxid) {
-  writeCursor(maxid);
+function emitAndExit(rows) {
+  // Advance to the last row we are about to REPORT, never to the table's tip: a message
+  // landing between the SELECT and the tip query would be skipped over by the cursor and
+  // would then never wake anyone.
+  writeCursor(rows[rows.length - 1].rowid);
   releaseLock();
   const lines = rows.map((r) => `  rowid=${r.rowid} [${r.sender}] ${r.snippet}`);
   process.stderr.write(
@@ -125,9 +140,20 @@ function releaseLock() {
   if (haveLock) { try { rmSync(LOCK, { force: true }); } catch {} haveLock = false; }
 }
 
+// Never exit non-zero on a fault: that would wake the session with a false alarm. But
+// never exit SILENTLY either — a hook that dies without a word is the exact failure this
+// script exists to fix. One line on stderr is visible when run by hand and harmless to
+// the harness at exit 0.
+function bail(what, err) {
+  const detail = err instanceof Error ? err.message : String(err ?? "");
+  process.stderr.write(`murmur wake: ${what}${detail ? `: ${detail}` : ""} (db=${DB})\n`);
+  releaseLock();
+  process.exit(0);
+}
+
 async function main() {
-  // DB not present (daemon never started) → nothing to do.
-  try { statSync(DB); } catch { process.exit(0); }
+  // DB not present (daemon never started) → nothing to do, and say which path was tried.
+  try { statSync(DB); } catch (err) { bail("store not readable", err); }
 
   // First run ever: establish a baseline at the current tip, do not dump history.
   let cursorExists = true;
@@ -144,9 +170,8 @@ async function main() {
     const db = openDb();
     const since = readCursor();
     const rows = newRows(db, since);
-    const maxid = maxInbound(db);
     db.close();
-    if (rows.length) emitAndExit(rows, maxid);
+    if (rows.length) emitAndExit(rows);
     process.exit(0);
   }
 
@@ -159,13 +184,12 @@ async function main() {
     const db = openDb();
     const since = readCursor();
     const rows = newRows(db, since);
-    const maxid = maxInbound(db);
     db.close();
-    if (rows.length) emitAndExit(rows, maxid);
+    if (rows.length) emitAndExit(rows);
     await sleep(POLL_MS);
   }
   releaseLock();
   process.exit(0);
 }
 
-main().catch(() => { releaseLock(); process.exit(0); });
+main().catch((err) => bail("drain failed", err));

--- a/scripts/wake-drain-claude.sh
+++ b/scripts/wake-drain-claude.sh
@@ -15,7 +15,7 @@
 #   MURMUR_WAKE_SESSION_KEY overrides the session key used to build the default cursor
 set -uo pipefail
 
-DB="${MURMUR_DB:-/opt/lifecoach/murmur/.data/murmur.db}"
+DB="${MURMUR_DB:-.data/murmur.db}"
 
 # ── ключ сессии: свой курсор у каждой сессии ─────────────────────────────
 # WHY (26.08.2026): общий курсор на всех означает, что первая же сессия, дошедшая

--- a/tests/wake-drain-claude-node.test.mjs
+++ b/tests/wake-drain-claude-node.test.mjs
@@ -1,0 +1,161 @@
+// The node port of wake-drain-claude.sh (Windows / no sqlite3 CLI). Mirrors the shell
+// suite, plus the cases the port itself introduced: a lock, a session key, and faults
+// that must be reported instead of swallowed.
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+
+const script = path.resolve("scripts/wake-drain-claude.mjs");
+
+function withDb() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-wake-node-"));
+  const dbPath = path.join(dir, "murmur.db");
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE local_messages (
+      msg_id TEXT PRIMARY KEY,
+      created_at TEXT,
+      sender TEXT,
+      conversation_id TEXT,
+      direction TEXT,
+      text TEXT
+    );
+  `);
+  return { db, dbPath, dir, cursorPath: path.join(dir, "cursor"), lockPath: path.join(dir, "lock") };
+}
+
+function insertMessage(db, { msgId, direction = "inbound", sender = "agent-jarvis", text = "hello" }) {
+  db.prepare(`
+    INSERT INTO local_messages (msg_id, created_at, sender, conversation_id, direction, text)
+    VALUES (?, '2026-08-28T00:00:00.000Z', ?, 'codex:task:test', ?, ?)
+  `).run(msgId, sender, direction, text);
+}
+
+function drain(ctx, extraEnv = {}) {
+  return spawnSync(process.execPath, ["--no-warnings", script, "--once"], {
+    env: {
+      ...process.env,
+      MURMUR_DB: ctx.dbPath,
+      MURMUR_WAKE_CURSOR: ctx.cursorPath,
+      MURMUR_WAKE_LOCK: ctx.lockPath,
+      ...extraEnv,
+    },
+    encoding: "utf8",
+  });
+}
+
+test("node drain seeds the cursor to the tip on first run and stays silent", () => {
+  const ctx = withDb();
+  insertMessage(ctx.db, { msgId: "old-1", text: "history one" });
+  insertMessage(ctx.db, { msgId: "old-2", text: "history two" });
+
+  const result = drain(ctx);
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, "");
+  assert.equal(fs.readFileSync(ctx.cursorPath, "utf8").trim(), "2");
+});
+
+test("node drain emits new inbound rows and advances the cursor", () => {
+  const ctx = withDb();
+  drain(ctx); // seed
+
+  insertMessage(ctx.db, { msgId: "in-1", text: "first\nline" });
+  insertMessage(ctx.db, { msgId: "out-1", direction: "outbound", text: "ignore me" });
+  insertMessage(ctx.db, { msgId: "in-2", sender: "agent-peer", text: "second" });
+
+  const result = drain(ctx);
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Murmur wake: 2 new inbound message\(s\):/);
+  assert.match(result.stderr, /rowid=1 \[agent-jarvis\] first line/);
+  assert.match(result.stderr, /rowid=3 \[agent-peer\] second/);
+  assert.doesNotMatch(result.stderr, /ignore me/);
+  assert.equal(fs.readFileSync(ctx.cursorPath, "utf8").trim(), "3");
+});
+
+test("node drain dedups: the same message does not wake twice", () => {
+  const ctx = withDb();
+  drain(ctx);
+  insertMessage(ctx.db, { msgId: "in-1", text: "first" });
+
+  assert.equal(drain(ctx).status, 2);
+  const second = drain(ctx);
+
+  assert.equal(second.status, 0);
+  assert.equal(second.stderr, "");
+});
+
+// The cursor must land on the last row that was REPORTED. Advancing it to the table's
+// tip instead skips anything inserted between the SELECT and the tip query — that row
+// then never wakes anyone.
+test("node drain never advances the cursor past a row it did not report", () => {
+  const ctx = withDb();
+  drain(ctx);
+  insertMessage(ctx.db, { msgId: "in-1", text: "reported" });
+
+  const result = drain(ctx);
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /reported/);
+  assert.equal(fs.readFileSync(ctx.cursorPath, "utf8").trim(), "1", "cursor = last reported rowid");
+});
+
+test("node drain keeps a separate cursor per session key", () => {
+  const ctx = withDb();
+  const homeA = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-node-home-a-"));
+  const homeB = fs.mkdtempSync(path.join(os.tmpdir(), "murmur-node-home-b-"));
+
+  const drainAs = (home, sessionKey) =>
+    spawnSync(process.execPath, ["--no-warnings", script, "--once"], {
+      env: {
+        ...process.env,
+        MURMUR_DB: ctx.dbPath,
+        MURMUR_WAKE_CURSOR: "",
+        MURMUR_WAKE_LOCK: "",
+        HOME: home,
+        USERPROFILE: home,
+        CLAUDE_CODE_SESSION_ID: sessionKey,
+      },
+      encoding: "utf8",
+    });
+
+  assert.equal(drainAs(homeA, "aaaaaaaa-1111").status, 0);
+  assert.equal(drainAs(homeB, "bbbbbbbb-2222").status, 0);
+
+  insertMessage(ctx.db, { msgId: "in-1", text: "one message, two sessions" });
+
+  assert.equal(drainAs(homeA, "aaaaaaaa-1111").status, 2, "session A must wake");
+  assert.equal(drainAs(homeB, "bbbbbbbb-2222").status, 2, "session B must wake on the same message");
+
+  assert.ok(fs.existsSync(path.join(homeA, ".murmur-wake-cursor-aaaaaaaa")));
+  assert.ok(fs.existsSync(path.join(homeB, ".murmur-wake-cursor-bbbbbbbb")));
+});
+
+// A hook that dies without a word is the failure this script was written to fix, so a
+// fault reports the reason. It still exits 0: a non-zero exit would wake the session
+// with a false alarm.
+test("node drain reports a missing store instead of exiting silently", () => {
+  const ctx = withDb();
+  const result = drain(ctx, { MURMUR_DB: path.join(ctx.dir, "nope.db") });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stderr, /murmur wake: store not readable/);
+  assert.match(result.stderr, /nope\.db/);
+});
+
+test("node drain reports an unreadable store instead of exiting silently", () => {
+  const ctx = withDb();
+  drain(ctx); // seed, so the run gets past the baseline branch
+  fs.writeFileSync(ctx.dbPath, "this is not a sqlite database");
+
+  const result = drain(ctx);
+
+  assert.equal(result.status, 0);
+  assert.match(result.stderr, /murmur wake: drain failed/);
+});


### PR DESCRIPTION
Follow-up to #115 by @lichtpfad, merged as-is first so the contribution keeps its
authorship. Four things the port needed:

1. **Per-session cursor and lock.** #115 was written against main before #111 landed, so
   the node drain kept the old shared cursor while the shell drain moved to a
   per-session one — one message would wake the first session to reach the hook and no
   other. Same env contract now (`MURMUR_WAKE_SESSION_KEY`, else
   `CLAUDE_CODE_SESSION_ID`).

2. **Cursor bound to what was reported.** It advanced to `MAX(rowid)` taken in a second
   query, so a row inserted between the SELECT and that query was stepped over and never
   woke anyone. Now it advances to the last reported row. (Same latent bug exists in the
   shell version; fixed there separately if it shows up.)

3. **Faults are reported.** `main().catch(() => process.exit(0))` swallowed everything.
   Verified against the merged script: a corrupt store, a missing `local_messages` table
   and a Node without `node:sqlite` all exited 0 with no output — indistinguishable from
   "no new messages", which is precisely the silent-hook failure this port was written to
   remove. Now one line on stderr; the exit code stays 0 so a fault never fakes a wake.

4. **No private paths.** `MURMUR_DB` defaulted to `/opt/lifecoach/mur-mur-v2/.data/murmur.db`
   — one machine's home, inherited from the shell script. Defaults to `.data/murmur.db`
   now (what `SQLiteMessageStore` itself uses), in the node drain, the shell drain and the
   cold-idle watcher. `scripts/murmur-to-acp-producer.sh` execed an absolute path that
   exists nowhere outside that machine; it resolves relative to the repo now.

## Tests

`tests/wake-drain-claude-node.test.mjs` — the port shipped without any: seed-to-tip,
emit + cursor advance, dedup, the cursor bound, the per-session split (one message wakes
two sessions), and both fault paths.

140/140 green.