### PR TITLE
feat(phase-n): route messages by member identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Phase N structured member routing** — optional signed `channelId`, `senderMemberId`,
+  and `addresseeMemberId` fields now flow through the envelope, MCP send/request tools,
+  durable inbox, daemon roster policy, receive-hook environment, and shell sender. Legacy
+  fieldless envelopes remain byte-identical. `murmur_request` can distinguish replies from
+  multiple members sharing one transport agent. The receive-time wake decision is persisted
+  so observer-muted history cannot wake through delayed backlog processing, and configured
+  proxy subjects apply the same structured member-addressing decision.
+
 ### Pending
 - **NATS transport security (TLS + per-peer auth)** — reviewed and CI-green in #103, held for a coordinated broker/peer credential cutover. It intentionally makes existing non-loopback `nats://` configurations fail closed, so it ships with a maintenance window, not as a routine merge. Two gaps to close first: the Kubernetes ACL example does not cover JetStream subjects (`$JS.API.*`, `$JS.ACK.*`, `_INBOX.*`), and the dashboard's NATS client supports a token only, no user/password or CA.
 - **Turning on `ackSecurity.requireSigned`** — a rollout step, not a code step. Until every peer runs 2.5.0+ and the flag is set, unsigned ACKs are still accepted.

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ murmur_send(to: "bob", text: "Hello from Alice!")
 murmur_request(to: "bob", text: "Review this code please", timeout_ms: 300000)
 ```
 
+For Phase N member-level addressing, configure a stable local `memberId` and the
+peer's `channelId` / `memberId`, or pass `channelId`, `senderMemberId`, and
+`addresseeMemberId` to `murmur_send` / `murmur_request`. Enable the same channel roster
+on every receiving daemon. See [the coordinated routing rollout](docs/phase-n-routing.md).
+
 That's it. Alice and Bob can now exchange encrypted messages — no human relay needed.
 
 ---

--- a/docs/phase-n-routing.md
+++ b/docs/phase-n-routing.md
@@ -1,0 +1,71 @@
+# Phase N structured member routing
+
+Murmur has three separate identities:
+
+- `senderAgentId` / `recipients` identify encrypted transport peers.
+- `channelId` + `memberId` identify stable logical members in a typed channel roster.
+- `conversationId` labels message history or a live client session; it is not membership.
+
+Keeping these separate lets multiple logical members share one daemon or transport key
+without inventing routing headers inside message text.
+
+## Configuration
+
+The MCP server and shell sender accept explicit `channelId`, `senderMemberId`, and
+`addresseeMemberId` values. They may also default from private `agent-config.json`:
+
+```json
+{
+  "agentId": "transport-a",
+  "memberId": "member-a",
+  "peers": {
+    "transport-b": {
+      "subject": "msg.transport-b",
+      "channelId": "channel-example",
+      "memberId": "member-b"
+    }
+  },
+  "channelRoster": {
+    "enabled": true,
+    "path": ".data/channel-roster.db"
+  }
+}
+```
+
+The omitted key blocks are unchanged. Do not commit private keys, broker credentials, or
+production-specific member names. Populate the same roster on every receiver before
+enabling structured sends.
+
+## Receive hooks
+
+Alongside the existing message variables, `onReceive` and `wake.auditHook` receive:
+
+- `MURMUR_CHANNEL_ID`
+- `MURMUR_SENDER_MEMBER_ID`
+- `MURMUR_ADDRESSEE_MEMBER_ID`
+
+They are empty for a legacy envelope. Routing metadata stays out of decrypted message
+text and is returned separately by `murmur_inbox`.
+
+The daemon also persists its local receive-time wake decision. Observer copies remain in
+channel history but stay muted when processed later through the durable backlog. Existing
+rows without that local decision retain legacy wake behavior.
+
+Configured proxy subjects apply the same roster decision for the proxy agent derived from
+the subject before any proxy wake effect runs. Fieldless proxy traffic retains its legacy
+behavior.
+
+## Coordinated rollout
+
+1. Upgrade and build every peer while leaving existing fieldless sends unchanged.
+2. Create the identical typed channel and member roster on every receiving host.
+3. Enable `channelRoster` on receivers and verify legacy delivery still works.
+4. Add private local/peer member defaults or pass explicit fields at the sender.
+5. Test an addressed message and reply in each direction, then test two members sharing
+   one transport agent to confirm request correlation and wake selection.
+
+Receivers with the roster enabled reject unknown channels, unknown or mismatched sender
+members, closed channels, and unknown addressees. An addressed observer may retain the
+message in channel history but does not wake. Disabling structured sends is the rollback:
+fieldless envelopes retain legacy v1 behaviour. Disable the roster only after all queued
+structured messages have drained.

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -23,7 +23,8 @@ discriminated structurally — `presenceVersion: "1.0"` for presence, `kind` for
 - **Forward-compatible reads.** Unknown top-level fields are **permitted and ignored**
   (no `additionalProperties: false`). A future minor MAY add optional fields without
   bumping `schemaVersion`; older consumers ignore them. Current optional fields:
-  `ttlSeconds`, `traceId`, `sequence`, `parentMsgId`.
+  `ttlSeconds`, `traceId`, `sequence`, `parentMsgId`, `channelId`,
+  `senderMemberId`, `addresseeMemberId`, `authToken`.
 - **Breaking change ⇒ new version.** Removing/renaming a required field, changing a
   type, or tightening an enum bumps `schemaVersion` (e.g. `2.0`). Consumers gate on it.
 - **Signature/crypto are out of band of the schema.** The schema validates *shape*;
@@ -49,7 +50,15 @@ discriminated structurally — `presenceVersion: "1.0"` for presence, `kind` for
 | `traceId` | — | string | |
 | `sequence` | — | number | |
 | `parentMsgId` | — | string | |
+| `channelId` | — | string | non-empty; requires `senderMemberId` |
+| `senderMemberId` | — | string | non-empty; requires `channelId` |
+| `addresseeMemberId` | — | string | non-empty; requires `channelId` |
 | `authToken` | — | string | non-empty if present; bearer (`MURMUR-AUTH:…`) |
+
+The Phase N routing fields are covered by the envelope signature. Their order in the
+canonical signing payload is `channelId`, `senderMemberId`, `addresseeMemberId`, followed
+by `authToken`. If all three are absent, the signing bytes and delivery semantics are
+identical to legacy v1 envelopes.
 
 **`authToken` is part of the signed payload.** When present it is appended to
 `stableEnvelopePayload` in a fixed final position, so it cannot be stripped or swapped

--- a/docs/protocol-v1.md
+++ b/docs/protocol-v1.md
@@ -52,6 +52,20 @@ helper gated by `MURMUR_ENFORCE_AUTH`) is forthcoming in auth/authz #47 PR-D. Ab
 un-authenticated envelopes, which sign byte-identically to before the field existed —
 see [`protocol-compatibility.md`](protocol-compatibility.md).
 
+### Typed channel identity and addressing
+
+Phase N messages may carry the signed routing tuple `channelId`, `senderMemberId`, and
+optional `addresseeMemberId`. `memberId` is stable within a channel and is distinct from
+both the transport-level `senderAgentId` and the history/session label `conversationId`.
+This lets several logical members share one transport agent while replies still correlate
+to the intended member.
+
+`channelId` and `senderMemberId` must appear together; `addresseeMemberId` requires them.
+When the daemon's channel roster is enabled, it verifies the authenticated sender owns
+`senderMemberId`, rejects unknown/closed channels or non-members, stores broadcasts for
+the channel, and wakes only the explicit addressee. With no routing tuple, v1 legacy
+delivery remains unchanged. See [`phase-n-routing.md`](phase-n-routing.md) for rollout.
+
 ## Delivery model
 - at-least-once delivery
 - idempotent consumers mandatory

--- a/packages/core/schema/protocol-v1.schema.json
+++ b/packages/core/schema/protocol-v1.schema.json
@@ -33,10 +33,18 @@
         "traceId": { "type": "string" },
         "sequence": { "type": "number" },
         "parentMsgId": { "type": "string" },
+        "channelId": { "type": "string", "minLength": 1 },
+        "senderMemberId": { "type": "string", "minLength": 1 },
+        "addresseeMemberId": { "type": "string", "minLength": 1 },
         "authToken": { "type": "string", "minLength": 1 },
         "payloadCiphertext": { "type": "string", "minLength": 1 },
         "payloadNonce": { "type": "string", "minLength": 1 },
         "signature": { "type": "string", "minLength": 1 }
+      },
+      "dependentRequired": {
+        "channelId": ["senderMemberId"],
+        "senderMemberId": ["channelId"],
+        "addresseeMemberId": ["channelId"]
       }
     },
     "AckV1": {

--- a/packages/core/src/channel.ts
+++ b/packages/core/src/channel.ts
@@ -70,6 +70,7 @@ export interface ChannelAddressingInput {
   channelId?: string;
   selfAgentId: string;
   senderAgentId?: string;
+  senderMemberId?: string;
   addresseeMemberId?: string;
   addresseeAgentId?: string;
 }
@@ -418,8 +419,12 @@ export class ChannelRosterStore {
       return { allowAppend: false, allowWake: false, reject: true, reason: "self-not-member", channel };
     }
 
-    const senderMember = input.senderAgentId ? this.findActiveChannelMemberForAgent(input.channelId, input.senderAgentId) : undefined;
-    if (input.senderAgentId && !senderMember) {
+    const senderMember = input.senderMemberId
+      ? this.getChannelMember(input.channelId, input.senderMemberId)
+      : input.senderAgentId
+        ? this.findActiveChannelMemberForAgent(input.channelId, input.senderAgentId)
+        : undefined;
+    if (input.senderAgentId && (!senderMember || senderMember.leftAt || senderMember.agentId !== input.senderAgentId)) {
       return { allowAppend: false, allowWake: false, reject: true, reason: "sender-not-member", channel, selfMember };
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,10 @@ export interface EnvelopeV1 {
   traceId?: string;
   sequence?: number;
   parentMsgId?: string;
+  /** Phase N routing identity. Member ids are scoped to channelId. */
+  channelId?: string;
+  senderMemberId?: string;
+  addresseeMemberId?: string;
   /** Optional bearer auth token (`MURMUR-AUTH:...`) authorizing the sender. When present
    *  it is part of the signed payload (so it can't be stripped/swapped) and can be
    *  verified with @murmurv2/federation `verifyAuthToken`. Ingress enforcement (an
@@ -114,6 +118,11 @@ export const stableEnvelopePayload = (envelope: EnvelopeV1): string =>
     createdAt: envelope.createdAt,
     payloadCiphertext: envelope.payloadCiphertext,
     payloadNonce: envelope.payloadNonce,
+    // Phase N identity is optional and appended only when present. Legacy
+    // envelopes therefore retain their byte-identical signing payload.
+    ...(envelope.channelId !== undefined ? { channelId: envelope.channelId } : {}),
+    ...(envelope.senderMemberId !== undefined ? { senderMemberId: envelope.senderMemberId } : {}),
+    ...(envelope.addresseeMemberId !== undefined ? { addresseeMemberId: envelope.addresseeMemberId } : {}),
     // authToken is appended ONLY when present, in a fixed final position: envelopes
     // without it sign byte-identically to before this field existed (back-compat),
     // and when present it is covered by the signature so it can't be stripped/swapped.
@@ -773,6 +782,11 @@ export interface LocalMessageRecord {
   text: string;
   createdAt: string;
   transport?: string;
+  channelId?: string;
+  senderMemberId?: string;
+  addresseeMemberId?: string;
+  /** Local receive-time authorization decision; never transported on EnvelopeV1. */
+  wakeEligible?: boolean;
 }
 
 /**
@@ -820,7 +834,11 @@ export class SQLiteMessageStore {
         sender TEXT NOT NULL,
         text TEXT NOT NULL,
         created_at TEXT NOT NULL,
-        transport TEXT
+        transport TEXT,
+        channel_id TEXT,
+        sender_member_id TEXT,
+        addressee_member_id TEXT,
+        wake_eligible INTEGER
       );
       CREATE INDEX IF NOT EXISTS idx_local_messages_conversation ON local_messages(conversation_id, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_local_messages_text ON local_messages(text);
@@ -839,6 +857,13 @@ export class SQLiteMessageStore {
       CREATE INDEX IF NOT EXISTS idx_message_events_conversation ON message_events(conversation_id, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_message_events_relates ON message_events(relates_to);
     `);
+    const messageColumns = new Set(
+      (this.db.prepare("PRAGMA table_info(local_messages)").all() as Array<{ name: string }>).map((column) => column.name),
+    );
+    if (!messageColumns.has("channel_id")) this.db.exec("ALTER TABLE local_messages ADD COLUMN channel_id TEXT");
+    if (!messageColumns.has("sender_member_id")) this.db.exec("ALTER TABLE local_messages ADD COLUMN sender_member_id TEXT");
+    if (!messageColumns.has("addressee_member_id")) this.db.exec("ALTER TABLE local_messages ADD COLUMN addressee_member_id TEXT");
+    if (!messageColumns.has("wake_eligible")) this.db.exec("ALTER TABLE local_messages ADD COLUMN wake_eligible INTEGER");
     secureSqliteFiles(dbPath);
   }
 
@@ -946,8 +971,9 @@ export class SQLiteMessageStore {
     this.db
       .prepare(
         `INSERT INTO local_messages
-         (id, conversation_id, msg_id, direction, sender, text, created_at, transport)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+         (id, conversation_id, msg_id, direction, sender, text, created_at, transport,
+          channel_id, sender_member_id, addressee_member_id, wake_eligible)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         row.id,
@@ -958,6 +984,10 @@ export class SQLiteMessageStore {
         row.text,
         row.createdAt,
         row.transport ?? null,
+        row.channelId ?? null,
+        row.senderMemberId ?? null,
+        row.addresseeMemberId ?? null,
+        row.wakeEligible === undefined ? null : Number(row.wakeEligible),
       );
     return row;
   }
@@ -986,7 +1016,10 @@ export class SQLiteMessageStore {
            sender,
            text,
            created_at as createdAt,
-           transport
+           transport,
+           channel_id as channelId,
+           sender_member_id as senderMemberId,
+           addressee_member_id as addresseeMemberId
          FROM local_messages
          WHERE conversation_id = ? AND direction = 'inbound' AND created_at > ?
          ORDER BY created_at ASC
@@ -1016,7 +1049,10 @@ export class SQLiteMessageStore {
            sender,
            text,
            created_at as createdAt,
-           transport
+           transport,
+           channel_id as channelId,
+           sender_member_id as senderMemberId,
+           addressee_member_id as addresseeMemberId
          FROM local_messages
          WHERE direction = 'inbound'
          ORDER BY created_at DESC, rowid DESC
@@ -1038,7 +1074,10 @@ export class SQLiteMessageStore {
            sender,
            text,
            created_at as createdAt,
-           transport
+           transport,
+           channel_id as channelId,
+           sender_member_id as senderMemberId,
+           addressee_member_id as addresseeMemberId
          FROM local_messages
          WHERE text LIKE ? OR sender LIKE ? OR conversation_id LIKE ?
          ORDER BY created_at DESC
@@ -1638,6 +1677,14 @@ export const isEnvelopeV1 = (v: unknown): v is EnvelopeV1 => {
     hasOptional("traceId", "string") &&
     hasOptional("sequence", "number") &&
     hasOptional("parentMsgId", "string") &&
+    hasOptional("channelId", "string") &&
+    hasOptional("senderMemberId", "string") &&
+    hasOptional("addresseeMemberId", "string") &&
+    (o.channelId === undefined || (typeof o.channelId === "string" && o.channelId.length > 0)) &&
+    (o.senderMemberId === undefined || (typeof o.senderMemberId === "string" && o.senderMemberId.length > 0)) &&
+    (o.addresseeMemberId === undefined || (typeof o.addresseeMemberId === "string" && o.addresseeMemberId.length > 0)) &&
+    (o.channelId === undefined) === (o.senderMemberId === undefined) &&
+    (o.addresseeMemberId === undefined || o.channelId !== undefined) &&
     // authToken: optional, but if present must be a non-empty string (a bearer token)
     (o.authToken === undefined || (typeof o.authToken === "string" && o.authToken.length > 0))
   );

--- a/packages/core/test/conformance.test.mjs
+++ b/packages/core/test/conformance.test.mjs
@@ -6,7 +6,7 @@
 // StreamStart/StreamChunk/StreamEnd (+ the discriminated StreamFrame union). No external validator
 // dep: a tiny subset validator interprets the flat protocol $defs
 // (type incl. boolean / required / const / enum / minLength / pattern / minItems / items /
-// exclusiveMinimum / oneOf).
+// exclusiveMinimum / dependentRequired / oneOf).
 // The only runtime-only check is `format: date-time` validity, which Draft 2020-12 treats as an
 // advisory annotation (not an assertion); the guards enforce it via Date.parse and it sits outside
 // the agreement matrices (documented per-type). Everything else — including ttlMs > 0 and non-empty
@@ -55,6 +55,13 @@ function validate(def, value, p = "$") {
       for (const req of def.required ?? []) if (!(req in value)) errs.push(`${p}.${req}: required`);
       for (const [k, sub] of Object.entries(def.properties ?? {})) {
         if (k in value) errs.push(...validate(sub, value[k], `${p}.${k}`));
+      }
+      for (const [trigger, dependencies] of Object.entries(def.dependentRequired ?? {})) {
+        if (trigger in value) {
+          for (const dependency of dependencies) {
+            if (!(dependency in value)) errs.push(`${p}.${dependency}: required by ${trigger}`);
+          }
+        }
       }
       // unknown properties are intentionally allowed (forward compatibility)
       break;
@@ -153,6 +160,26 @@ test("optional fields + forward-compatible unknown fields are accepted by both",
   const e = { ...GOOD, ttlSeconds: 60, traceId: "t", sequence: 3, parentMsgId: "p", authToken: "MURMUR-AUTH:abc", futureFieldV2: "x" };
   assert.equal(envelopeOk(e), true);
   assert.equal(isEnvelopeV1(e), true);
+});
+
+test("Phase N routing fields are optional as a group and schema/runtime reject partial identity", () => {
+  const routed = {
+    ...GOOD,
+    channelId: "channel-1",
+    senderMemberId: "member-a",
+    addresseeMemberId: "member-b",
+  };
+  assert.equal(envelopeOk(routed), true);
+  assert.equal(isEnvelopeV1(routed), true);
+  for (const partial of [
+    { ...GOOD, channelId: "channel-1" },
+    { ...GOOD, senderMemberId: "member-a" },
+    { ...GOOD, addresseeMemberId: "member-b" },
+    { ...GOOD, channelId: "channel-1", addresseeMemberId: "member-b" },
+  ]) {
+    assert.equal(envelopeOk(partial), false);
+    assert.equal(isEnvelopeV1(partial), false);
+  }
 });
 
 test("AckV1: required fields + status enum", () => {

--- a/packages/core/test/stable-envelope-payload.test.mjs
+++ b/packages/core/test/stable-envelope-payload.test.mjs
@@ -35,6 +35,19 @@ test("stableEnvelopePayload appends authToken ONLY when present (back-compat for
   );
 });
 
+test("stableEnvelopePayload signs Phase N routing fields in a fixed order", () => {
+  assert.equal(
+    stableEnvelopePayload({
+      ...ENV,
+      channelId: "channel-1",
+      senderMemberId: "member-a",
+      addresseeMemberId: "member-b",
+      authToken: "MURMUR-AUTH:tok",
+    }),
+    '{"schemaVersion":"1.0","msgId":"m1","conversationId":"c1","senderAgentId":"agent-a","recipients":["agent-b","agent-c"],"createdAt":"2026-06-22T00:00:00.000Z","payloadCiphertext":"ct","payloadNonce":"no","channelId":"channel-1","senderMemberId":"member-a","addresseeMemberId":"member-b","authToken":"MURMUR-AUTH:tok"}',
+  );
+});
+
 test("stableEnvelopePayload excludes the signature field (it is what gets signed)", () => {
   const signed = stableEnvelopePayload(ENV);
   const unsigned = stableEnvelopePayload({ ...ENV, signature: "" });

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -31,6 +31,7 @@ interface JsonRpcRequest {
 
 interface AgentConfig {
   agentId: string;
+  memberId?: string;
   natsUrl: string;
   natsToken?: string;
   subject: string;
@@ -45,6 +46,8 @@ interface AgentConfig {
       encryption: { publicKey: string };
       signing: { publicKey: string };
       subject: string;
+      channelId?: string;
+      memberId?: string;
     }
   >;
 }
@@ -154,7 +157,37 @@ const asMessage = (r: LocalMessageRecord): Record<string, unknown> => ({
   text: r.text,
   createdAt: r.createdAt,
   transport: r.transport,
+  channelId: r.channelId,
+  senderMemberId: r.senderMemberId,
+  addresseeMemberId: r.addresseeMemberId,
 });
+
+interface RoutingMetadata {
+  channelId?: string;
+  senderMemberId?: string;
+  addresseeMemberId?: string;
+}
+
+const optionalString = (value: unknown): string | undefined => {
+  if (value === undefined || value === null) return undefined;
+  const result = String(value).trim();
+  return result || undefined;
+};
+
+const resolveRoutingMetadata = (
+  args: Record<string, unknown>,
+  config: AgentConfig,
+  peer: AgentConfig["peers"][string],
+): RoutingMetadata => {
+  const channelId = optionalString(args.channelId) ?? optionalString(peer.channelId);
+  const senderMemberId = optionalString(args.senderMemberId) ?? optionalString(config.memberId);
+  const addresseeMemberId = optionalString(args.addresseeMemberId) ?? optionalString(peer.memberId);
+  if (!channelId && !senderMemberId && !addresseeMemberId) return {};
+  if (!channelId || !senderMemberId) {
+    throw new Error("channelId and senderMemberId are required together for structured routing");
+  }
+  return { channelId, senderMemberId, addresseeMemberId };
+};
 
 // --- Tool handlers ---
 const handleTool = async (name: string, args: Record<string, unknown>): Promise<unknown> => {
@@ -240,6 +273,7 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
         channelId: args.channelId === undefined ? undefined : String(args.channelId),
         selfAgentId,
         senderAgentId: args.senderAgentId === undefined ? undefined : String(args.senderAgentId),
+        senderMemberId: args.senderMemberId === undefined ? undefined : String(args.senderMemberId),
         addresseeMemberId: args.addresseeMemberId === undefined ? undefined : String(args.addresseeMemberId),
         addresseeAgentId: args.addresseeAgentId === undefined ? undefined : String(args.addresseeAgentId),
       }),
@@ -261,6 +295,7 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
 
     const conversationId = String(args.conversationId ?? `dm:${agentConfig.agentId}:${to}`);
     const msgId = randomUUID();
+    const routing = resolveRoutingMetadata(args, agentConfig, peer);
 
     // Encrypt
     const encrypted = await encryptPayload(
@@ -280,6 +315,7 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
       payloadCiphertext: encrypted.ciphertext,
       payloadNonce: encrypted.nonce,
       signature: "",
+      ...routing,
     };
 
     // Sign
@@ -300,9 +336,10 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
       text,
       createdAt: envelope.createdAt,
       transport: "nats",
+      ...routing,
     });
 
-    return { msgId, to, conversationId, status: "queued" };
+    return { msgId, to, conversationId, status: "queued", ...routing };
   }
 
   if (name === "murmur_inbox") {
@@ -335,6 +372,7 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
     const conversationId = String(args.conversationId ?? `dm:${agentConfig.agentId}:${to}`);
     const msgId = randomUUID();
     const sentAt = new Date().toISOString();
+    const routing = resolveRoutingMetadata(args, agentConfig, peer);
 
     // Encrypt
     const encrypted = await encryptPayload(
@@ -354,6 +392,7 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
       payloadCiphertext: encrypted.ciphertext,
       payloadNonce: encrypted.nonce,
       signature: "",
+      ...routing,
     };
 
     // Sign
@@ -374,6 +413,7 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
       text,
       createdAt: sentAt,
       transport: "nats",
+      ...routing,
     });
 
     // Wait for the reply. Store polling is the durable fallback and always runs;
@@ -382,7 +422,7 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
     // signal-only — the daemon stays the source of truth for decrypt + persistence.
     const graceMs = Number(args.grace_ms ?? 250);
     const deadline = Date.now() + timeoutMs;
-    const matchReply = buildReplyMatcher(conversationId, to);
+    const matchReply = buildReplyMatcher(conversationId, to, routing.addresseeMemberId);
 
     const broker = await getWakeBroker();
     // Holder object: the tap is attached inside a callback, so a plain `let` would be
@@ -415,8 +455,11 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
     try {
       reply = await waitForReply({
         checkStore: async () => {
-          const inbound = await store.getInboundAfter(conversationId, sentAt, 1);
-          return inbound.length > 0 ? inbound[0] : null;
+          const inbound = await store.getInboundAfter(conversationId, sentAt, 50);
+          return inbound.find((row) =>
+            row.sender === to &&
+            (!routing.addresseeMemberId || row.senderMemberId === routing.addresseeMemberId)
+          ) ?? null;
         },
         pollMs,
         graceMs,
@@ -440,6 +483,7 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
         msgId,
         conversationId,
         sentAt,
+        ...routing,
         reply: asMessage(reply),
         // Precise telemetry (per CODEX-VOLT review): tapAttached = the read-only NATS
         // tap was live for this wait; wokenBySignal = a matching envelope actually
@@ -454,6 +498,7 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
       msgId,
       conversationId,
       sentAt,
+      ...routing,
       timeout_ms: timeoutMs,
       hint: "Use murmur_inbox to check for late responses",
     };
@@ -465,6 +510,8 @@ const handleTool = async (name: string, args: Record<string, unknown>): Promise<
     const peerList = Object.entries(agentConfig.peers).map(([id, p]) => ({
       agentId: id,
       subject: p.subject,
+      channelId: p.channelId,
+      memberId: p.memberId,
       hasEncryptionKey: !!p.encryption?.publicKey,
       hasSigningKey: !!p.signing?.publicKey,
     }));
@@ -575,6 +622,7 @@ const tools = [
         channelId: { type: "string" },
         selfAgentId: { type: "string" },
         senderAgentId: { type: "string" },
+        senderMemberId: { type: "string" },
         addresseeMemberId: { type: "string" },
         addresseeAgentId: { type: "string" },
       },
@@ -591,6 +639,9 @@ const tools = [
         to: { type: "string", description: "Recipient agent ID (must be in peers config)" },
         text: { type: "string", description: "Message text (will be encrypted)" },
         conversationId: { type: "string", description: "Optional conversation ID" },
+        channelId: { type: "string", description: "Optional typed-channel ID; may default from peer config" },
+        senderMemberId: { type: "string", description: "Optional sender member identity; may default from local config" },
+        addresseeMemberId: { type: "string", description: "Optional target member identity; may default from peer config" },
       },
       required: ["to", "text"],
     },
@@ -605,6 +656,9 @@ const tools = [
         to: { type: "string", description: "Recipient agent ID (must be in peers config)" },
         text: { type: "string", description: "Message text (will be encrypted)" },
         conversationId: { type: "string", description: "Optional conversation ID" },
+        channelId: { type: "string", description: "Optional typed-channel ID; may default from peer config" },
+        senderMemberId: { type: "string", description: "Optional sender member identity; may default from local config" },
+        addresseeMemberId: { type: "string", description: "Optional target member identity; may default from peer config" },
         timeout_ms: { type: "number", description: "Max wait time in ms (default: 300000 = 5 min)" },
         poll_interval_ms: { type: "number", description: "Store-poll fallback interval in ms (default: 10000 = 10s)" },
         grace_ms: { type: "number", description: "Delay after a wake signal before re-checking the store, to let the daemon persist (default: 250)" },

--- a/packages/mcp-server/src/request-reply.ts
+++ b/packages/mcp-server/src/request-reply.ts
@@ -82,6 +82,8 @@ export async function waitForReply(deps: ReplyWaiterDeps): Promise<LocalMessageR
  * plaintext (conversationId / senderAgentId), so this needs no decryption.
  */
 export const buildReplyMatcher =
-  (conversationId: string, fromAgentId: string) =>
-  (envelope: { conversationId: string; senderAgentId: string }): boolean =>
-    envelope.conversationId === conversationId && envelope.senderAgentId === fromAgentId;
+  (conversationId: string, fromAgentId: string, fromMemberId?: string) =>
+  (envelope: { conversationId: string; senderAgentId: string; senderMemberId?: string }): boolean =>
+    envelope.conversationId === conversationId &&
+    envelope.senderAgentId === fromAgentId &&
+    (!fromMemberId || envelope.senderMemberId === fromMemberId);

--- a/scripts/murmur-daemon.mjs
+++ b/scripts/murmur-daemon.mjs
@@ -193,7 +193,11 @@ const loadInboundAfter = async (cursor) => {
          msg_id as msgId,
          sender as "from",
          text,
-         created_at as ts
+         created_at as ts,
+         channel_id as channelId,
+         sender_member_id as senderMemberId,
+         addressee_member_id as addresseeMemberId,
+         wake_eligible as wakeEligible
        FROM local_messages
        WHERE direction = 'inbound' AND rowid > ?
        ORDER BY rowid ASC
@@ -205,6 +209,11 @@ const loadInboundAfter = async (cursor) => {
     text: row.text,
     msgId: row.msgId,
     conversationId: row.conversationId,
+    channelId: row.channelId || undefined,
+    senderMemberId: row.senderMemberId || undefined,
+    addresseeMemberId: row.addresseeMemberId || undefined,
+    // NULL is a pre-Phase-N/legacy row and retains legacy wake behavior.
+    wakeEligible: row.wakeEligible === null ? true : Boolean(row.wakeEligible),
     ts: row.ts,
     cursor: Number(row.cursor),
   }));
@@ -272,6 +281,16 @@ const onMessage = async (envelope) => {
     keys.encryption.privateKey,
   );
 
+  const addressing = channelRosterStore?.evaluateAddressing({
+    channelId: envelope.channelId,
+    selfAgentId: agentId,
+    senderAgentId: senderId,
+    senderMemberId: envelope.senderMemberId,
+    addresseeMemberId: envelope.addresseeMemberId,
+  });
+  if (addressing?.reject) throw new Error(`channel-addressing-rejected:${addressing.reason}`);
+  const wakeEligible = addressing?.allowWake !== false;
+
   await msgStore.append({
     conversationId: envelope.conversationId,
     msgId: envelope.msgId,
@@ -280,12 +299,20 @@ const onMessage = async (envelope) => {
     text: plaintext,
     createdAt: envelope.createdAt,
     transport: "nats",
+    channelId: envelope.channelId,
+    senderMemberId: envelope.senderMemberId,
+    addresseeMemberId: envelope.addresseeMemberId,
+    wakeEligible,
   });
 
   log("info", "Message received", {
     msgId: envelope.msgId,
     from: senderId,
     conversationId: envelope.conversationId,
+    channelId: envelope.channelId,
+    senderMemberId: envelope.senderMemberId,
+    addresseeMemberId: envelope.addresseeMemberId,
+    wakeEligible,
     textLen: plaintext.length,
   });
 
@@ -294,11 +321,15 @@ const onMessage = async (envelope) => {
     text: plaintext,
     msgId: envelope.msgId,
     conversationId: envelope.conversationId,
+    channelId: envelope.channelId,
+    senderMemberId: envelope.senderMemberId,
+    addresseeMemberId: envelope.addresseeMemberId,
+    wakeEligible,
     ts: new Date().toISOString(),
     cursor: inboundCursorForMsg(envelope.msgId),
   };
 
-  if (effectiveNotifyTargets.length > 0) {
+  if (effectiveNotifyTargets.length > 0 && wakeEligible) {
     notifyQueue.enqueueMessage(payload, effectiveNotifyTargets);
     log("info", "Notifications queued", {
       msgId: envelope.msgId,
@@ -306,7 +337,7 @@ const onMessage = async (envelope) => {
     });
   }
 
-  await wakeMonitor.onInbound(payload);
+  if (wakeEligible) await wakeMonitor.onInbound(payload);
 };
 
 let running = true;
@@ -360,16 +391,38 @@ try {
   // Also subscribe to proxy subjects (agents without their own daemon)
   const proxySubjects = (config.proxySubjects || []);
   for (const ps of proxySubjects) {
+    const proxyAgentId = ps.replace(/^msg\./, "");
     const proxyOnMessage = async (envelope, plaintext) => {
       const senderId = envelope.senderAgentId || "unknown";
-      log("info", "Proxy message received", { subject: ps, from: senderId, len: plaintext?.length });
+      const addressing = channelRosterStore?.evaluateAddressing({
+        channelId: envelope.channelId,
+        selfAgentId: proxyAgentId,
+        senderAgentId: senderId,
+        senderMemberId: envelope.senderMemberId,
+        addresseeMemberId: envelope.addresseeMemberId,
+      });
+      if (addressing?.reject) throw new Error(`channel-addressing-rejected:${addressing.reason}`);
+      const wakeEligible = addressing?.allowWake !== false;
+      log("info", "Proxy message received", {
+        subject: ps,
+        from: senderId,
+        channelId: envelope.channelId,
+        senderMemberId: envelope.senderMemberId,
+        addresseeMemberId: envelope.addresseeMemberId,
+        wakeEligible,
+        len: plaintext?.length,
+      });
       await proxyWakeMonitor.onInbound({
         from: senderId,
         text: plaintext ?? "",
         msgId: envelope.msgId,
         conversationId: envelope.conversationId,
+        channelId: envelope.channelId,
+        senderMemberId: envelope.senderMemberId,
+        addresseeMemberId: envelope.addresseeMemberId,
+        wakeEligible,
         ts: new Date().toISOString(),
-        env: { MURMUR_PROXY_AGENT: ps.replace("msg.", "") },
+        env: { MURMUR_PROXY_AGENT: proxyAgentId },
       });
     };
     await broker.subscribeWithAck({ subject: ps, consumerId: `${agentId}-proxy-${durableSafe(ps)}`, dedupe: store, onMessage: proxyOnMessage });

--- a/scripts/murmur-shell-send.mjs
+++ b/scripts/murmur-shell-send.mjs
@@ -15,6 +15,9 @@ for (let i = 0; i < args.length; i += 1) {
   const a = args[i];
   if (a === "--to") opt.to = args[++i];
   else if (a === "--conv" || a === "--conversation") opt.conversationId = args[++i];
+  else if (a === "--channel") opt.channelId = args[++i];
+  else if (a === "--sender-member") opt.senderMemberId = args[++i];
+  else if (a === "--addressee-member") opt.addresseeMemberId = args[++i];
   else if (a === "--text") opt.text = args[++i];
   else if (a === "--text-file") opt.textFile = args[++i];
   else if (a === "--stdin") opt.stdin = true;
@@ -23,7 +26,7 @@ for (let i = 0; i < args.length; i += 1) {
 
 if (opt.help || !opt.to || (!opt.text && !opt.textFile && !opt.stdin)) {
   process.stderr.write(
-    "usage: murmur-shell-send.mjs --to <peer-id> (--text <txt> | --text-file <path> | --stdin) [--conv <id>]\n",
+    "usage: murmur-shell-send.mjs --to <peer-id> (--text <txt> | --text-file <path> | --stdin) [--conv <id>] [--channel <id> --sender-member <id> [--addressee-member <id>]]\n",
   );
   process.exit(1);
 }
@@ -60,6 +63,19 @@ if (!peer) {
 const conversationId = opt.conversationId || `dm:${cfg.agentId}:${opt.to}`;
 const msgId = randomUUID();
 const createdAt = new Date().toISOString();
+const optionalString = (value) => typeof value === "string" && value.trim() ? value.trim() : undefined;
+const channelId = optionalString(opt.channelId) ?? optionalString(peer.channelId);
+const senderMemberId = optionalString(opt.senderMemberId) ?? optionalString(cfg.memberId);
+const addresseeMemberId = optionalString(opt.addresseeMemberId) ?? optionalString(peer.memberId);
+if ((channelId || senderMemberId || addresseeMemberId) && (!channelId || !senderMemberId)) {
+  process.stderr.write("error: channelId and senderMemberId are required together for structured routing\n");
+  process.exit(2);
+}
+const routing = channelId ? {
+  channelId,
+  senderMemberId,
+  ...(addresseeMemberId ? { addresseeMemberId } : {}),
+} : {};
 
 
 try {
@@ -79,6 +95,7 @@ try {
     payloadCiphertext: encrypted.ciphertext,
     payloadNonce: encrypted.nonce,
     signature: "",
+    ...routing,
   };
   envelope.signature = await signEnvelope(
     stableEnvelopePayload(envelope),
@@ -99,10 +116,11 @@ try {
     text,
     createdAt,
     transport: "nats",
+    ...routing,
   });
 
   process.stdout.write(
-    `${JSON.stringify({ msgId, to: opt.to, conversationId, status: "queued" })}\n`,
+    `${JSON.stringify({ msgId, to: opt.to, conversationId, status: "queued", ...routing })}\n`,
   );
   process.exit(0);
 } catch (err) {

--- a/scripts/wake-monitor.mjs
+++ b/scripts/wake-monitor.mjs
@@ -59,6 +59,9 @@ export const createShellHook = ({ command, timeoutMs = 10000, baseEnv = process.
       MURMUR_TEXT: payload.text,
       MURMUR_MSG_ID: payload.msgId,
       MURMUR_CONVERSATION_ID: payload.conversationId,
+      MURMUR_CHANNEL_ID: payload.channelId || "",
+      MURMUR_SENDER_MEMBER_ID: payload.senderMemberId || "",
+      MURMUR_ADDRESSEE_MEMBER_ID: payload.addresseeMemberId || "",
       ...(payload.env || {}),
     };
     execFile("sh", ["-c", command], { env, timeout: timeoutMs }, (err) => {
@@ -77,6 +80,9 @@ export const createAuditShellHook = ({ command, timeoutMs = 10000, baseEnv = pro
       MURMUR_TEXT: payload.text,
       MURMUR_MSG_ID: payload.msgId,
       MURMUR_CONVERSATION_ID: payload.conversationId,
+      MURMUR_CHANNEL_ID: payload.channelId || "",
+      MURMUR_SENDER_MEMBER_ID: payload.senderMemberId || "",
+      MURMUR_ADDRESSEE_MEMBER_ID: payload.addresseeMemberId || "",
       ...(payload.env || {}),
     };
     execFile("sh", ["-c", command], { env, timeout: timeoutMs }, (err, stdout) => {
@@ -155,6 +161,18 @@ export class WakeMonitor {
   }
 
   async processPayload(payload) {
+    // `wakeEligible` is a local receive-time authorization decision persisted by
+    // the daemon. Check it at the shared effect boundary so delayed backlog rows
+    // cannot bypass the immediate channel-addressing gate. Missing means legacy.
+    if (payload.wakeEligible === false) {
+      this.advanceCursor(payload);
+      this.log("info", "WakeMonitor policy mute", {
+        msgId: payload.msgId,
+        conversationId: payload.conversationId,
+        reason: "receive-time-ineligible",
+      });
+      return;
+    }
     const key = this.keyFor(payload);
     const now = this.now();
     this.pruneSeen(now);

--- a/tests/core-channels-roster.test.mjs
+++ b/tests/core-channels-roster.test.mjs
@@ -233,6 +233,47 @@ test("addressing policy wakes only the explicit addressee and mutes observers", 
   });
 });
 
+test("addressing policy authenticates an exact member when one transport agent owns several members", async () => {
+  await withRoster(async (store) => {
+    store.createChannel({
+      channelId: "chan:shared-transport",
+      conversationId: "codex:task:shared",
+      type: "group",
+      members: [
+        { memberId: "mac", agentId: "agent-mac" },
+        { memberId: "topic:33", memberSlot: "33", agentId: "agent-server" },
+        { memberId: "topic:5935", memberSlot: "5935", agentId: "agent-server" },
+      ],
+    });
+
+    const exact = store.evaluateAddressing({
+      channelId: "chan:shared-transport",
+      selfAgentId: "agent-mac",
+      senderAgentId: "agent-server",
+      senderMemberId: "topic:5935",
+      addresseeMemberId: "mac",
+    });
+    assert.equal(exact.reject, false);
+    assert.equal(exact.senderMember.memberId, "topic:5935");
+
+    assert.equal(store.evaluateAddressing({
+      channelId: "chan:shared-transport",
+      selfAgentId: "agent-mac",
+      senderAgentId: "agent-server",
+      senderMemberId: "missing-topic",
+      addresseeMemberId: "mac",
+    }).reason, "sender-not-member");
+
+    assert.equal(store.evaluateAddressing({
+      channelId: "chan:shared-transport",
+      selfAgentId: "agent-mac",
+      senderAgentId: "agent-other",
+      senderMemberId: "topic:5935",
+      addresseeMemberId: "mac",
+    }).reason, "sender-not-member");
+  });
+});
+
 test("addressing policy treats channel messages without addressee as channel broadcast", async () => {
   await withRoster(async (store) => {
     store.createChannel({

--- a/tests/core-envelope-validation.test.mjs
+++ b/tests/core-envelope-validation.test.mjs
@@ -38,3 +38,15 @@ test("isEnvelopeV1 rejects missing payloadCiphertext", () => {
 test("isEnvelopeV1 accepts optional ttlSeconds and traceId", () => {
   assert.equal(isEnvelopeV1({ ...baseEnvelope, ttlSeconds: 60, traceId: "trace-1" }), true);
 });
+
+test("isEnvelopeV1 accepts complete Phase N identity and rejects incomplete identity", () => {
+  assert.equal(isEnvelopeV1({
+    ...baseEnvelope,
+    channelId: "channel-1",
+    senderMemberId: "member-a",
+    addresseeMemberId: "member-b",
+  }), true);
+  assert.equal(isEnvelopeV1({ ...baseEnvelope, channelId: "channel-1" }), false);
+  assert.equal(isEnvelopeV1({ ...baseEnvelope, senderMemberId: "member-a" }), false);
+  assert.equal(isEnvelopeV1({ ...baseEnvelope, addresseeMemberId: "member-b" }), false);
+});

--- a/tests/mcp-request-reply.test.mjs
+++ b/tests/mcp-request-reply.test.mjs
@@ -25,6 +25,13 @@ test("buildReplyMatcher matches same conversation + peer, rejects others", () =>
   assert.equal(match({ conversationId: "conv-2", senderAgentId: "agent.b" }), false);
 });
 
+test("buildReplyMatcher can distinguish members sharing one transport agent", () => {
+  const match = buildReplyMatcher("conv-1", "agent.b", "topic:5935");
+  assert.equal(match({ conversationId: "conv-1", senderAgentId: "agent.b", senderMemberId: "topic:5935" }), true);
+  assert.equal(match({ conversationId: "conv-1", senderAgentId: "agent.b", senderMemberId: "topic:33" }), false);
+  assert.equal(match({ conversationId: "conv-1", senderAgentId: "agent.b" }), false);
+});
+
 // --- A: durability when live-wait is OFF (pure store polling, no signal) ------
 
 test("A: resolves via store-poll fallback when no wake signal is wired", async () => {

--- a/tests/message-store-inbox.test.mjs
+++ b/tests/message-store-inbox.test.mjs
@@ -3,12 +3,14 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { DatabaseSync } from "node:sqlite";
 import { SQLiteMessageStore } from "../packages/core/dist/src/index.js";
 
 const withStore = () => {
   const dir = mkdtempSync(join(tmpdir(), "murmur-inbox-"));
-  const store = new SQLiteMessageStore(join(dir, "murmur.db"));
-  return { store, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  const dbPath = join(dir, "murmur.db");
+  const store = new SQLiteMessageStore(dbPath);
+  return { store, dbPath, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
 };
 
 const append = (store, { direction, sender, text, at }) =>
@@ -76,5 +78,110 @@ test("listInbound honours the limit and returns newest first", async () => {
     assert.deepEqual(inbound.map((m) => m.text), ["msg 4", "msg 3"]);
   } finally {
     cleanup();
+  }
+});
+
+test("message store persists Phase N routing metadata for inbox and request correlation", async () => {
+  const { store, cleanup } = withStore();
+  try {
+    await store.append({
+      conversationId: "codex:task:routed",
+      msgId: "routed-1",
+      direction: "inbound",
+      sender: "agent-server",
+      text: "routed reply",
+      createdAt: "2026-08-26T22:05:00.000Z",
+      transport: "nats",
+      channelId: "channel-1",
+      senderMemberId: "topic:5935",
+      addresseeMemberId: "mac",
+    });
+
+    const [row] = await store.getInboundAfter(
+      "codex:task:routed",
+      "2026-08-26T22:04:00.000Z",
+      10,
+    );
+    assert.equal(row.channelId, "channel-1");
+    assert.equal(row.senderMemberId, "topic:5935");
+    assert.equal(row.addresseeMemberId, "mac");
+  } finally {
+    cleanup();
+  }
+});
+
+test("message store persists receive-time wake eligibility without changing legacy NULL rows", async () => {
+  const { store, dbPath, cleanup } = withStore();
+  try {
+    await store.append({
+      conversationId: "codex:task:muted",
+      msgId: "muted-1",
+      direction: "inbound",
+      sender: "agent-server",
+      text: "observer copy",
+      createdAt: "2026-08-26T22:06:00.000Z",
+      wakeEligible: false,
+    });
+    await store.append({
+      conversationId: "legacy:conversation",
+      msgId: "legacy-1",
+      direction: "inbound",
+      sender: "agent-server",
+      text: "legacy copy",
+      createdAt: "2026-08-26T22:07:00.000Z",
+    });
+
+    const db = new DatabaseSync(dbPath);
+    const rows = db.prepare(
+      "SELECT msg_id as msgId, wake_eligible as wakeEligible FROM local_messages ORDER BY rowid",
+    ).all().map((row) => ({ ...row }));
+    db.close();
+    assert.deepEqual(rows, [
+      { msgId: "muted-1", wakeEligible: 0 },
+      { msgId: "legacy-1", wakeEligible: null },
+    ]);
+  } finally {
+    cleanup();
+  }
+});
+
+test("message store migrates legacy databases with wake eligibility defaulting to NULL", () => {
+  const dir = mkdtempSync(join(tmpdir(), "murmur-inbox-migration-"));
+  const dbPath = join(dir, "murmur.db");
+  try {
+    const legacy = new DatabaseSync(dbPath);
+    legacy.exec(`
+      CREATE TABLE local_messages (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        msg_id TEXT NOT NULL,
+        direction TEXT NOT NULL,
+        sender TEXT NOT NULL,
+        text TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        transport TEXT,
+        channel_id TEXT,
+        sender_member_id TEXT,
+        addressee_member_id TEXT
+      );
+      INSERT INTO local_messages
+        (id, conversation_id, msg_id, direction, sender, text, created_at)
+      VALUES
+        ('legacy-id', 'legacy:conversation', 'legacy-msg', 'inbound', 'agent-server', 'old row', '2026-08-26T22:00:00.000Z');
+    `);
+    legacy.close();
+
+    new SQLiteMessageStore(dbPath);
+
+    const migrated = new DatabaseSync(dbPath);
+    const columns = migrated.prepare("PRAGMA table_info(local_messages)").all();
+    const row = migrated.prepare(
+      "SELECT wake_eligible as wakeEligible FROM local_messages WHERE msg_id = 'legacy-msg'",
+    ).get();
+    migrated.close();
+    assert.ok(columns.some((column) => column.name === "wake_eligible"));
+    assert.equal(row.wakeEligible, null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/tests/wake-monitor.test.mjs
+++ b/tests/wake-monitor.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { WakeMonitor } from "../scripts/wake-monitor.mjs";
+import { createShellHook, WakeMonitor } from "../scripts/wake-monitor.mjs";
 
 const message = (msgId, cursor, text = msgId) => ({
   from: "agent-a",
@@ -58,4 +58,96 @@ test("WakeMonitor drains inbound backlog FIFO until idle", async () => {
   await monitor.onInbound(message("msg-1", 1));
 
   assert.deepEqual(calls, ["msg-1", "msg-2", "msg-3"]);
+});
+
+test("shell hooks receive structured Phase N routing metadata", async () => {
+  const warnings = [];
+  const hook = createShellHook({
+    command: '[ "$MURMUR_CHANNEL_ID" = "channel-1" ] && [ "$MURMUR_SENDER_MEMBER_ID" = "topic:5935" ] && [ "$MURMUR_ADDRESSEE_MEMBER_ID" = "mac" ]',
+    baseEnv: {},
+    log: (...args) => warnings.push(args),
+  });
+  await hook({
+    ...message("msg-routed", 4),
+    channelId: "channel-1",
+    senderMemberId: "topic:5935",
+    addresseeMemberId: "mac",
+  });
+  assert.deepEqual(warnings, []);
+});
+
+test("receive-time ineligible backlog rows advance without invoking wake effects", async () => {
+  const calls = [];
+  const auditCalls = [];
+  const leaseCalls = [];
+  const notifications = [];
+  let backlogReturned = false;
+  const monitor = new WakeMonitor({
+    hook: async (payload) => calls.push(payload.msgId),
+    auditHook: async (payload) => {
+      auditCalls.push(payload.msgId);
+      return "allow";
+    },
+    leaseGate: async (payload) => {
+      leaseCalls.push(payload.msgId);
+      return { allow: true };
+    },
+    notify: async (payload, reason) => notifications.push({ msgId: payload.msgId, reason }),
+    loadBacklogAfter: async () => {
+      if (backlogReturned) return [];
+      backlogReturned = true;
+      return [
+        { ...message("muted", 2), wakeEligible: false },
+        { ...message("allowed", 3), wakeEligible: true },
+      ];
+    },
+  });
+
+  await monitor.onInbound({ ...message("trigger", 1), wakeEligible: true });
+
+  assert.deepEqual(calls, ["trigger", "allowed"]);
+  assert.deepEqual(auditCalls, ["trigger", "allowed"]);
+  assert.deepEqual(leaseCalls, ["trigger", "allowed"]);
+  assert.deepEqual(notifications, []);
+  assert.equal(monitor.cursor, 3);
+});
+
+test("receive-time ineligible rows cannot reach the native injector", async () => {
+  const calls = [];
+  const monitor = new WakeMonitor({
+    peers: {
+      "agent-a": { mode: "codex_app_server" },
+    },
+    injector: async (payload) => calls.push(payload.msgId),
+    auditHook: async () => {
+      throw new Error("audit must not run");
+    },
+    leaseGate: async () => {
+      throw new Error("lease gate must not run");
+    },
+    notify: async () => {
+      throw new Error("notification must not run");
+    },
+  });
+
+  await monitor.onInbound({ ...message("muted-native", 1), wakeEligible: false });
+
+  assert.deepEqual(calls, []);
+  assert.equal(monitor.cursor, 1);
+});
+
+test("missing wake eligibility preserves legacy backlog behavior", async () => {
+  const calls = [];
+  let backlogReturned = false;
+  const monitor = new WakeMonitor({
+    hook: async (payload) => calls.push(payload.msgId),
+    loadBacklogAfter: async () => {
+      if (backlogReturned) return [];
+      backlogReturned = true;
+      return [message("legacy", 2)];
+    },
+  });
+
+  await monitor.onInbound(message("trigger", 1));
+  assert.deepEqual(calls, ["trigger", "legacy"]);
 });


### PR DESCRIPTION
## Summary

- carry optional `channelId`, `senderMemberId`, and `addresseeMemberId` through the signed EnvelopeV1 without changing legacy envelope bytes
- authenticate exact sender membership and apply the existing Phase N roster policy in daemon, MCP, shell-send, request/reply, inbox, and receive-hook paths
- persist the receive-time wake decision so observer copies cannot wake through delayed backlog processing
- apply the same addressing decision to configured proxy subjects
- preserve fieldless legacy traffic and document coordinated migration/rollback

This completes the transport/wiring gap around the existing Phase N primitives from #77, #87, and #91, and makes member identity usable by the session-presence work in #89. It does not add a parallel identity protocol.

## Compatibility

- all routing fields are optional
- fieldless envelopes retain byte-identical canonical signing payloads
- pre-migration local-message rows retain legacy wake behavior
- structured routing requires `channelId` and `senderMemberId` together

## Security

A security diff scan found a delayed-backlog observer-wake bypass. The fix persists the local receive-time decision and enforces it before audit, notification, lease, hook, or injector effects. A fresh bypass review then identified proxy subjects as an alternate ingress; that path now uses the same roster decision. Private deployment identities, broker addresses, credentials, and keys are not included.

## Validation

- `npm test`
- `node --check scripts/murmur-daemon.mjs`
- `git diff --check`
- focused routing, wake-monitor, request/reply, schema, canonical-signing, and SQLite migration tests
